### PR TITLE
docs(mds): 정산 화면 스펙 정리

### DIFF
--- a/apps/mds/docs/public/specs/settlement_detail_page/index.html
+++ b/apps/mds/docs/public/specs/settlement_detail_page/index.html
@@ -84,8 +84,8 @@ body.dark-mode .viewport {
   color: var(--color-text-secondary);
 }
 .settle-badge--ready {
-  background: rgba(var(--spec-blueprint-rgb), 0.10);
-  color: var(--color-primary);
+  background: rgba(255, 153, 0, 0.12);
+  color: var(--color-secondary);
 }
 .settle-badge--processing {
   background: rgba(255, 153, 0, 0.12);
@@ -251,12 +251,6 @@ body.dark-mode .viewport {
   border-top: 1px solid var(--color-divider);
   padding: var(--spacing-medium);
 }
-.download-sheet__handle {
-  width: 32px; height: 4px;
-  border-radius: 2px;
-  background: var(--color-divider);
-  margin: 0 auto var(--spacing-medium);
-}
 .download-sheet__title {
   font-size: var(--typography-font-size-app-bar-title);
   font-weight: 700;
@@ -311,7 +305,7 @@ body.dark-mode .viewport {
     <tbody>
       <tr>
         <th style="width: 140px;">Status</th>
-        <td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— 6개 state · 정산 lifecycle 전체 커버</em></td>
+        <td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— 6개 state · 상세 핵심 흐름 + status badge matrix</em></td>
       </tr>
       <tr>
         <th>App</th>
@@ -327,12 +321,12 @@ body.dark-mode .viewport {
       </tr>
       <tr>
         <th>Path</th>
-        <td><code>/settlement/:settlementId</code></td>
+        <td><code>/settlement/:id</code></td>
       </tr>
       <tr>
         <th>Hierarchy</th>
         <td>
-          <strong>Parent</strong>: <em>— (top-level partner screen — 정산 목록에서 진입하는 detail 화면)</em><br>
+          <strong>Parent</strong>: <a href="/specs/settlement_page/index.html"><code>SettlementPage</code></a> (월별 정산 tile 탭으로 진입)<br>
           <strong>Children</strong>: <em>— (CSV 다운로드 바텀시트는 state 6으로 이 spec 안에서 다룸)</em>
         </td>
       </tr>
@@ -355,7 +349,7 @@ body.dark-mode .viewport {
         <th>Background</th>
         <td>
           밍글릿은 PG 수수료, 플랫폼 수수료, VAT를 차감한 순 정산금을 파트너에게 지급한다.
-          각 정산 항목은 대기 → 확정 → 지급 중 → 지급 완료 흐름을 따르며 보류 / 지급 실패 / 취소 예외 상태도 존재한다.
+          각 정산 항목은 지급 대기 → 지급 예정 → 지급 중 → 지급 완료 흐름을 따르며 지급 보류 / 지급 실패 / 지급 취소 예외 상태도 존재한다.
           지급 실패 상태이면서 재지급이 가능한 경우에만 "재지급 요청" 버튼이 표시된다.
         </td>
       </tr>
@@ -385,6 +379,14 @@ body.dark-mode .viewport {
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td>2026-06-01</td>
+        <td>1.2</td>
+        <td>Codex</td>
+        <td>
+          SettlementPage spec과 상태 문구/색을 정렬. READY를 <code>지급 예정</code>으로 변경하고 READY/PROCESSING 색을 동일 계열로 통일. Loading은 spinner 대신 detail skeleton 지향으로 정리하고, route/provider reference drift를 갱신.
+        </td>
+      </tr>
       <tr>
         <td>2026-05-01</td>
         <td>1.1</td>
@@ -427,7 +429,7 @@ body.dark-mode .viewport {
     <h2>Blueprint &amp; tree</h2>
     <p class="intro">
       AppBar("정산 상세") + SingleChildScrollView(MinglitContentLayout) — 섹션 사이 spacing-medium.
-      로딩/오류/데이터 없음은 Center 위젯으로 처리.
+      초기 로딩은 실제 상세 화면 구조를 유지한 skeleton으로 처리하고, 오류/데이터 없음은 full-page state로 처리한다.
     </p>
     <div class="layout-grid">
       <div class="blueprint">
@@ -461,8 +463,8 @@ body.dark-mode .viewport {
       <div class="layout-tree"><b>Scaffold</b>
 ├─ <b>appBar</b>: AppBar(title: Text('정산 상세'))          ← ①
 └─ <b>body</b>
-   ├─ [isLoading]  <b>Center</b> → <b>CircularProgressIndicator</b>
-   ├─ [error]      <b>Center</b> → error icon + title + message + retry button
+   ├─ [isLoading]  <b>SettlementDetailShimmer</b> → status / amount / action card skeleton
+   ├─ [error]      <b>MinglitEmptyState</b> → error icon + "정산 정보를 불러오지 못했습니다" + retry button
    ├─ [detail null] <b>Center</b> → Text('정산 항목을 찾을 수 없습니다.')
    └─ [data]  <b>_DetailContent</b>
       └─ <b>SingleChildScrollView</b>
@@ -584,7 +586,7 @@ body.dark-mode .viewport {
     <p class="intro">
       본문 첫 카드 — 좌측에 상태 배지(pill), 우측에 한 줄 안내 메시지가 가로로 배치된 정보 카드.
       배지는 자기 너비만큼 차지하고 메시지는 남는 가로 공간을 모두 흡수한다.
-      배지 색상이 정산 상태(대기 / 확정 / 지급 중 / 지급 완료 / 보류 / 지급 실패 / 취소)에 따라 달라지며 메시지 텍스트도 함께 바뀐다.
+      배지 색상이 정산 상태(지급 대기 / 지급 예정 / 지급 중 / 지급 완료 / 지급 보류 / 지급 실패 / 지급 취소)에 따라 달라지며 메시지 텍스트도 함께 바뀐다.
     </p>
     <div class="layout-grid">
       <div class="blueprint" style="width: 343px; height: 110px;">
@@ -736,6 +738,7 @@ body.dark-mode .viewport {
     <p class="intro">
       처리 이력 카드 — 정산이 거쳐온 상태 전환을 위에서 아래로 시간순 정렬한다.
       각 항목은 좌측의 작은 점(8px) + 그 점들을 잇는 1px 세로선 + 우측의 상태/시각 텍스트로 구성된다.
+      상태 전환 텍스트는 raw enum이 아니라 사용자 노출 라벨(예: 지급 대기 → 지급 예정)로 표시한다.
       처리 이력이 하나도 없으면 카드 전체가 숨겨진다 (대기 상태에서 흔함).
     </p>
     <div class="layout-grid">
@@ -789,7 +792,7 @@ body.dark-mode .viewport {
                │   · margin-top: 5 (텍스트 첫 줄과 시각적 정렬)
                ├─ <b>SizedBox</b>(width: <i>spacing-sm = 12</i>)
                └─ <b>Column</b>(crossAxis: start)
-                  ├─ <b>Text</b>('PREV → NEXT', w600)
+                  ├─ <b>Text</b>('지급 대기 → 지급 예정', w600)
                   └─ <b>Text</b>('MM/dd HH:mm', caption)
 
       <em>Connector ㉢:</em> 항목 사이에 1px 세로선
@@ -897,7 +900,7 @@ body.dark-mode .viewport {
 
   <section class="doc">
     <p class="intro">
-      <strong>State 종류 식별 기준</strong>: 정산 상태(대기 / 확정 / 지급 중 / 지급 완료 / 보류 / 지급 실패 / 취소) + 데이터 도착 여부 + CSV 다운로드 바텀시트 노출 여부.
+      <strong>State 종류 식별 기준</strong>: 정산 상태(지급 대기 / 지급 예정 / 지급 중 / 지급 완료 / 지급 보류 / 지급 실패 / 지급 취소) + 데이터 도착 여부 + CSV 다운로드 바텀시트 노출 여부.
     </p>
 
     <!-- State 1: Default · COMPLETED (baseline) -->
@@ -931,11 +934,11 @@ body.dark-mode .viewport {
                 </div>
                 <div class="settle-card">
                   <div class="settle-card__title">처리 이력</div>
-                  <div class="timeline-item"><div class="timeline-item__dot"></div><div class="timeline-item__body"><div class="timeline-item__status">PENDING → READY</div><div class="timeline-item__time">04/22 10:00</div></div></div>
+                  <div class="timeline-item"><div class="timeline-item__dot"></div><div class="timeline-item__body"><div class="timeline-item__status">지급 대기 → 지급 예정</div><div class="timeline-item__time">04/22 10:00</div></div></div>
                   <div class="timeline-connector"></div>
-                  <div class="timeline-item"><div class="timeline-item__dot"></div><div class="timeline-item__body"><div class="timeline-item__status">READY → PROCESSING</div><div class="timeline-item__time">04/25 14:30</div></div></div>
+                  <div class="timeline-item"><div class="timeline-item__dot"></div><div class="timeline-item__body"><div class="timeline-item__status">지급 예정 → 지급 중</div><div class="timeline-item__time">04/25 14:30</div></div></div>
                   <div class="timeline-connector"></div>
-                  <div class="timeline-item"><div class="timeline-item__dot"></div><div class="timeline-item__body"><div class="timeline-item__status">PROCESSING → COMPLETED</div><div class="timeline-item__time">04/26 09:15</div></div></div>
+                  <div class="timeline-item"><div class="timeline-item__dot"></div><div class="timeline-item__body"><div class="timeline-item__status">지급 중 → 지급 완료</div><div class="timeline-item__time">04/26 09:15</div></div></div>
                 </div>
                 <div>
                   <div class="settle-action-btn settle-action-btn--outlined">
@@ -980,7 +983,7 @@ body.dark-mode .viewport {
         <tr>
           <td class="state-mini__aspect">토큰</td>
           <td>
-            · color: <code>color-background</code>, <code>color-surface</code>, <code>color-primary</code> (timeline dot · READY 배지), <code>color-success</code> (COMPLETED 배지), <code>color-text-primary/secondary</code>, <code>color-divider</code> (AppBar 하단 · 카드 border · OutlinedButton border)<br>
+            · color: <code>color-background</code>, <code>color-surface</code>, <code>color-primary</code> (timeline dot), <code>color-secondary</code> (READY/PROCESSING 배지), <code>color-success</code> (COMPLETED 배지), <code>color-text-primary/secondary</code>, <code>color-divider</code> (AppBar 하단 · 카드 border · OutlinedButton border)<br>
             · radius: <code>radius-card</code> (16 · Card), <code>radius-badge</code> (4 · Badge), <code>radius-button</code> (12 · 버튼)<br>
             · spacing: <code>spacing-medium</code> (16 · 섹션/카드 padding), <code>spacing-sm</code> (12 · badge↔message · title↔rows · timeline dot↔text), <code>spacing-small</code> (8 · 버튼 간격), <code>spacing-xsmall</code> (4 · amount row v-padding), <code>spacing-xsmall2</code> (6 · timeline item v-padding)<br>
             · typography: titleSmall (14/600 — 카드 타이틀), bodyMedium (14/400 — 일반 / 14/700 — 정산금 bold), labelSmall (11/600 — 배지 compact:true), bodySmall (12 — 타임스탬프), appBarTitle (18/600)
@@ -996,7 +999,7 @@ body.dark-mode .viewport {
     <!-- State 2: PENDING -->
     <table class="ref state-mini">
       <thead>
-        <tr><th colspan="3"><strong>정산 대기 (PENDING)</strong> <small>이벤트 종료 후 정산이 확정되기 전 단계</small></th></tr>
+        <tr><th colspan="3"><strong>지급 대기 (PENDING)</strong> <small>이벤트 종료 후 지급 예정 상태가 되기 전 단계</small></th></tr>
       </thead>
       <tbody>
         <tr>
@@ -1009,8 +1012,8 @@ body.dark-mode .viewport {
               <div class="settle-body">
                 <div class="settle-card">
                   <div class="settle-status-message">
-                    <div class="settle-badge settle-badge--pending">정산 대기</div>
-                    <div class="settle-status-message__text">정산이 확정되기를 기다리고 있습니다.</div>
+                    <div class="settle-badge settle-badge--pending">지급 대기</div>
+                    <div class="settle-status-message__text">지급 예정 상태가 되기를 기다리고 있습니다.</div>
                   </div>
                 </div>
                 <div class="settle-card">
@@ -1032,7 +1035,7 @@ body.dark-mode .viewport {
             </div>
           </td>
           <td class="state-mini__aspect">조건</td>
-          <td>정산 대기 상태이며 처리 이력이 아직 비어 있음.</td>
+          <td>지급 대기 상태이며 처리 이력이 아직 비어 있음.</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>
@@ -1040,11 +1043,11 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td class="state-mini__aspect">에지케이스</td>
-          <td>· 정산이 확정되는 시점에 자동으로 다음 상태로 넘어감. 화면이 자동으로 갱신되지는 않으므로 다시 진입해야 반영됨.</td>
+          <td>· 지급 예정 상태가 되는 시점에 자동으로 다음 상태로 넘어감. 화면이 자동으로 갱신되지는 않으므로 다시 진입해야 반영됨.</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">컴포넌트</td>
-          <td>↔ Badge → <strong>"정산 대기"</strong> (PENDING styling — <code>color-surface</code> bg)<br>− 처리 이력 카드 <em>(histories 비어있음)</em></td>
+          <td>↔ Badge → <strong>"지급 대기"</strong> (PENDING styling — <code>color-surface</code> bg)<br>− 처리 이력 카드 <em>(histories 비어있음)</em></td>
         </tr>
         <tr>
           <td class="state-mini__aspect">토큰</td>
@@ -1091,7 +1094,7 @@ body.dark-mode .viewport {
                   <div class="timeline-item">
                     <div class="timeline-item__dot" style="background:var(--color-error);"></div>
                     <div class="timeline-item__body">
-                      <div class="timeline-item__status">PROCESSING → FAILED</div>
+                      <div class="timeline-item__status">지급 중 → 지급 실패</div>
                       <div class="timeline-item__time">04/26 11:00</div>
                     </div>
                   </div>
@@ -1122,7 +1125,7 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td class="state-mini__aspect">컴포넌트</td>
-          <td>+ <code>FilledButton.icon</code> (refresh icon · 재지급 요청 · primary bg)<br>↔ Badge → <strong>"지급 실패"</strong> (FAILED styling — <code>color-error</code> bg/text)<br>↔ Timeline dot 1개 → <code>color-error</code> (PROCESSING → FAILED 전환 표시)<br>↔ Status message 텍스트 → "지급에 실패했습니다. 계좌 정보를 확인해 주세요."</td>
+          <td>+ <code>FilledButton.icon</code> (refresh icon · 재지급 요청 · primary bg)<br>↔ Badge → <strong>"지급 실패"</strong> (FAILED styling — <code>color-error</code> bg/text)<br>↔ Timeline dot 1개 → <code>color-error</code> (지급 중 → 지급 실패 전환 표시)<br>↔ Status message 텍스트 → "지급에 실패했습니다. 계좌 정보를 확인해 주세요."</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">토큰</td>
@@ -1138,7 +1141,7 @@ body.dark-mode .viewport {
     <!-- State 4: HOLD -->
     <table class="ref state-mini">
       <thead>
-        <tr><th colspan="3"><strong>보류 (HOLD)</strong> <small>지원센터 문의가 필요한 보류 상태</small></th></tr>
+        <tr><th colspan="3"><strong>지급 보류 (HOLD)</strong> <small>지원센터 문의가 필요한 보류 상태</small></th></tr>
       </thead>
       <tbody>
         <tr>
@@ -1151,8 +1154,8 @@ body.dark-mode .viewport {
               <div class="settle-body">
                 <div class="settle-card">
                   <div class="settle-status-message">
-                    <div class="settle-badge settle-badge--hold">보류</div>
-                    <div class="settle-status-message__text">정산이 보류 중입니다. 지원센터에 문의해 주세요.</div>
+                    <div class="settle-badge settle-badge--hold">지급 보류</div>
+                    <div class="settle-status-message__text">지급이 보류 중입니다. 지원센터에 문의해 주세요.</div>
                   </div>
                 </div>
                 <div class="settle-card">
@@ -1186,7 +1189,7 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td class="state-mini__aspect">컴포넌트</td>
-          <td>↔ Badge → <strong>"보류"</strong> (HOLD styling — <code>color-error</code> bg + 약한 opacity)<br>− 처리 이력 카드<br>− FilledButton (재지급)</td>
+          <td>↔ Badge → <strong>"지급 보류"</strong> (HOLD styling — <code>color-error</code> bg + 약한 opacity)<br>− 처리 이력 카드<br>− FilledButton (재지급)</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">토큰</td>
@@ -1202,7 +1205,7 @@ body.dark-mode .viewport {
     <!-- State 5: Loading -->
     <table class="ref state-mini">
       <thead>
-        <tr><th colspan="3"><strong>Loading</strong> <small>진입 직후 데이터 조회 중</small></th></tr>
+        <tr><th colspan="3"><strong>Loading</strong> <small>진입 직후 데이터 조회 중 · detail skeleton</small></th></tr>
       </thead>
       <tbody>
         <tr>
@@ -1212,10 +1215,29 @@ body.dark-mode .viewport {
                 <div class="settle-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg></div>
                 <div class="settle-appbar__title">정산 상세</div>
               </div>
-              <div style="position:absolute;top:56px;left:0;right:0;bottom:0;display:flex;align-items:center;justify-content:center;">
-                <div style="width:36px;height:36px;border:3px solid var(--color-divider);border-top-color:var(--color-primary);border-radius:50%;animation:spin 0.7s linear infinite;"></div>
+              <div class="settle-body">
+                <div class="settle-card">
+                  <div class="settle-status-message">
+                    <div class="skeleton-bar" style="width:84px;height:28px;border-radius:var(--radius-badge);"></div>
+                    <div class="skeleton-bar" style="flex:1;height:16px;"></div>
+                  </div>
+                </div>
+                <div class="settle-card">
+                  <div class="skeleton-bar" style="width:80px;height:18px;margin-bottom:12px;"></div>
+                  <div class="skeleton-bar" style="height:18px;margin-bottom:8px;"></div>
+                  <div class="skeleton-bar" style="height:18px;margin-bottom:8px;width:92%;"></div>
+                  <div class="skeleton-bar" style="height:18px;margin-bottom:8px;width:88%;"></div>
+                  <div class="skeleton-bar" style="height:18px;margin-bottom:12px;width:82%;"></div>
+                  <div class="amount-divider"></div>
+                  <div class="skeleton-bar" style="height:20px;margin-top:12px;"></div>
+                </div>
+                <div class="settle-card">
+                  <div class="skeleton-bar" style="width:80px;height:18px;margin-bottom:12px;"></div>
+                  <div class="skeleton-bar" style="height:28px;margin-bottom:8px;"></div>
+                  <div class="skeleton-bar" style="height:28px;width:86%;"></div>
+                </div>
+                <div class="skeleton-bar" style="height:48px;border-radius:var(--radius-button);"></div>
               </div>
-              <style>@keyframes spin{to{transform:rotate(360deg);}}</style>
             </div>
           </td>
           <td class="state-mini__aspect">조건</td>
@@ -1231,15 +1253,15 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td class="state-mini__aspect">컴포넌트</td>
-          <td>↔ body (StatusCard / Amount / Timeline / Actions 4개 카드) → <code>CircularProgressIndicator</code> 단일 (Material 기본 · MinglitCircularProgressIndicator 미사용)<br>− 모든 spec 컴포넌트</td>
+          <td>↔ body → <code>SettlementDetailShimmer</code><br>+ status card skeleton / amount card skeleton / timeline skeleton / action button skeleton<br>− <code>CircularProgressIndicator</code> initial loading</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">토큰</td>
-          <td>− 카드/배지/timeline 토큰 미사용. 스피너만 <code>color-primary</code> + <code>color-divider</code> (track)</td>
+          <td>+ skeleton base: <code>color-surface</code><br>+ shimmer highlight: <code>color-divider</code><br>+ animation: 1.2s linear sweep</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">노트</td>
-          <td>📝 AppBar는 유지 (back tap 가능). body만 spinner로 대체.</td>
+          <td>📝 AppBar는 유지 (back tap 가능). spinner 대신 상세 화면 골격을 먼저 보여 layout shift를 줄인다.</td>
         </tr>
       </tbody>
     </table>
@@ -1267,18 +1289,13 @@ body.dark-mode .viewport {
               </div>
               <div class="scrim"></div>
               <div class="download-sheet" style="z-index:10;position:absolute;">
-                <div class="download-sheet__handle"></div>
                 <div class="download-sheet__title">CSV 다운로드</div>
-                <div class="download-sheet__options">
-                  <div class="download-sheet__option">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>
-                    이번 정산 내역 CSV
-                  </div>
-                  <div class="download-sheet__option">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-                    전체 정산 이력 CSV
-                  </div>
+                <div style="font-size:var(--typography-font-size-caption);color:var(--color-text-secondary);line-height:1.5;margin-bottom:var(--spacing-large);">정산 내역을 CSV 파일로 저장합니다.</div>
+                <div class="settle-action-btn settle-action-btn--filled">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                  CSV 저장
                 </div>
+                <div style="height:40px;display:flex;align-items:center;justify-content:center;color:var(--color-primary);font-weight:600;">취소</div>
               </div>
             </div>
           </td>
@@ -1288,18 +1305,18 @@ body.dark-mode .viewport {
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>
           <td>
-            ① <strong>"이번 정산 내역 CSV" 탭</strong> → OS 파일 공유 시트 / 저장 다이얼로그<br>
-            ② <strong>"전체 정산 이력 CSV" 탭</strong> → 동일하게 OS 공유 시트 (범위만 다름)<br>
+            ① <strong>"CSV 저장" 탭</strong> → CSV 생성 → OS 공유 시트 / 저장 다이얼로그<br>
+            ② <strong>"취소" 탭</strong> → 시트 닫힘, 배경 화면 복귀<br>
             ③ <strong>스크림 탭 / 아래 스와이프</strong> → 시트 닫힘, 배경 화면 복귀
           </td>
         </tr>
         <tr>
           <td class="state-mini__aspect">에지케이스</td>
-          <td>· CSV 생성 실패 (서버 오류) → 오류 안내 메시지가 노출되고 시트는 닫힘<br>· 매우 큰 데이터셋 (수만 행) → 별도 진행 UI 없이 곧바로 OS 공유 시트로 진입</td>
+          <td>· CSV 생성 실패 → SnackBar 오류가 노출되고 시트는 유지됨<br>· 생성 중에는 버튼 라벨이 "생성 중..."으로 바뀌고 16px progress가 icon 자리에 표시됨</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">컴포넌트</td>
-          <td>+ <code>DownloadBottomSheet</code> (Material <code>showModalBottomSheet</code> 기반)<br>+ Scrim (반투명 검정 overlay · 배경 dim)<br>+ <code>_DownloadOption</code> 행 2개 (icon + label)</td>
+          <td>+ <code>DownloadBottomSheet</code> (Material <code>showModalBottomSheet</code> 기반)<br>+ Scrim (반투명 검정 overlay · 배경 dim)<br>+ title / description / <code>FilledButton.icon</code>('CSV 저장') / <code>TextButton</code>('취소')</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">토큰</td>
@@ -1341,17 +1358,18 @@ body.dark-mode .viewport {
     <h2>Status badge / Amount card — visual</h2>
     <p class="intro">
       상태 배지는 정산 lifecycle 7개 상태에 따라 색이 달라지는 pill. 같은 모양·크기·radius를 유지하며 배경/텍스트 색만 바뀐다.
+      READY와 PROCESSING은 사용자가 모두 "지급이 곧/현재 진행됨"으로 인지하므로 같은 주황 계열로 통일한다.
       취소 상태는 가로 취소선이 추가로 그어진다. 그 아래는 금액 내역 카드 — 항목별 행이 양 끝 정렬로 쌓이고 합계만 굵게 강조된다.
     </p>
     <div class="visual-gallery" style="background: var(--color-surface); padding: 24px; border-radius: var(--radius-card); display: flex; flex-direction: column; gap: 20px; align-items: center;">
       <div class="viewport" style="width: 343px; background: var(--color-background); border: 1px solid var(--color-divider); border-radius: 8px; padding: 16px; display: flex; flex-wrap: wrap; gap: 8px;">
-        <div class="settle-badge settle-badge--pending">정산 대기</div>
-        <div class="settle-badge settle-badge--ready">정산 확정</div>
+        <div class="settle-badge settle-badge--pending">지급 대기</div>
+        <div class="settle-badge settle-badge--ready">지급 예정</div>
         <div class="settle-badge settle-badge--processing">지급 중</div>
         <div class="settle-badge settle-badge--completed">지급 완료</div>
         <div class="settle-badge settle-badge--failed">지급 실패</div>
-        <div class="settle-badge settle-badge--hold">보류</div>
-        <div class="settle-badge settle-badge--canceled">취소</div>
+        <div class="settle-badge settle-badge--hold">지급 보류</div>
+        <div class="settle-badge settle-badge--canceled">지급 취소</div>
       </div>
       <div class="viewport" style="width: 343px; background: var(--color-background); border: 1px solid var(--color-divider); border-radius: 8px; padding: 16px;">
         <div class="settle-card" style="border:none;padding:0;">
@@ -1370,13 +1388,13 @@ body.dark-mode .viewport {
         <tr><th style="width: 140px;">Status</th><th style="width: 220px;">Visual</th><th>의미</th></tr>
       </thead>
       <tbody>
-        <tr><td>정산 대기 (PENDING)</td><td>회색 배경 + 보조 텍스트 색</td><td>이벤트 종료 직후, 정산이 확정되기 전</td></tr>
-        <tr><td>정산 확정 (READY)</td><td>파트너 보라 10% 틴트 + 보라 텍스트</td><td>정산 금액이 확정됨, 지급 대기</td></tr>
+        <tr><td>지급 대기 (PENDING)</td><td>회색 배경 + 보조 텍스트 색</td><td>이벤트 종료 직후, 지급 예정으로 넘어가기 전</td></tr>
+        <tr><td>지급 예정 (READY)</td><td>주황 12% 틴트 + 주황 텍스트</td><td>정산 금액이 확정됨, 지급 시작 전</td></tr>
         <tr><td>지급 중 (PROCESSING)</td><td>주황 12% 틴트 + 주황 텍스트</td><td>송금이 처리되는 중</td></tr>
         <tr><td>지급 완료 (COMPLETED)</td><td>초록 10% 틴트 + 초록 텍스트</td><td>정산금이 계좌에 입금됨</td></tr>
         <tr><td>지급 실패 (FAILED)</td><td>빨강 10% 틴트 + 빨강 텍스트</td><td>송금 실패, 재지급 가능 시 강조 버튼 노출</td></tr>
-        <tr><td>보류 (HOLD)</td><td>빨강 10% 틴트 + 빨강 텍스트</td><td>운영 개입 — 분쟁/검증 등으로 일시 정지</td></tr>
-        <tr><td>취소 (CANCELED)</td><td>회색 배경 + 가로 취소선</td><td>정산 자체가 취소됨</td></tr>
+        <tr><td>지급 보류 (HOLD)</td><td>빨강 10% 틴트 + 빨강 텍스트</td><td>운영 개입 — 분쟁/검증 등으로 일시 정지</td></tr>
+        <tr><td>지급 취소 (CANCELED)</td><td>회색 배경 + 가로 취소선</td><td>정산 자체가 취소됨</td></tr>
       </tbody>
     </table>
   </section>
@@ -1460,7 +1478,7 @@ body.dark-mode .viewport {
   <section class="doc">
     <h2>Global edge cases</h2>
     <ul class="notes">
-      <li><strong>취소 상태</strong> — 보류와 별도. 배지 텍스트에 취소선 스타일이 적용되며 "정산이 취소되었습니다." 메시지가 노출됨. CSV만 가능. (위 6개 state에는 미포함 — 발생 빈도가 낮은 운영 경로)</li>
+      <li><strong>지급 취소 상태</strong> — 지급 보류와 별도. 배지 텍스트에 취소선 스타일이 적용되며 "정산이 취소되었습니다." 메시지가 노출됨. CSV만 가능. (위 6개 state에는 미포함 — 발생 빈도가 낮은 운영 경로)</li>
       <li><strong>데이터 조회 실패</strong> — 오류 상태로 진입하며 일반 오류 메시지 + "다시 시도" 버튼이 노출됨.</li>
       <li><strong>금액 음수/0원</strong> — 그대로 표시. 비정상값도 가시화하는 의도.</li>
     </ul>
@@ -1482,13 +1500,13 @@ body.dark-mode .viewport {
     <table class="ref">
       <tbody>
         <tr><th style="width: 200px;">Widget</th><td><code>SettlementDetailPage</code> + <code>_DetailContent</code> — <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/features/settlement/settlement_detail_page.dart"><code>apps/app_partner/lib/src/features/settlement/settlement_detail_page.dart</code></a></td></tr>
-        <tr><th>Route</th><td><code>SettlementDetailRoute</code> · <code>/settlement/:settlementId</code> · <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/routing/app_routes.dart"><code>app_routes.dart</code></a></td></tr>
-        <tr><th>Provider</th><td><code>partnerSettlementDetailProvider(settlementId)</code> · <code>currentPartnerInfoProvider</code> (재지급 요청 guard)</td></tr>
-        <tr><th>Repository</th><td><code>partner_settlement_repository</code> — settlement status enum 정의 (PENDING / READY / PROCESSING / COMPLETED / HOLD / FAILED / CANCELED)</td></tr>
-        <tr><th>Status component</th><td><code>SettlementStatusBadge</code> — 8 status × bg/text color, CANCELED은 strikethrough</td></tr>
+        <tr><th>Route</th><td><code>SettlementDetailRoute</code> · <code>/settlement/:id</code> · <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/routing/app_routes.dart"><code>app_routes.dart</code></a></td></tr>
+        <tr><th>Data source</th><td><code>settlementRepositoryProvider.getSettlementItemDetail(itemId)</code> · <code>currentPartnerInfoProvider</code> (재지급 요청 guard)</td></tr>
+        <tr><th>Repository</th><td><code>settlementRepositoryProvider</code> — settlement status string: PENDING / READY / PROCESSING / COMPLETED / HOLD / FAILED / CANCELED</td></tr>
+        <tr><th>Status component</th><td><code>SettlementStatusBadge</code> — 8 status × bg/text color, CANCELED은 strikethrough. 본 spec 기준 READY label은 <strong>지급 예정</strong>, READY/PROCESSING은 같은 주황 계열.</td></tr>
         <tr><th>Sub-component</th><td><code>DownloadBottomSheet</code> — Material <code>showModalBottomSheet</code> 기반 (state 6에서 사용)</td></tr>
         <tr><th>Layout helper</th><td><code>MinglitContentLayout</code> (sectionGap: spacing-medium) — 섹션을 Column으로 배치</td></tr>
-        <tr><th>⚠️ 알려진 drift</th><td>FAILED timeline dot 색상 — spec은 <code>color-error</code>이나 현재 Dart 소스는 모든 dot을 <code>color-primary</code>로 표시. 디자인 개선 권고.</td></tr>
+        <tr><th>⚠️ 알려진 drift</th><td>· 현재 Dart 소스는 loading에 <code>CircularProgressIndicator</code>를 사용하므로 <code>SettlementDetailShimmer</code>로 교체 필요<br>· 현재 오류 상태는 inline <code>Center + Column</code>이고 title이 '오류가 발생했습니다' + raw error 문자열 노출이므로 <code>MinglitEmptyState</code>('정산 정보를 불러오지 못했습니다')로 교체 필요<br>· 현재 <code>SettlementStatus.ready.label</code>은 '정산 확정'이고 READY 색은 primaryContainer라 본 spec의 '지급 예정' + 주황 계열로 변경 필요<br>· 현재 <code>StatusMessageCard._messages</code>는 PENDING/READY/HOLD에 '정산 확정/정산 보류' 문구를 사용하므로 지급 대기/지급 예정/지급 보류 copy로 교체 필요<br>· 현재 timeline은 <code>${entry.fromStatus} → ${entry.toStatus}</code> raw enum을 그대로 표시하므로 사용자 노출 라벨로 변환 필요<br>· FAILED timeline dot 색상 — spec은 <code>color-error</code>이나 현재 Dart 소스는 모든 dot을 <code>color-primary</code>로 표시. 디자인 개선 권고.</td></tr>
       </tbody>
     </table>
   </section>

--- a/apps/mds/docs/public/specs/settlement_page/index.html
+++ b/apps/mds/docs/public/specs/settlement_page/index.html
@@ -10,9 +10,8 @@
 
    Partner app theme:
    - Page (Scaffold) bg = light gray (var(--color-surface))
-   - AppBar matches scaffold (light gray) — but TabBar adds an
-     explicit bottom hairline divider since TabBar.bottom is a
-     PreferredSizeWidget under the AppBar.
+   - AppBar matches scaffold (light gray). Settlement is a single
+     monthly scroll surface; no TabBar / status filter chip row.
    - Brand primary = MinglitPartnerColors.primary (#6c3ce1 — indigo)
      → use via var(--color-partner-primary). Scoped to .viewport
      so docs chrome stays neutral.
@@ -49,130 +48,159 @@ body.dark-mode .viewport {
   color: var(--color-text-primary);
 }
 
-/* --- TabBar (2 tabs · partner primary indicator) --- */
-.sp-tabbar {
-  height: 48px;
-  display: flex;
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-divider);
-}
-.sp-tab {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--typography-font-size-body);
-  font-weight: 500;
-  color: var(--color-text-secondary);
-  position: relative;
-}
-.sp-tab--active {
-  color: var(--color-primary);
-  font-weight: 700;
-}
-.sp-tab--active::after {
-  content: "";
-  position: absolute;
-  left: 0; right: 0; bottom: 0;
-  height: 2px;
-  background: var(--color-primary);
-}
-
-/* --- Body (List tab) --- */
+/* --- Body (single monthly settlement scroll) --- */
 .sp-body {
   position: absolute;
-  top: 104px;          /* 56 appbar + 48 tabbar */
+  top: 56px;           /* 56 appbar */
   left: 0; right: 0; bottom: 0;
   background: var(--color-surface);
-  display: flex;
-  flex-direction: column;
-}
-
-/* --- Filter chip row --- */
-.sp-chips {
-  display: flex;
-  gap: var(--spacing-small);
-  padding: var(--spacing-small) var(--spacing-medium);
-  overflow-x: auto;
+  overflow-y: auto;
   scrollbar-width: none;
-  background: var(--color-surface);
 }
-.sp-chips::-webkit-scrollbar { display: none; }
-.sp-chip {
-  height: 32px;
-  padding: 0 var(--spacing-sm);
-  border-radius: var(--radius-chip);
-  display: flex;
-  align-items: center;
-  font-size: var(--typography-font-size-caption);
-  font-weight: 600;
-  flex-shrink: 0;
-  border: 1px solid var(--color-divider);
-  background: var(--color-background);
-  color: var(--color-text-secondary);
-}
-.sp-chip--active {
-  background: color-mix(in srgb, var(--color-primary) 14%, transparent);
-  color: var(--color-primary);
-  border-color: transparent;
-}
+.sp-body::-webkit-scrollbar { display: none; }
 
 /* --- Scrollable list area --- */
 .sp-list {
-  flex: 1;
-  overflow-y: auto;
-  scrollbar-width: none;
-  background: var(--color-background);
+  background: var(--color-surface);
+  padding: 0 0 var(--spacing-medium);
 }
-.sp-list::-webkit-scrollbar { display: none; }
-
-/* --- Month header (sticky-look · onSurfaceVariant bold) --- */
-.sp-month {
-  padding: var(--spacing-medium) var(--spacing-medium) var(--spacing-xsmall);
-  font-size: var(--typography-font-size-caption);
-  font-weight: 700;
-  color: var(--color-text-secondary);
-  background: var(--color-background);
+.sp-empty-host {
+  position: relative;
+  min-height: 100%;
 }
 
-/* --- Settlement card row (SettlementCard · InkWell + Padding + Row) --- */
-.sp-card {
+/* --- Monthly settings group (MinglitSettingsGroup pattern) --- */
+.sp-month-section {
+  padding: 0 var(--spacing-medium);
+}
+.sp-month-section + .sp-month-section {
+  margin-top: var(--spacing-large);
+}
+.sp-month-header {
   display: flex;
   align-items: center;
-  padding: var(--spacing-sm) var(--spacing-medium);
+  justify-content: space-between;
+  gap: var(--spacing-small);
+  padding: 0 0 var(--spacing-small) var(--spacing-xsmall);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+.sp-month-header__count {
+  font-size: var(--typography-font-size-caption);
+  font-weight: 500;
+  white-space: nowrap;
+}
+.sp-month-card {
   background: var(--color-background);
-  gap: var(--spacing-sm);
+  border-radius: var(--radius-card);
+  overflow: hidden;
 }
-.sp-card + .sp-card {
-  border-top: 1px solid var(--color-divider);
+body.dark-mode .sp-month-card { background: var(--color-dark-surface); }
+
+/* --- Settlement settings tile (MinglitSettingsTile-like row) --- */
+.sp-tile {
+  display: flex;
+  align-items: center;
+  min-height: 60px;
+  padding: var(--spacing-sm) var(--spacing-medium);
+  gap: var(--spacing-medium);
+  position: relative;
 }
-.sp-card__main {
+.sp-tile + .sp-tile::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 0.5px;
+  background: var(--color-divider);
+}
+.sp-tile__icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  color: var(--color-primary);
+  background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+  flex-shrink: 0;
+}
+.sp-tile__icon--ready {
+  background: rgba(255, 153, 0, 0.12);
+  color: var(--color-secondary);
+}
+.sp-tile__icon--processing {
+  background: rgba(255, 153, 0, 0.12);
+  color: var(--color-secondary);
+}
+.sp-tile__icon--completed {
+  background: rgba(22, 163, 74, 0.12);
+  color: var(--color-success);
+}
+.sp-tile__icon--failed,
+.sp-tile__icon--hold {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--color-error);
+}
+.sp-tile__icon--pending,
+.sp-tile__icon--canceled {
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+}
+.sp-tile__icon svg {
+  width: 18px;
+  height: 18px;
+}
+.sp-tile__body {
   flex: 1;
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
-.sp-card__title {
+.sp-tile__title {
   font-size: var(--typography-font-size-body);
   font-weight: 600;
   color: var(--color-text-primary);
   line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.sp-card__date {
+.sp-tile__subtitle {
   font-size: var(--typography-font-size-caption);
   color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.sp-card__amount {
+.sp-tile__trailing {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.sp-tile__amount {
   font-size: var(--typography-font-size-body);
+  font-weight: 700;
   color: var(--color-text-primary);
+  white-space: nowrap;
 }
-.sp-card__amount--neg { color: var(--color-text-primary); }
+.sp-tile__amount--neg { color: var(--color-text-primary); }
+.sp-tile__chevron {
+  width: 16px;
+  height: 16px;
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+}
 
 /* --- Status badge (mirrors SettlementStatusBadge — see settlement_detail_page) --- */
 .sp-badge {
   display: inline-flex;
   align-items: center;
+  gap: 4px;
   padding: var(--spacing-xxsmall) var(--spacing-small);
   border-radius: var(--radius-badge);
   font-size: var(--typography-font-size-caption);
@@ -180,14 +208,18 @@ body.dark-mode .viewport {
   white-space: nowrap;
   flex-shrink: 0;
 }
+.sp-badge svg {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+}
 .sp-badge--pending {
   background: var(--color-surface);
   color: var(--color-text-secondary);
 }
 .sp-badge--ready {
-  /* primaryContainer-like — partner primary @ ~10% */
-  background: color-mix(in srgb, var(--color-primary) 12%, transparent);
-  color: var(--color-primary);
+  background: rgba(255, 153, 0, 0.12);
+  color: var(--color-secondary);
 }
 .sp-badge--processing {
   background: rgba(255, 153, 0, 0.12);
@@ -200,10 +232,12 @@ body.dark-mode .viewport {
 .sp-badge--failed {
   background: rgba(239, 68, 68, 0.10);
   color: var(--color-error);
+  box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.20);
 }
 .sp-badge--hold {
   background: rgba(239, 68, 68, 0.10);
   color: var(--color-error);
+  box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.20);
 }
 .sp-badge--canceled {
   background: var(--color-surface);
@@ -211,13 +245,14 @@ body.dark-mode .viewport {
   text-decoration: line-through;
 }
 
-/* --- Dashboard tab — RevenueSummaryCard (gradient) --- */
+/* --- RevenueSummaryCard (plain surface card) --- */
 .sp-revenue {
   margin: var(--spacing-medium);
-  padding: var(--spacing-large);
-  border-radius: var(--radius-button);
-  background: linear-gradient(135deg, var(--color-primary) 0%, color-mix(in srgb, var(--color-primary) 60%, white) 100%);
-  color: #fff;
+  padding: var(--spacing-xlarge) var(--spacing-large);
+  border-radius: var(--radius-card);
+  background: var(--color-background);
+  color: var(--color-text-primary);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
 .sp-revenue__period {
   display: flex;
@@ -228,62 +263,35 @@ body.dark-mode .viewport {
   color: var(--color-text-primary);
 }
 .sp-revenue__period svg { width: 20px; height: 20px; color: var(--color-text-secondary); }
-.sp-revenue__period-label { font-size: var(--typography-font-size-body); font-weight: 700; }
+.sp-revenue__period-label {
+  font-size: var(--typography-font-size-app-bar-title);
+  font-weight: 700;
+}
 .sp-revenue__caption {
   font-size: var(--typography-font-size-caption);
-  opacity: 0.7;
+  font-weight: 600;
+  color: var(--color-text-secondary);
 }
 .sp-revenue__total {
-  font-size: 32px;
-  font-weight: 900;
-  letter-spacing: -1px;
-  margin-top: 2px;
+  font-size: 38px;
+  font-weight: 850;
+  letter-spacing: 0;
+  line-height: 1.12;
+  margin-top: var(--spacing-small);
+  margin-bottom: var(--spacing-medium);
 }
 .sp-revenue__row {
   display: flex;
   justify-content: space-between;
-  margin-top: var(--spacing-small);
-  font-size: var(--typography-font-size-caption);
-}
-.sp-revenue__row-label { opacity: 0.7; }
-
-/* --- Dashboard tab — Status summary grid card --- */
-.sp-grid-card {
-  margin: 0 var(--spacing-medium) var(--spacing-medium);
-  padding: var(--spacing-medium);
-  background: var(--color-background);
-  border-radius: var(--radius-card);
-  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
-}
-.sp-grid-card__title {
-  font-size: var(--typography-font-size-body);
-  font-weight: 700;
-  color: var(--color-text-primary);
-  margin-bottom: var(--spacing-sm);
-}
-.sp-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: var(--spacing-small);
-}
-.sp-grid__cell {
-  aspect-ratio: 1.2 / 1;
-  border-radius: var(--radius-small);
-  display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
-}
-.sp-grid__cell-count {
+  gap: var(--spacing-medium);
+  padding: var(--spacing-sm) 0;
+  border-top: 1px solid var(--color-divider);
   font-size: var(--typography-font-size-body);
-  font-weight: 700;
-  line-height: 1.2;
 }
-.sp-grid__cell-label {
-  font-size: var(--typography-font-size-caption);
-}
+.sp-revenue__row-label { color: var(--color-text-secondary); }
 
-/* --- Empty state (centered icon + text + optional CTA) --- */
+/* --- Empty / error state (centered icon + text + optional CTA) --- */
 .sp-empty {
   position: absolute;
   inset: 0;
@@ -318,19 +326,86 @@ body.dark-mode .viewport {
   font-weight: 700;
   border: none;
 }
+.sp-section-empty {
+  margin: 0 var(--spacing-medium);
+  min-height: 188px;
+  border-radius: var(--radius-card);
+  background: var(--color-background);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-xlarge) var(--spacing-large);
+  text-align: center;
+}
+.sp-section-empty svg {
+  width: 40px;
+  height: 40px;
+  color: var(--color-text-secondary);
+  opacity: 0.65;
+}
+.sp-section-empty__title {
+  font-size: var(--typography-font-size-body);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+.sp-section-empty__sub {
+  font-size: var(--typography-font-size-caption);
+  color: var(--color-text-secondary);
+  line-height: 1.45;
+}
 
-/* --- Spinner --- */
-.sp-spinner {
-  width: 36px; height: 36px;
-  border: 3px solid var(--color-divider);
-  border-top-color: var(--color-primary);
-  border-radius: 50%;
-  animation: sp-spin 0.7s linear infinite;
+/* --- Settlement shimmer skeleton --- */
+.sp-skeleton {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-small);
+  background: color-mix(in srgb, var(--color-text-primary) 12%, transparent);
+}
+.sp-skeleton::after {
+  content: "";
   position: absolute;
   inset: 0;
-  margin: auto;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--color-text-primary) 4%, transparent) 50%,
+    transparent 100%
+  );
+  animation: sp-shimmer 1.2s ease-in-out infinite;
 }
-@keyframes sp-spin { to { transform: rotate(360deg); } }
+@keyframes sp-shimmer { to { transform: translateX(100%); } }
+.sp-skeleton-card {
+  margin: var(--spacing-medium);
+  padding: var(--spacing-xlarge) var(--spacing-large);
+  border-radius: var(--radius-card);
+  background: var(--color-background);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+.sp-skeleton-line { height: 14px; }
+.sp-skeleton-total { height: 42px; border-radius: 10px; }
+.sp-skeleton-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-medium);
+  min-height: 60px;
+  padding: var(--spacing-sm) var(--spacing-medium);
+}
+.sp-skeleton-row + .sp-skeleton-row { border-top: 1px solid var(--color-divider); }
+.sp-skeleton-circle {
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+.sp-skeleton-stack {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-small);
+}
 </style>
 </head>
 <body>
@@ -358,7 +433,7 @@ body.dark-mode .viewport {
     <tbody>
       <tr>
         <th style="width: 140px;">Status</th>
-        <td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— 5 state · 정산 dashboard + 내역 list parent</em></td>
+        <td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— single scroll · 월별 요약 + settings-list style 정산 내역</em></td>
       </tr>
       <tr>
         <th>App</th>
@@ -366,11 +441,11 @@ body.dark-mode .viewport {
       </tr>
       <tr>
         <th>Category</th>
-        <td>settlement · list · dashboard</td>
+        <td>settlement · monthly overview · list</td>
       </tr>
       <tr>
         <th>Route / Surface</th>
-        <td><code>SettlementRoute</code> · widget: <code>SettlementPage</code> (Scaffold + 2-tab TabBar: 대시보드 / 정산 내역)</td>
+        <td><code>SettlementRoute</code> · widget: <code>SettlementPage</code> (Scaffold + single monthly settlement scroll)</td>
       </tr>
       <tr>
         <th>Path</th>
@@ -382,7 +457,7 @@ body.dark-mode .viewport {
           <strong>Parent</strong>: <em>— (StatefulShellBranch top-level — bottom nav "정산" 탭)</em><br>
           <strong>Children</strong>:
           <a href="/specs/settlement_detail_page/index.html"><code>SettlementDetailPage</code></a>
-          (정산 내역 탭의 카드 탭으로 진입 · <code>/settlement/:id</code>) ·
+          (월별 정산 tile 탭으로 진입 · route: <code>/settlement/:id</code>) ·
           <a href="/specs/bank_account_page/index.html"><code>BankAccountPage</code></a>
           (AppBar 우측 지갑 아이콘 · <code>/settlement/bank-account</code> · SETTLEMENT_EDIT 권한 보유 시만)
         </td>
@@ -390,8 +465,7 @@ body.dark-mode .viewport {
       <tr>
         <th>Purpose</th>
         <td>
-          파트너가 (1) 월별 정산 대시보드(완료 매출 / 대기 / 상태별 카운트)와
-          (2) 정산 항목 list(상태 필터 + 월별 그룹)를 한 화면에서 확인한다.
+          파트너가 월별 핵심 정산금 요약과 정산 항목 list(월별 그룹)를 한 화면에서 확인한다.
           개별 항목 상세는 <code>SettlementDetailPage</code>로 진입.
         </td>
       </tr>
@@ -399,13 +473,13 @@ body.dark-mode .viewport {
         <th>User journey</th>
         <td>
           <strong>Entry points</strong>: 하단 네비게이션 "정산" 탭 / 푸시 알림(정산 완료) 탭.<br>
-          <strong>Exit points</strong>: 카드 탭 → 정산 상세 화면 · AppBar 지갑 아이콘 → 정산 계좌 화면 (정산 편집 권한 보유 시) · 빈 상태 CTA "첫 이벤트 만들기" → 파티 생성 화면 (다른 탭으로 점프).
+          <strong>Exit points</strong>: 정산 tile 탭 → 정산 상세 화면 · AppBar 지갑 아이콘 → 정산 계좌 화면 (정산 편집 권한 보유 시).
         </td>
       </tr>
       <tr>
         <th>Background</th>
         <td>
-          정산 항목은 7가지 상태(대기 / 준비 / 처리 중 / 완료 / 실패 / 보류 / 취소)로 분류된다. 대시보드 카드는 정산 완료 매출 / 완료 순매출 / 대기 매출 / 상태별 카운트를 보여주며, 정산 내역 리스트는 항목 생성일 기준으로 월별 그룹으로 묶인다.
+          정산 항목은 7가지 상태(지급 대기 / 지급 예정 / 지급 중 / 지급 완료 / 지급 실패 / 지급 보류 / 지급 취소)로 분류된다. 화면 상단은 선택 월의 핵심 금액만 보여주며, 하단 리스트도 같은 선택 월의 정산 항목만 정산 기준일 내림차순으로 보여준다. 상태는 필터 chip이 아니라 각 tile의 status badge로만 확인한다.
         </td>
       </tr>
       <tr>
@@ -434,6 +508,12 @@ body.dark-mode .viewport {
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td>2026-05-31</td>
+        <td>1.1</td>
+        <td>Codex</td>
+        <td>2-tab 구조와 상태 filter chip을 제거하고, 월별 요약 카드 아래에 <code>MinglitSettingsGroup</code> + <code>MinglitSettingsTile</code> 월별 정산 리스트를 배치.</td>
+      </tr>
       <tr>
         <td>2026-05-01</td>
         <td>1.0</td>
@@ -465,9 +545,9 @@ body.dark-mode .viewport {
   <section class="doc">
     <h2>Blueprint &amp; tree</h2>
     <p class="intro">
-      Scaffold + AppBar(title:"정산", actions: 지갑 IconButton, bottom: 2-tab TabBar)
-      + TabBarView(<code>_DashboardTab</code> / <code>_ListTab</code>).
-      List 탭은 StatusFilterChips(8 chips) + ListView(month header + SettlementCard rows).
+      Scaffold + AppBar(title:"정산", actions: 지갑 IconButton)
+      + RefreshIndicator + SingleChildScrollView.
+      본문은 월 선택 + 요약 카드 + 월별 SettingsGroup 리스트로 이어지는 단일 흐름이다.
     </p>
     <div class="layout-grid">
       <div class="blueprint">
@@ -477,17 +557,13 @@ body.dark-mode .viewport {
         <div class="blueprint__region blueprint__region--shaded" style="top:0;left:0;right:0;height:56px;">
           <span class="blueprint__region-label">① AppBar — "정산" + 지갑 IconButton (SETTLEMENT_EDIT only)</span>
         </div>
-        <!-- TabBar -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:56px;left:0;right:0;height:48px;">
-          <span class="blueprint__region-label">② TabBar — 대시보드 · 정산 내역</span>
+        <!-- Summary -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:72px;left:0;right:0;height:156px;">
+          <span class="blueprint__region-label">② PeriodSelector + RevenueSummaryCard</span>
         </div>
-        <!-- Filter chips (List tab) -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:112px;left:0;right:0;height:48px;">
-          <span class="blueprint__region-label">③ StatusFilterChips (8 chips · h-scroll · List 탭 한정)</span>
-        </div>
-        <!-- List body -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:168px;left:0;right:0;bottom:0;">
-          <span class="blueprint__region-label">④ ListView — _MonthHeaderWidget + SettlementCard rows<br>(또는 Dashboard 탭: PeriodSelector + RevenueSummaryCard + StatusSummaryGrid)</span>
+        <!-- Monthly list body -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:244px;left:0;right:0;bottom:0;">
+          <span class="blueprint__region-label">③ 월별 SettingsGroup + SettlementTile rows</span>
         </div>
 
         <div class="blueprint__align-marker" style="top:8px;right:8px;">screen-edge pad</div>
@@ -500,33 +576,19 @@ body.dark-mode .viewport {
 │  │  IconButton(info_outline) → showMinglitHelpSheet(...),
 │  │  if canEditSettlement: IconButton(account_balance_wallet_outlined → BankAccount),
 │  │ ]
-│  └─ <b>bottom</b>: TabBar(controller, length:2)          ← ②
-│     ├─ Tab('대시보드')
-│     └─ Tab('정산 내역')
-└─ <b>body</b>: TabBarView(controller)
-   ├─ <b>_DashboardTab</b> (RefreshIndicator + SingleChildScrollView)
-   │  └─ Column(stretch · padding spacing-medium)
-   │     ├─ <b>_PeriodSelector</b>(selectedMonth · ◀ "YYYY년 M월" ▶)
-   │     ├─ status.when(
-   │     │   data: [
-   │     │     <b>_RevenueSummaryCard</b>(gradient · "정산 완료 매출" 라벨 + 큰 금액 + 완료/대기 행)
-   │     │     <b>_StatusSummaryGrid</b>(Card · 4×2 grid · 7 status)
-   │     │   ],
-   │     │   loading: CircularProgressIndicator,
-   │     │   error:   Text+다시시도 FilledButton)
-   │     └─
-   └─ <b>_ListTab</b> (Column)
-      ├─ <b>StatusFilterChips</b>(MinglitChipGroup · 8 ChoiceChip)   ← ③
-      └─ <b>Expanded</b>                                              ← ④
-         ├─ [error&amp;&amp;empty] <b>MinglitEmptyState</b>(error_outline · "다시 시도")
-         ├─ [empty]         <b>MinglitEmptyState</b>(receipt_long · CTA "첫 이벤트 만들기"
-         │                    필터 없을 때만 · cross-branch root push)
-         └─ [data]          <b>RefreshIndicator</b> → <b>ListView.builder</b>
-            ├─ <b>_MonthHeaderWidget</b>('YYYY년 M월') + …
-            ├─ <b>SettlementCard</b>(item · onTap → SettlementDetailRoute(id))
-            │  └─ Row(Column[정산 항목 / yyyy-MM-dd / ±₩금액] + SettlementStatusBadge)
-            ├─ Divider(1px) · …
-            └─ [isLoading more] CircularProgressIndicator footer</div>
+└─ <b>body</b>: RefreshIndicator → SingleChildScrollView
+   └─ Column(stretch)
+      ├─ <b>_PeriodSelector</b>(selectedMonth · ◀ "YYYY년 M월" ▶)       ← ②
+      ├─ <b>_RevenueSummaryCard</b>("이번 달 정산금" total + 정산 대상 이벤트/정산 대기/정산 완료 행)
+      ├─ [loading] <b>SettlementPageShimmer</b>(period 유지 · summary skeleton + list skeleton)
+      ├─ [empty] <b>SectionEmptyState</b>(receipt_long · "정산 항목이 없습니다" · CTA 없음)
+      ├─ [error] <b>MinglitEmptyState</b>(error_outline · "다시 시도")
+      └─ [data] <b>SettlementMonthList</b>                              ← ③
+         ├─ <b>SettlementMonthGroup</b>(MinglitSettingsGroup-like · header:'상세 내역 N건' · selected month only)
+         │  ├─ <b>SettlementTile</b>(MinglitSettingsTile-like · leading status icon)
+         │  │  └─ title: event/party name · subtitle: yyyy-MM-dd · trailing: ±₩금액 + icon+label SettlementStatusBadge + chevron · date desc
+         │  └─ internal Divider(0.5px) · …
+         └─ [isLoading more] Settlement shimmer footer row</div>
     </div>
   </section>
 
@@ -543,12 +605,10 @@ body.dark-mode .viewport {
       </thead>
       <tbody>
         <tr><td>①</td><td>AppBar</td><td>height 56 · title 좌측 (centerTitle 미설정) · 2 actions trailing (info + 지갑)</td><td>표준 AppBar · scaffold-gray bg · 하단 border 없음</td></tr>
-        <tr><td>②</td><td>TabBar</td><td>height 48 · 2 equal-flex tabs · indicator 2px</td><td>indicator color = partner primary · active label = primary, inactive = secondary · 하단 1px <code>color-divider</code></td></tr>
-        <tr><td>③</td><td>StatusFilterChips</td><td>row · h-scroll · 칩 8개 (전체 + 7 status)</td><td>chip 간: <code>spacing-small (8)</code> · row v-pad: <code>spacing-small</code> 위/아래 · h-pad: <code>spacing-medium</code></td></tr>
-        <tr><td>④a</td><td>SettlementCard row (List 탭)</td><td>Row · 좌 Column(title/date/amount stacked) · 우 SettlementStatusBadge</td><td>row pad: <code>spacing-medium (16h)</code> · <code>spacing-sm (12v)</code> · 행 분리: 1px Divider · column 내부: <code>spacing-xsmall (4)</code></td></tr>
-        <tr><td>④b</td><td>_MonthHeaderWidget</td><td>좌측 정렬 · UPPERCASE 아님 · bold</td><td>pad: 16/16/16/4 (top/right/bottom/left? 실제는 16,16,16,4 fromLTRB) · onSurfaceVariant · labelMedium bold</td></tr>
-        <tr><td>④c</td><td>RevenueSummaryCard (Dashboard)</td><td>column start · gradient bg · 큰 금액 강조</td><td>card outer margin: <code>spacing-medium</code> · inner pad: <code>spacing-large (24)</code> · 라벨↔금액: <code>spacing-xsmall</code> · row 간격: <code>spacing-sm</code></td></tr>
-        <tr><td>④d</td><td>StatusSummaryGrid (Dashboard)</td><td>4-col grid · childAspectRatio 1.2 · 7 status (PENDING/READY/PROCESSING/COMPLETED/FAILED/HOLD/CANCELED)</td><td>card inner pad: <code>spacing-medium</code> · grid main/cross spacing: <code>spacing-small</code></td></tr>
+        <tr><td>②a</td><td>PeriodSelector</td><td>centered row · left/right month arrows</td><td>top pad: <code>spacing-medium</code> · label: appBarTitle size</td></tr>
+        <tr><td>②b</td><td>RevenueSummaryCard</td><td>column start · white card · large total amount · muted labels</td><td>card outer margin: <code>spacing-medium</code> · inner pad: <code>spacing-xlarge</code>/<code>spacing-large</code> · total bottom gap: <code>spacing-medium</code> · row pad: <code>spacing-sm</code> · row divider: 1px</td></tr>
+        <tr><td>③a</td><td>SettlementTile row</td><td>Settings tile 구조 · leading status icon · 좌 title/subtitle · 우 amount/status/chevron</td><td>tile min-height: 60 · h-pad: <code>spacing-medium</code> · v-pad: <code>spacing-sm</code> · 행 분리: group 내부 0.5px Divider</td></tr>
+        <tr><td>③b</td><td>SettlementMonthGroup</td><td>header + rounded group card · 월별 묶음</td><td>group h-pad: <code>spacing-medium</code> · group gap: <code>spacing-large</code> · header left pad: <code>spacing-xsmall</code> · header bottom: <code>spacing-small</code> · card radius: <code>radius-card</code></td></tr>
       </tbody>
     </table>
   </section>
@@ -564,7 +624,7 @@ body.dark-mode .viewport {
       </thead>
       <tbody>
         <tr><td>① Title (leading)</td><td>좌측 정렬 · 1줄</td><td>"정산" · <code>--typography-font-size-app-bar-title</code> 18 · w600 · <code>color-text-primary</code>. padding-left medium.</td></tr>
-        <tr><td>② Info action (1st trailing)</td><td>우측 · 40×40 hit-region</td><td>info_outline 22×22 · 탭 시 <strong>도움말 bottom sheet</strong> 진입 (State 7). 파트너 앱 모든 화면에 동일 패턴 적용.</td></tr>
+        <tr><td>② Info action (1st trailing)</td><td>우측 · 40×40 hit-region</td><td>info_outline 22×22 · 탭 시 <strong>도움말 bottom sheet</strong> 진입 (State 5). 파트너 앱 모든 화면에 동일 패턴 적용.</td></tr>
         <tr><td>③ Wallet action (2nd trailing)</td><td>우측 · 40×40 hit-region · SETTLEMENT_EDIT 권한 보유 시만</td><td>account_balance_wallet_outlined 22×22 · 탭 시 정산 계좌 화면 push.</td></tr>
         <tr><td>—</td><td>AppBar bg</td><td><code>--color-surface</code> · surfaceTint transparent · border-bottom 없음.</td></tr>
       </tbody>
@@ -599,22 +659,22 @@ body.dark-mode .viewport {
   <div class="perspective__header">
     <span class="glyph">🎨</span>
     <h2>States</h2>
-    <span class="lede">시각 변형 5종. baseline = 정산 내역 탭 + 데이터 있음, 나머지는 additive diff.</span>
+    <span class="lede">시각 변형. baseline = 월별 요약 + 정산 내역이 함께 보이는 단일 스크롤.</span>
   </div>
 
   <section class="doc">
     <p class="intro">
       <strong>State 종류 식별 기준</strong>:
-      ① 활성 탭(대시보드 / 정산 내역)
-      ② 정산 항목이 비어있는지 여부 + 상태 필터 선택 여부
-      ③ 정산 목록 조회 실패 여부
-      ④ 정산 목록 로딩 진행 여부.
+      ① 선택 월
+      ② 정산 항목이 비어있는지 여부
+      ③ 선택 월 정산 정보 조회 실패 여부
+      ④ 선택 월 정산 정보 로딩 진행 여부.
     </p>
 
-    <!-- State 1: List · Default (baseline) -->
+    <!-- State 1: Monthly overview + list (baseline) -->
     <table class="ref state-mini is-baseline-tint">
       <thead>
-        <tr><th colspan="3"><strong>List · 정산 내역 (mixed status)</strong> 🎯 <small>baseline · production</small></th></tr>
+        <tr><th colspan="3"><strong>Monthly overview + list</strong> 🎯 <small>baseline · production</small></th></tr>
       </thead>
       <tbody>
         <tr>
@@ -627,95 +687,101 @@ body.dark-mode .viewport {
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12V7H5a2 2 0 0 1 0-4h14v4"/><path d="M3 5v14a2 2 0 0 0 2 2h16v-5"/><path d="M18 12a2 2 0 0 0 0 4h4v-4Z"/></svg>
                 </div>
               </div>
-              <div class="sp-tabbar">
-                <div class="sp-tab">대시보드</div>
-                <div class="sp-tab sp-tab--active">정산 내역</div>
-              </div>
               <div class="sp-body">
-                <div class="sp-chips">
-                  <div class="sp-chip sp-chip--active">전체</div>
-                  <div class="sp-chip">대기</div>
-                  <div class="sp-chip">확정</div>
-                  <div class="sp-chip">지급중</div>
-                  <div class="sp-chip">완료</div>
-                  <div class="sp-chip">실패</div>
-                  <div class="sp-chip">보류</div>
+                <div class="sp-revenue__period" style="padding-top:16px;">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+                  <span class="sp-revenue__period-label">2026년 4월</span>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                </div>
+                <div class="sp-revenue">
+                  <div class="sp-revenue__caption">이번 달 정산금</div>
+                  <div class="sp-revenue__total">₩1,539,400</div>
+                  <div class="sp-revenue__row"><span class="sp-revenue__row-label">정산 대상 이벤트</span><span style="font-weight:700;">3건</span></div>
+                  <div class="sp-revenue__row"><span class="sp-revenue__row-label">정산 대기</span><span style="font-weight:700;">₩817,000</span></div>
+                  <div class="sp-revenue__row"><span class="sp-revenue__row-label">정산 완료</span><span style="font-weight:700;">₩722,400</span></div>
                 </div>
                 <div class="sp-list">
-                  <div class="sp-month">2026년 4월</div>
-                  <div class="sp-card">
-                    <div class="sp-card__main">
-                      <div class="sp-card__title">정산 항목</div>
-                      <div class="sp-card__date">2026-04-26</div>
-                      <div class="sp-card__amount">₩722,400</div>
+                  <div class="sp-month-section">
+                    <div class="sp-month-header">상세 내역 4건</div>
+                    <div class="sp-month-card">
+                      <div class="sp-tile">
+                        <div class="sp-tile__icon sp-tile__icon--completed"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M20 6 9 17l-5-5"/></svg></div>
+                        <div class="sp-tile__body">
+                          <div class="sp-tile__title">라틴 소셜 나이트</div>
+                          <div class="sp-tile__subtitle">2026-04-26</div>
+                        </div>
+                        <div class="sp-tile__trailing">
+                          <div class="sp-tile__amount">₩722,400</div>
+                          <div class="sp-badge sp-badge--completed"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6 9 17l-5-5"/></svg>지급 완료</div>
+                        </div>
+                        <svg class="sp-tile__chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>
+                      </div>
+                      <div class="sp-tile">
+                        <div class="sp-tile__icon sp-tile__icon--processing"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M16 8h5V3"/></svg></div>
+                        <div class="sp-tile__body">
+                          <div class="sp-tile__title">와인 클래스 4월</div>
+                          <div class="sp-tile__subtitle">2026-04-25</div>
+                        </div>
+                        <div class="sp-tile__trailing">
+                          <div class="sp-tile__amount">₩516,000</div>
+                          <div class="sp-badge sp-badge--processing"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M16 8h5V3"/></svg>지급 중</div>
+                        </div>
+                        <svg class="sp-tile__chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>
+                      </div>
+                      <div class="sp-tile">
+                        <div class="sp-tile__icon sp-tile__icon--ready"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M16 8h5V3"/></svg></div>
+                        <div class="sp-tile__body">
+                          <div class="sp-tile__title">루프탑 네트워킹</div>
+                          <div class="sp-tile__subtitle">2026-04-22</div>
+                        </div>
+                        <div class="sp-tile__trailing">
+                          <div class="sp-tile__amount">₩301,000</div>
+                          <div class="sp-badge sp-badge--ready"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M16 8h5V3"/></svg>지급 예정</div>
+                        </div>
+                        <svg class="sp-tile__chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>
+                      </div>
+                      <div class="sp-tile">
+                        <div class="sp-tile__icon sp-tile__icon--failed"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="9"/><path d="M12 7v6"/><path d="M12 17h.01"/></svg></div>
+                        <div class="sp-tile__body">
+                          <div class="sp-tile__title">멤버십 환불 조정</div>
+                          <div class="sp-tile__subtitle">2026-04-18</div>
+                        </div>
+                        <div class="sp-tile__trailing">
+                          <div class="sp-tile__amount sp-tile__amount--neg">-₩42,000</div>
+                          <div class="sp-badge sp-badge--failed"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v6"/><path d="M12 17h.01"/></svg>지급 실패</div>
+                        </div>
+                        <svg class="sp-tile__chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>
+                      </div>
                     </div>
-                    <div class="sp-badge sp-badge--completed">지급 완료</div>
-                  </div>
-                  <div class="sp-card">
-                    <div class="sp-card__main">
-                      <div class="sp-card__title">정산 항목</div>
-                      <div class="sp-card__date">2026-04-25</div>
-                      <div class="sp-card__amount">₩516,000</div>
-                    </div>
-                    <div class="sp-badge sp-badge--processing">지급 중</div>
-                  </div>
-                  <div class="sp-card">
-                    <div class="sp-card__main">
-                      <div class="sp-card__title">정산 항목</div>
-                      <div class="sp-card__date">2026-04-22</div>
-                      <div class="sp-card__amount">₩301,000</div>
-                    </div>
-                    <div class="sp-badge sp-badge--ready">정산 확정</div>
-                  </div>
-                  <div class="sp-card">
-                    <div class="sp-card__main">
-                      <div class="sp-card__title">정산 항목</div>
-                      <div class="sp-card__date">2026-04-18</div>
-                      <div class="sp-card__amount">-₩42,000</div>
-                    </div>
-                    <div class="sp-badge sp-badge--failed">지급 실패</div>
-                  </div>
-                  <div class="sp-month">2026년 3월</div>
-                  <div class="sp-card">
-                    <div class="sp-card__main">
-                      <div class="sp-card__title">정산 항목</div>
-                      <div class="sp-card__date">2026-03-30</div>
-                      <div class="sp-card__amount">₩188,000</div>
-                    </div>
-                    <div class="sp-badge sp-badge--hold">보류</div>
-                  </div>
-                  <div class="sp-card">
-                    <div class="sp-card__main">
-                      <div class="sp-card__title">정산 항목</div>
-                      <div class="sp-card__date">2026-03-15</div>
-                      <div class="sp-card__amount">₩155,000</div>
-                    </div>
-                    <div class="sp-badge sp-badge--pending">정산 대기</div>
                   </div>
                 </div>
               </div>
             </div>
           </td>
           <td class="state-mini__aspect">조건</td>
-          <td>활성 탭이 정산 내역이며, 정산 항목이 1개 이상 있고 상태 필터는 '전체'.</td>
+          <td>선택 월의 요약 데이터와 정산 항목이 모두 도착한 상태.</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>
           <td>
-            ① <strong>카드 탭</strong> → 정산 상세 화면으로 이동<br>
-            ② <strong>chip 탭</strong> → 해당 상태로 리스트가 좁혀짐 (State 2)<br>
-            ③ <strong>탭 스와이프 / "대시보드" tap</strong> → 대시보드 탭으로 전환<br>
-            ④ <strong>스크롤 끝</strong> → 다음 페이지가 자동으로 더 불러와짐<br>
-            ⑤ <strong>pull-to-refresh</strong> → 리스트 새로고침<br>
-            ⑥ <strong>지갑 아이콘</strong> → 정산 계좌 화면 (정산 편집 권한 보유 시만 노출)
+            ① <strong>◀ / ▶ 월 이동</strong> → 요약 카드와 월별 리스트가 같은 월 기준으로 갱신됨<br>
+            ② <strong>정산 tile 탭</strong> → <code>settlementCoordinator.goToDetail(item.id)</code> → <code>SettlementDetailRoute(id)</code> push<br>
+            ③ <strong>스크롤 끝</strong> → 선택 월 안의 다음 페이지가 자동으로 더 불러와짐<br>
+            ④ <strong>pull-to-refresh</strong> → 요약 + 리스트 새로고침<br>
+            ⑤ <strong>지갑 아이콘</strong> → 정산 계좌 화면 (정산 편집 권한 보유 시만 노출)
           </td>
         </tr>
         <tr>
           <td class="state-mini__aspect">에지케이스</td>
           <td>
             · 음수 정산금: <code>-₩42,000</code> 형식 (마이너스 부호가 ₩ 앞)<br>
-            · 동일 월 내 여러 항목 → 월 헤더는 1회만 표시 후 카드 연속<br>
-            · 추가 로딩 중간 실패 → 하단 스피너가 사라지고 다음 스크롤 시 재시도<br>
+            · 정산 대상 이벤트 3건 = 지급 완료 1건 + 지급 예정/지급 중 2건. 지급 실패 1건은 list에는 보이지만 정산 대상 이벤트 수와 금액 합산에서 제외<br>
+            · list header의 '상세 내역 4건'은 선택 월에 표시되는 정산 내역 전체 건수. 선택 월은 상단 period selector에만 표시<br>
+            · 상태별 필터 chip은 제공하지 않음 — 상태는 각 tile의 badge로 확인<br>
+            · tile 전체 row가 hit target이며, amount/badge/chevron 영역을 탭해도 같은 상세 화면으로 진입<br>
+            · 정렬: 선택 월 안에서 정산 기준일 최신순<br>
+            · 선택 월 외 항목(예: 2026년 4월 선택 상태의 3월 항목)은 표시하지 않음<br>
+            · 동일 월 내 여러 항목 → 월별 header는 1회만 표시되고 rounded group card 내부에 tile이 연속됨<br>
             · 취소된 항목 → 배지에 취소선 표시
           </td>
         </tr>
@@ -723,34 +789,34 @@ body.dark-mode .viewport {
           <td class="state-mini__aspect">컴포넌트</td>
           <td>
             · <code>AppBar</code>(title:'정산', actions:[wallet IconButton, gated by SETTLEMENT_EDIT])<br>
-            · <code>TabBar</code> + <code>TabController</code>(length:2) · <code>TabBarView</code><br>
-            · <code>StatusFilterChips</code>(MinglitChipGroup · 8 ChoiceChip — 전체/PENDING/READY/PROCESSING/COMPLETED/FAILED/HOLD/CANCELED)<br>
-            · <code>RefreshIndicator</code> + <code>ListView.builder</code>(_scrollController · loadMore at maxScroll-200)<br>
-            · <code>_MonthHeaderWidget</code>(labelMedium bold · onSurfaceVariant · padding 16,16,16,4)<br>
-            · <code>SettlementCard</code> — InkWell + Row(Column[title='정산 항목' bodyMedium 600, date bodySmall onSurfaceVariant, amount bodyMedium] + <a href="/specs/settlement_detail_page/index.html"><code>SettlementStatusBadge</code></a> compact:true)<br>
-            · <code>Divider</code>(height 1) 카드 사이
+            · <code>RefreshIndicator</code> + <code>SingleChildScrollView</code><br>
+            · <code>_PeriodSelector</code> + <code>_RevenueSummaryCard</code><br>
+            · <code>SettlementMonthList</code>(_scrollController · loadMore at maxScroll-200)<br>
+            · <code>SettlementMonthGroup</code> — <code>MinglitSettingsGroup</code> style header + rounded group card · selected month only<br>
+            · <code>SettlementTile</code> — <code>MinglitSettingsTile</code> style row(leading status icon + title/event name + subtitle[date only] + trailing amount/status badge/chevron · onTap → detail)<br>
+            · <code>Divider</code>(height 0.5) group card 내부 tile 사이
           </td>
         </tr>
         <tr>
           <td class="state-mini__aspect">토큰</td>
           <td>
-            · color: <code>color-partner-primary</code> (<code>#6c3ce1</code> — TabBar indicator/active label · chip selected · READY 배지 · loadMore spinner), <code>color-success</code> (COMPLETED 배지), <code>color-secondary</code> (PROCESSING — 주황 #ff9900 계열), <code>color-error</code> (FAILED · HOLD), <code>color-surface</code> (scaffold + appbar + tabbar + chip row), <code>color-background</code> (list bg + 카드 bg), <code>color-divider</code> (TabBar 하단 hairline · 카드 사이 Divider · 비선택 chip border)<br>
-            · radius: <code>radius-chip</code> (100 · ChoiceChip), <code>radius-badge</code> (4 · Badge)<br>
-            · spacing: <code>spacing-medium</code> (16 · 카드 h-pad · 월 헤더 pad), <code>spacing-sm</code> (12 · 카드 v-pad · badge↔content), <code>spacing-small</code> (8 · chip 간격 · row 위/아래 v-pad), <code>spacing-xsmall</code> (4 · 월 헤더 하단 pad · row 내 텍스트 stacked gap)<br>
-            · typography: appBarTitle (18/600), bodyMedium (14/600 — 카드 title · "지급 완료" 텍스트), bodySmall (12 — 날짜 · onSurfaceVariant · amount), labelMedium (12/700 — 월 헤더 · onSurfaceVariant), labelSmall (11/600 — Badge compact:true)
+            · color: <code>color-secondary</code> (READY/PROCESSING icon/badge — 주황 #ff9900 계열), <code>color-success</code> (COMPLETED icon/badge), <code>color-error</code> (FAILED · HOLD icon/badge), <code>color-surface</code> (scaffold + appbar + list bg), <code>color-background</code> (summary card + group card bg), <code>color-divider</code> (summary row · tile 사이 Divider)<br>
+            · radius: <code>radius-card</code> (summary card · 월별 group card), <code>radius-badge</code> (4 · Badge)<br>
+            · spacing: <code>spacing-medium</code> (16 · card margin · group h-pad · tile h-pad · icon↔body), <code>spacing-large</code> (24 · group 간격), <code>spacing-sm</code> (12 · tile v-pad), <code>spacing-small</code> (8 · header bottom), <code>spacing-xsmall</code> (4 · header left pad · tile text gap)<br>
+            · typography: appBarTitle (18/600), bodyMedium (14/600 — tile title · amount), bodySmall (12 — subtitle · status context), labelMedium (13/600 — month header), labelSmall (11/600 — Badge compact:true)
           </td>
         </tr>
         <tr>
           <td class="state-mini__aspect">노트</td>
-          <td>📝 정산 카드 자체는 별도 widget이지만 spec은 분리하지 않음 (단순 row + 상태 배지만 재사용). 상태 배지 색상은 settlement_detail spec과 100% 동일.</td>
+          <td>📝 투탭 구조를 제거하고 월별 요약과 월별 내역을 같은 스크롤에 배치한다. 상태는 좌측 icon tint + 우측 icon+label <code>SettlementStatusBadge</code>가 함께 담당하고 subtitle은 날짜만 표시한다. 배지 색상은 <code>SettlementStatus.backgroundColor/textColor</code> 정의를 따른다.</td>
         </tr>
       </tbody>
     </table>
 
-    <!-- State 2: Filtered -->
+    <!-- State 2: Empty detail list -->
     <table class="ref state-mini">
       <thead>
-        <tr><th colspan="3"><strong>List · Filtered (PROCESSING)</strong> <small>지급중 chip 선택 · 해당 상태만 표시</small></th></tr>
+        <tr><th colspan="3"><strong>Detail list · Empty</strong> <small>요약 카드는 유지 · 상세 내역만 empty</small></th></tr>
       </thead>
       <tbody>
         <tr>
@@ -763,125 +829,39 @@ body.dark-mode .viewport {
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12V7H5a2 2 0 0 1 0-4h14v4"/><path d="M3 5v14a2 2 0 0 0 2 2h16v-5"/><path d="M18 12a2 2 0 0 0 0 4h4v-4Z"/></svg>
                 </div>
               </div>
-              <div class="sp-tabbar">
-                <div class="sp-tab">대시보드</div>
-                <div class="sp-tab sp-tab--active">정산 내역</div>
-              </div>
               <div class="sp-body">
-                <div class="sp-chips">
-                  <div class="sp-chip">전체</div>
-                  <div class="sp-chip">대기</div>
-                  <div class="sp-chip">확정</div>
-                  <div class="sp-chip sp-chip--active">지급중</div>
-                  <div class="sp-chip">완료</div>
-                  <div class="sp-chip">실패</div>
-                  <div class="sp-chip">보류</div>
+                <div class="sp-revenue__period" style="padding-top:16px;">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+                  <span class="sp-revenue__period-label">2026년 4월</span>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                </div>
+                <div class="sp-revenue">
+                  <div class="sp-revenue__caption">이번 달 정산금</div>
+                  <div class="sp-revenue__total">₩0</div>
+                  <div class="sp-revenue__row"><span class="sp-revenue__row-label">정산 대상 이벤트</span><span style="font-weight:700;">0건</span></div>
+                  <div class="sp-revenue__row"><span class="sp-revenue__row-label">정산 대기</span><span style="font-weight:700;">₩0</span></div>
+                  <div class="sp-revenue__row"><span class="sp-revenue__row-label">정산 완료</span><span style="font-weight:700;">₩0</span></div>
                 </div>
                 <div class="sp-list">
-                  <div class="sp-month">2026년 4월</div>
-                  <div class="sp-card">
-                    <div class="sp-card__main">
-                      <div class="sp-card__title">정산 항목</div>
-                      <div class="sp-card__date">2026-04-25</div>
-                      <div class="sp-card__amount">₩516,000</div>
-                    </div>
-                    <div class="sp-badge sp-badge--processing">지급 중</div>
+                  <div class="sp-month-section">
+                    <div class="sp-month-header">상세 내역 0건</div>
                   </div>
-                  <div class="sp-card">
-                    <div class="sp-card__main">
-                      <div class="sp-card__title">정산 항목</div>
-                      <div class="sp-card__date">2026-04-21</div>
-                      <div class="sp-card__amount">₩232,000</div>
-                    </div>
-                    <div class="sp-badge sp-badge--processing">지급 중</div>
-                  </div>
-                  <div class="sp-card">
-                    <div class="sp-card__main">
-                      <div class="sp-card__title">정산 항목</div>
-                      <div class="sp-card__date">2026-04-19</div>
-                      <div class="sp-card__amount">₩98,000</div>
-                    </div>
-                    <div class="sp-badge sp-badge--processing">지급 중</div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </td>
-          <td class="state-mini__aspect">조건</td>
-          <td>'지급중' chip이 선택되어 있고 해당 상태의 항목이 1개 이상 존재.</td>
-        </tr>
-        <tr>
-          <td class="state-mini__aspect">사용자 액션</td>
-          <td>+ "전체" chip 탭 → baseline으로 복귀 · 동일 chip 재탭 → 변화 없음<br>나머지 동일</td>
-        </tr>
-        <tr>
-          <td class="state-mini__aspect">에지케이스</td>
-          <td>· 필터가 켜진 상태에서 결과 0건 → 빈 상태가 노출되며 안내 부제는 "다른 상태를 선택해 보세요." (CTA 없음)</td>
-        </tr>
-        <tr>
-          <td class="state-mini__aspect">컴포넌트</td>
-          <td>↔ chip 선택 → '지급중'<br>− 다른 상태의 카드는 보이지 않음</td>
-        </tr>
-        <tr>
-          <td class="state-mini__aspect">토큰</td>
-          <td>동일</td>
-        </tr>
-        <tr>
-          <td class="state-mini__aspect">노트</td>
-          <td>📝 chip 라벨은 다음 7개 상태로 고정: 전체 · 대기 · 확정 · 지급중 · 완료 · 실패 · 보류 · 취소.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <!-- State 3: Empty (no settlements ever) -->
-    <table class="ref state-mini">
-      <thead>
-        <tr><th colspan="3"><strong>List · Empty (no settlements)</strong> <small>최초 진입 · CTA "첫 이벤트 만들기"</small></th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td class="state-mini__mock" rowspan="6">
-            <div class="viewport">
-              <div class="sp-appbar">
-                <div class="sp-appbar__title">정산</div>
-                <div class="sp-appbar__action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg></div>
-                <div class="sp-appbar__action">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12V7H5a2 2 0 0 1 0-4h14v4"/><path d="M3 5v14a2 2 0 0 0 2 2h16v-5"/><path d="M18 12a2 2 0 0 0 0 4h4v-4Z"/></svg>
-                </div>
-              </div>
-              <div class="sp-tabbar">
-                <div class="sp-tab">대시보드</div>
-                <div class="sp-tab sp-tab--active">정산 내역</div>
-              </div>
-              <div class="sp-body">
-                <div class="sp-chips">
-                  <div class="sp-chip sp-chip--active">전체</div>
-                  <div class="sp-chip">대기</div>
-                  <div class="sp-chip">확정</div>
-                  <div class="sp-chip">지급중</div>
-                  <div class="sp-chip">완료</div>
-                  <div class="sp-chip">실패</div>
-                  <div class="sp-chip">보류</div>
-                </div>
-                <div class="sp-list" style="position:relative;">
-                  <div class="sp-empty">
+                  <div class="sp-section-empty">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 3v4a1 1 0 0 0 1 1h4"/><path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z"/><path d="M9 13h6M9 17h6M9 9h2"/></svg>
-                    <div class="sp-empty__title">정산 항목이 없습니다</div>
-                    <div class="sp-empty__sub">파티를 만들고 첫 이벤트를 시작해 보세요.</div>
-                    <button class="sp-empty__cta">첫 이벤트 만들기</button>
+                    <div class="sp-section-empty__title">정산 항목이 없습니다</div>
+                    <div class="sp-section-empty__sub">선택한 월에 표시할 정산 상세 내역이 없습니다.</div>
                   </div>
                 </div>
               </div>
             </div>
           </td>
           <td class="state-mini__aspect">조건</td>
-          <td>정산 항목이 0개이고 로딩/오류가 아니며 상태 필터는 '전체'.</td>
+          <td>선택 월의 요약 데이터는 도착했지만 상세 내역이 0건인 상태.</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>
           <td>
-            + <strong>"첫 이벤트 만들기" CTA 탭</strong> → 파티 생성 화면으로 이동 (정산 탭에서 더보기/이벤트 영역으로 점프)<br>
-            + chip 탭 → 다른 상태 선택 시 빈 필터 상태로 전환
+            + <strong>◀ / ▶ 월 이동</strong> → 다른 월의 요약과 상세 내역 조회
           </td>
         </tr>
         <tr>
@@ -890,23 +870,23 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td class="state-mini__aspect">컴포넌트</td>
-          <td>+ <code>MinglitEmptyState</code>(variant:fullPage · icon:<code>Icons.receipt_long_outlined</code> · title '정산 항목이 없습니다' · subtitle '파티를 만들고 첫 이벤트를 시작해 보세요.' · actionLabel '첫 이벤트 만들기' · onAction → coordinator)<br>− Month header / SettlementCard / Divider</td>
+          <td>↔ <code>_RevenueSummaryCard</code> 유지<br>+ 상세 내역 section empty card(icon:<code>Icons.receipt_long_outlined</code> · title '정산 항목이 없습니다' · subtitle '선택한 월에 표시할 정산 상세 내역이 없습니다.')<br>− SettlementTile / internal Divider</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">토큰</td>
-          <td>+ icon @ <code>color-text-secondary</code> opacity 0.6 (Icons.display 48px · MinglitEmptyState fullPage default · outline tone)<br>+ FilledButton bg = <code>color-partner-primary</code> · fg white</td>
+          <td>+ section empty card bg <code>color-background</code> · radius <code>radius-card</code> · icon 40px @ <code>color-text-secondary</code> opacity 0.65<br>− fullPage empty CTA</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">노트</td>
-          <td>📝 빈 정산 상태에 CTA 추가 (Fix #997) — 필터 없을 때만 노출. 필터가 켜진 상태에서는 CTA가 노출되지 않고 안내 부제만 변경됨.</td>
+          <td>📝 정산 화면 자체는 비어 있지 않다. 월별 요약 카드와 월 이동은 유지하고, 상세 내역 section만 empty로 표현한다.</td>
         </tr>
       </tbody>
     </table>
 
-    <!-- State 4: Dashboard tab -->
+    <!-- State 3: Loading -->
     <table class="ref state-mini">
       <thead>
-        <tr><th colspan="3"><strong>Dashboard tab</strong> <small>대시보드 탭 · 월별 요약 + 상태별 카운트</small></th></tr>
+        <tr><th colspan="3"><strong>Loading</strong> <small>진입 직후 · Settlement shimmer skeleton</small></th></tr>
       </thead>
       <tbody>
         <tr>
@@ -919,88 +899,92 @@ body.dark-mode .viewport {
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12V7H5a2 2 0 0 1 0-4h14v4"/><path d="M3 5v14a2 2 0 0 0 2 2h16v-5"/><path d="M18 12a2 2 0 0 0 0 4h4v-4Z"/></svg>
                 </div>
               </div>
-              <div class="sp-tabbar">
-                <div class="sp-tab sp-tab--active">대시보드</div>
-                <div class="sp-tab">정산 내역</div>
-              </div>
-              <div class="sp-body" style="overflow-y:auto;">
-                <div class="sp-revenue__period" style="padding-top:16px;">
+              <div class="sp-body">
+                <div class="sp-revenue__period" style="margin:16px 16px 0;">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
                   <span class="sp-revenue__period-label">2026년 4월</span>
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
                 </div>
-                <div class="sp-revenue">
-                  <div class="sp-revenue__caption">정산 완료 매출</div>
-                  <div class="sp-revenue__total">₩1,884,400</div>
-                  <div class="sp-revenue__row"><span class="sp-revenue__row-label">정산 완료</span><span style="font-weight:700;">₩1,621,200</span></div>
-                  <div class="sp-revenue__row"><span class="sp-revenue__row-label">정산 대기</span><span style="font-weight:700;">₩516,000</span></div>
+                <div class="sp-skeleton-card">
+                  <div class="sp-skeleton sp-skeleton-line" style="width:42%;"></div>
+                  <div class="sp-skeleton sp-skeleton-total" style="width:78%;margin-top:12px;margin-bottom:16px;"></div>
+                  <div class="sp-revenue__row">
+                    <div class="sp-skeleton sp-skeleton-line" style="width:38%;"></div>
+                    <div class="sp-skeleton sp-skeleton-line" style="width:16%;"></div>
+                  </div>
+                  <div class="sp-revenue__row">
+                    <div class="sp-skeleton sp-skeleton-line" style="width:32%;"></div>
+                    <div class="sp-skeleton sp-skeleton-line" style="width:34%;"></div>
+                  </div>
+                  <div class="sp-revenue__row">
+                    <div class="sp-skeleton sp-skeleton-line" style="width:32%;"></div>
+                    <div class="sp-skeleton sp-skeleton-line" style="width:34%;"></div>
+                  </div>
                 </div>
-                <div class="sp-grid-card">
-                  <div class="sp-grid-card__title">상태별 현황</div>
-                  <div class="sp-grid">
-                    <div class="sp-grid__cell" style="background:rgba(0,0,0,0.04); color:var(--color-text-secondary);"><div class="sp-grid__cell-count">3</div><div class="sp-grid__cell-label">대기</div></div>
-                    <div class="sp-grid__cell" style="background:color-mix(in srgb, var(--color-primary) 10%, transparent); color:var(--color-primary);"><div class="sp-grid__cell-count">2</div><div class="sp-grid__cell-label">확정</div></div>
-                    <div class="sp-grid__cell" style="background:rgba(255,153,0,0.10); color:var(--color-secondary);"><div class="sp-grid__cell-count">1</div><div class="sp-grid__cell-label">지급중</div></div>
-                    <div class="sp-grid__cell" style="background:rgba(22,163,74,0.10); color:var(--color-success);"><div class="sp-grid__cell-count">5</div><div class="sp-grid__cell-label">완료</div></div>
-                    <div class="sp-grid__cell" style="background:rgba(239,68,68,0.10); color:var(--color-error);"><div class="sp-grid__cell-count">1</div><div class="sp-grid__cell-label">실패</div></div>
-                    <div class="sp-grid__cell" style="background:rgba(239,68,68,0.10); color:var(--color-error);"><div class="sp-grid__cell-count">1</div><div class="sp-grid__cell-label">보류</div></div>
-                    <div class="sp-grid__cell" style="background:rgba(0,0,0,0.04); color:var(--color-text-secondary);"><div class="sp-grid__cell-count">0</div><div class="sp-grid__cell-label">취소</div></div>
+                <div class="sp-month-section">
+                  <div class="sp-month-header">
+                    <div class="sp-skeleton sp-skeleton-line" style="width:104px;"></div>
+                  </div>
+                  <div class="sp-month-card">
+                    <div class="sp-skeleton-row">
+                      <div class="sp-skeleton sp-skeleton-circle"></div>
+                      <div class="sp-skeleton-stack">
+                        <div class="sp-skeleton sp-skeleton-line" style="width:72%;"></div>
+                        <div class="sp-skeleton sp-skeleton-line" style="width:42%;height:12px;"></div>
+                      </div>
+                      <div class="sp-skeleton sp-skeleton-line" style="width:72px;height:20px;"></div>
+                    </div>
+                    <div class="sp-skeleton-row">
+                      <div class="sp-skeleton sp-skeleton-circle"></div>
+                      <div class="sp-skeleton-stack">
+                        <div class="sp-skeleton sp-skeleton-line" style="width:64%;"></div>
+                        <div class="sp-skeleton sp-skeleton-line" style="width:36%;height:12px;"></div>
+                      </div>
+                      <div class="sp-skeleton sp-skeleton-line" style="width:72px;height:20px;"></div>
+                    </div>
+                    <div class="sp-skeleton-row">
+                      <div class="sp-skeleton sp-skeleton-circle"></div>
+                      <div class="sp-skeleton-stack">
+                        <div class="sp-skeleton sp-skeleton-line" style="width:70%;"></div>
+                        <div class="sp-skeleton sp-skeleton-line" style="width:40%;height:12px;"></div>
+                      </div>
+                      <div class="sp-skeleton sp-skeleton-line" style="width:72px;height:20px;"></div>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </td>
           <td class="state-mini__aspect">조건</td>
-          <td>활성 탭이 대시보드이며 월별 요약 데이터가 도착한 상태.</td>
+          <td>최초 데이터 조회 중이고 아직 표시 가능한 요약/리스트 데이터가 없는 상태. 선택 월은 유지하고, 요약 카드와 상세 리스트 영역을 실제 레이아웃 크기에 맞춘 <code>SettlementPageShimmer</code>로 표시.</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>
-          <td>
-            + <strong>◀ / ▶ 월 이동</strong> → 이전/다음 달로 이동하며 대시보드 데이터가 갱신됨<br>
-            + <strong>pull-to-refresh</strong> → 대시보드 새로고침<br>
-            + <strong>"정산 내역" tab tap / 우 swipe</strong> → 정산 내역 탭으로 전환<br>
-            ↔ 상태 필터 chip 없음 (정산 내역 탭 한정)
-          </td>
+          <td>↔ 월 이동은 가능하지만 로딩 중에는 중복 요청을 막음. shimmer row는 탭/hover/ripple 없음.</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">에지케이스</td>
-          <td>
-            · '정산 완료 매출'은 완료 상태 항목만 합산 (지급중/확정/보류 제외)<br>
-            · 상태 카운트가 누락된 상태는 해당 cell이 0으로 표시<br>
-            · 로딩 중: 중앙 스피너 · 오류: 안내 텍스트 + "다시 시도" 버튼
-          </td>
+          <td>· 새로고침 시 기존 항목을 그대로 둔 채 RefreshIndicator만 노출 (별도 shimmer state로 되돌리지 않음)<br>· loadMore는 전체 shimmer 전환 없이 리스트 하단에 <code>SettlementShimmerFooter</code> row 1개만 추가<br>· 데이터 조회 실패 → 오류 상태로 진입 (아래)</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">컴포넌트</td>
-          <td>
-            ↔ body → <code>_DashboardTab</code> (RefreshIndicator + SingleChildScrollView · padding spacing-medium)<br>
-            + <code>_PeriodSelector</code> (Row · IconButton chevron_left + Text titleMedium + IconButton chevron_right · centered)<br>
-            + <code>_RevenueSummaryCard</code> (Container · gradient primary→primary@scrimLight · radius-button · displayLarge w900 -1px letter)<br>
-            + <code>_StatusSummaryGrid</code> (Card · Column · titleSmall '상태별 현황' + GridView 4×2 · childAspectRatio 1.2)<br>
-            + <code>_StatusCell</code> (Container · status.textColor @ MinglitOpacity.highlight bg · radius-small · count titleMedium bold + label bodySmall)<br>
-            − chip row · ListView · SettlementCard
-          </td>
+          <td>↔ Body → <code>SettlementPageShimmer</code><br>+ 기존 <code>SettlementListShimmer</code>의 shimmer sweep 패턴을 summary caption / amount / metric rows + month header + 3 <code>SettlementTile</code>-shaped rows까지 확장<br>− <code>CircularProgressIndicator</code> initial loading</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">토큰</td>
-          <td>
-            + gradient: <code>color-partner-primary</code> 0% → <code>color-partner-primary</code> @ <code>MinglitOpacity.scrimLight</code> 100% (topLeft → bottomRight)<br>
-            + onPrimary text @ <code>scrimLight</code> opacity (caption '정산 완료 매출' · 행 라벨), full opacity (큰 금액 · 행 값)<br>
-            + grid cell bg: <code>SettlementStatus.textColor</code> @ <code>MinglitOpacity.highlight</code> (~10%) · cell text: <code>SettlementStatus.textColor</code> 그대로<br>
-            − chip / divider tokens
-          </td>
+          <td>+ skeleton base: <code>onSurface</code> @ <code>MinglitOpacity.skeletonBase</code><br>+ shimmer highlight: <code>onSurface</code> @ <code>MinglitOpacity.shimmerHighlight</code><br>+ animation: 1.2s easeInOut repeat (기존 <code>SettlementListShimmer</code> timing과 동일)</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">노트</td>
-          <td>📝 대시보드 탭은 7개 상태 모두 cell이 있고, 정산 내역 탭 chip도 동일 7개. 두 화면의 색·라벨은 단일 매핑으로 통일되어 drift 없음.</td>
+          <td>📝 spinner 대신 shimmer — 화면 골격을 먼저 보여줘 layout shift를 줄인다. 기존 <code>SettlementListShimmer</code>는 리스트만 커버하므로 동일한 sweep animation과 skeleton token을 재사용해 <code>SettlementPageShimmer</code>로 확장한다.</td>
         </tr>
       </tbody>
     </table>
 
-    <!-- State 5: Loading -->
+    <!-- State 4: Error -->
     <table class="ref state-mini">
       <thead>
-        <tr><th colspan="3"><strong>Loading</strong> <small>진입 직후 또는 새로고침 중</small></th></tr>
+        <tr><th colspan="3"><strong>Error</strong> <small>정산 정보를 받지 못함 · 재시도 CTA</small></th></tr>
       </thead>
       <tbody>
         <tr>
@@ -1013,86 +997,11 @@ body.dark-mode .viewport {
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12V7H5a2 2 0 0 1 0-4h14v4"/><path d="M3 5v14a2 2 0 0 0 2 2h16v-5"/><path d="M18 12a2 2 0 0 0 0 4h4v-4Z"/></svg>
                 </div>
               </div>
-              <div class="sp-tabbar">
-                <div class="sp-tab">대시보드</div>
-                <div class="sp-tab sp-tab--active">정산 내역</div>
-              </div>
               <div class="sp-body">
-                <div class="sp-chips">
-                  <div class="sp-chip sp-chip--active">전체</div>
-                  <div class="sp-chip">대기</div>
-                  <div class="sp-chip">확정</div>
-                  <div class="sp-chip">지급중</div>
-                  <div class="sp-chip">완료</div>
-                  <div class="sp-chip">실패</div>
-                  <div class="sp-chip">보류</div>
-                </div>
-                <div class="sp-list" style="position:relative;">
-                  <div class="sp-spinner"></div>
-                </div>
-              </div>
-            </div>
-          </td>
-          <td class="state-mini__aspect">조건</td>
-          <td>최초 데이터 조회 중이고 항목이 비어 있는 상태. 추가 페이지를 더 받아오는 경우는 리스트 하단 스피너로 표시되며 이 화면과는 다름.</td>
-        </tr>
-        <tr>
-          <td class="state-mini__aspect">사용자 액션</td>
-          <td>↔ chip 탭 가능 (탭하면 새 조회 시작), 카드 탭 영역은 없음. 탭 전환은 그대로 가능</td>
-        </tr>
-        <tr>
-          <td class="state-mini__aspect">에지케이스</td>
-          <td>· 새로고침 시 기존 항목을 그대로 둔 채 상단에 인디케이터만 노출 (별도 state로 그리지 않음)<br>· 데이터 조회 실패 → 오류 상태로 진입 (아래)</td>
-        </tr>
-        <tr>
-          <td class="state-mini__aspect">컴포넌트</td>
-          <td>↔ ListView body → <code>CircularProgressIndicator</code> 단일<br>− SettlementCard / Month header</td>
-        </tr>
-        <tr>
-          <td class="state-mini__aspect">토큰</td>
-          <td>− 카드 토큰 미사용. 스피너만 <code>color-partner-primary</code> + <code>color-divider</code> (track)</td>
-        </tr>
-        <tr>
-          <td class="state-mini__aspect">노트</td>
-          <td>📝 AppBar + TabBar + chip row는 유지. body만 spinner.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <!-- State 6: Error -->
-    <table class="ref state-mini">
-      <thead>
-        <tr><th colspan="3"><strong>Error</strong> <small>정산 목록을 받지 못함 · 재시도 CTA</small></th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td class="state-mini__mock" rowspan="6">
-            <div class="viewport">
-              <div class="sp-appbar">
-                <div class="sp-appbar__title">정산</div>
-                <div class="sp-appbar__action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg></div>
-                <div class="sp-appbar__action">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12V7H5a2 2 0 0 1 0-4h14v4"/><path d="M3 5v14a2 2 0 0 0 2 2h16v-5"/><path d="M18 12a2 2 0 0 0 0 4h4v-4Z"/></svg>
-                </div>
-              </div>
-              <div class="sp-tabbar">
-                <div class="sp-tab">대시보드</div>
-                <div class="sp-tab sp-tab--active">정산 내역</div>
-              </div>
-              <div class="sp-body">
-                <div class="sp-chips">
-                  <div class="sp-chip sp-chip--active">전체</div>
-                  <div class="sp-chip">대기</div>
-                  <div class="sp-chip">확정</div>
-                  <div class="sp-chip">지급중</div>
-                  <div class="sp-chip">완료</div>
-                  <div class="sp-chip">실패</div>
-                  <div class="sp-chip">보류</div>
-                </div>
-                <div class="sp-list" style="position:relative;">
+                <div class="sp-list sp-empty-host">
                   <div class="sp-empty">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-                    <div class="sp-empty__title">목록을 불러오지 못했습니다</div>
+                    <div class="sp-empty__title">정산 정보를 불러오지 못했습니다</div>
                     <div class="sp-empty__sub">잠시 후 다시 시도해 주세요.</div>
                     <button class="sp-empty__cta">다시 시도</button>
                   </div>
@@ -1101,19 +1010,19 @@ body.dark-mode .viewport {
             </div>
           </td>
           <td class="state-mini__aspect">조건</td>
-          <td>정산 목록 조회가 실패했고 항목 캐시가 비어 있는 상태 (Fix #127: 빈 상태 대신 명시적 오류 화면).</td>
+          <td>선택 월의 요약 또는 상세 내역 조회가 실패했고 표시 가능한 캐시가 없는 상태 (Fix #127: 빈 상태 대신 명시적 오류 화면).</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>
-          <td>+ <strong>"다시 시도" CTA</strong> → 새로고침 시도 · 성공 시 baseline / 빈 상태 / 오류 중 하나로 전환</td>
+          <td>+ <strong>"다시 시도" CTA</strong> → 선택 월의 요약과 상세 내역을 함께 새로고침 · 성공 시 baseline / 빈 상태 / 오류 중 하나로 전환</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">에지케이스</td>
-          <td>· 오류는 발생했지만 직전 항목 캐시가 남아 있는 경우 → 빈 화면 대신 직전 리스트 + 무음 오류 (이 화면에는 해당 안 됨)<br>· 권한 부족으로 인한 거부 → 동일 화면으로 표시 (메시지 분기 없음 — 후속 개선 후보)</td>
+          <td>· 오류는 발생했지만 직전 요약/항목 캐시가 남아 있는 경우 → 빈 화면 대신 직전 화면 유지 + 무음 오류 (이 화면에는 해당 안 됨)<br>· 권한 부족으로 인한 거부 → 동일 화면으로 표시 (메시지 분기 없음 — 후속 개선 후보)</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">컴포넌트</td>
-          <td>↔ body → <code>MinglitEmptyState</code>(icon:<code>Icons.error_outline</code> · title '목록을 불러오지 못했습니다' · subtitle '잠시 후 다시 시도해 주세요.' · actionLabel '다시 시도' · onAction → refresh)</td>
+          <td>↔ body → <code>MinglitEmptyState</code>(icon:<code>Icons.error_outline</code> · title '정산 정보를 불러오지 못했습니다' · subtitle '잠시 후 다시 시도해 주세요.' · actionLabel '다시 시도' · onAction → refresh summary + list)</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">토큰</td>
@@ -1126,7 +1035,7 @@ body.dark-mode .viewport {
       </tbody>
     </table>
 
-    <!-- ─── State 7: Help bottom sheet ─────────────────── -->
+    <!-- ─── State 5: Help bottom sheet ─────────────────── -->
     <table class="ref state-mini">
       <thead>
         <tr><th colspan="3"><strong>Help · 도움말 bottom sheet</strong> 🆘 <small>info 아이콘 탭 시 노출 — 파트너 앱 일관 패턴</small></th></tr>
@@ -1139,10 +1048,6 @@ body.dark-mode .viewport {
                 <div class="sp-appbar__title">정산</div>
                 <div class="sp-appbar__action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg></div>
                 <div class="sp-appbar__action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12V7H5a2 2 0 0 1 0-4h14v4"/><path d="M3 5v14a2 2 0 0 0 2 2h16v-5"/><path d="M18 12a2 2 0 0 0 0 4h4v-4Z"/></svg></div>
-              </div>
-              <div class="sp-tabbar">
-                <div class="sp-tab">대시보드</div>
-                <div class="sp-tab sp-tab--active">정산 내역</div>
               </div>
               <div style="position:absolute;inset:0;background:rgba(0,0,0,0.45);display:flex;align-items:flex-end;z-index:10;">
                 <div style="background:var(--color-background);border-radius:16px 16px 0 0;width:100%;padding-bottom:8px;">
@@ -1213,8 +1118,8 @@ body.dark-mode .viewport {
       </thead>
       <tbody>
         <tr>
-          <td>탭 전환 (대시보드 ↔ 정산 내역)</td>
-          <td>탭/스와이프 모두 가능. 두 탭은 데이터를 별도로 가져오므로 한쪽을 새로고침해도 다른 쪽은 자동 갱신되지 않음.</td>
+          <td>월 이동 (◀ / ▶)</td>
+          <td>요약 카드와 월별 정산 리스트가 같은 선택 월 기준으로 함께 갱신됨.</td>
         </tr>
         <tr>
           <td>AppBar 지갑 IconButton</td>
@@ -1231,6 +1136,28 @@ body.dark-mode .viewport {
         <tr>
           <td>금액 포맷 (모든 state 공통)</td>
           <td>정산 카드 금액은 음수일 때 마이너스 부호가 ₩ 앞에 표시됨 (예: <code>-₩42,000</code>). 천 단위 콤마는 모든 금액에 일관되게 적용.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Navigation contract</h2>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 220px;">Trigger</th>
+          <th>Route / Behavior</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>SettlementTile 전체 row tap</td>
+          <td><code>settlementCoordinator.goToDetail(item.id)</code> 호출 → <code>SettlementDetailRoute(id: item.id)</code> push → <code>/settlement/:id</code>. 전환은 <code>MinglitPageTransitions.sharedAxisScaled</code>.</td>
+        </tr>
+        <tr>
+          <td>상세 화면 back</td>
+          <td>이전 <code>SettlementPage</code>로 pop. 선택 월과 scroll position은 가능한 한 유지.</td>
         </tr>
       </tbody>
     </table>
@@ -1256,24 +1183,19 @@ body.dark-mode .viewport {
           <td>Bottom nav indexChanged · StatefulShell branch 전환은 cut transition이 default.</td>
         </tr>
         <tr>
-          <td>TabBarView 스와이프 / tap</td>
-          <td><code>MinglitAnimation.medium</code> (350ms)</td>
-          <td>Material default TabController.animateTo curve.</td>
+          <td>월 이동</td>
+          <td><code>MinglitAnimation.fast</code> (200ms)</td>
+          <td>period label과 요약 카드가 같은 월로 갱신됨. 최초 로딩은 <code>SettlementPageShimmer</code>, 기존 데이터가 있는 월 변경/새로고침은 기존 항목 유지 + progress 표시.</td>
         </tr>
         <tr>
-          <td>chip 토글</td>
-          <td><code>MinglitAnimation.micro</code> (100ms)</td>
-          <td>ChoiceChip ripple + fill swap. 직후 list refetch (별도 spinner는 없음 — items 그대로 두고 갱신).</td>
-        </tr>
-        <tr>
-          <td>카드 tap → SettlementDetail 진입</td>
+          <td>SettlementTile tap → SettlementDetail 진입</td>
           <td><code>MinglitAnimation.medium</code> (350ms)</td>
           <td><code>MinglitPageTransitions.sharedAxisScaled</code> (X-axis · scale + slide).</td>
         </tr>
         <tr>
           <td>pull-to-refresh / loadMore</td>
           <td>Material default</td>
-          <td>RefreshIndicator는 자체 progress · loadMore는 ListView footer spinner (cut 표시).</td>
+          <td>RefreshIndicator는 자체 progress · loadMore는 선택 월 리스트 하단 <code>SettlementShimmerFooter</code> row (cut 표시).</td>
         </tr>
       </tbody>
     </table>
@@ -1282,10 +1204,10 @@ body.dark-mode .viewport {
   <section class="doc">
     <h2>Global edge cases</h2>
     <ul class="notes">
-      <li><strong>정산 조회 권한만 보유</strong> — AppBar 지갑 아이콘이 보이지 않음. 리스트 / 대시보드는 정상 표시.</li>
-      <li><strong>무한 스크롤 race</strong> — 리스트 끝에 가까워지면 자동으로 다음 페이지가 로드됨. 이미 로드 중인 동안에는 중복 호출이 일어나지 않도록 보장 필요 (drift 점검 후보).</li>
-      <li><strong>탭 경계 CTA</strong> — 빈 상태의 "첫 이벤트 만들기"는 정산 탭에서 다른 탭으로 점프해야 하므로 일반 push가 아닌 표준 코디네이터를 통해 이동.</li>
-      <li><strong>대시보드 오류</strong> — 대시보드 오류 화면의 '다시 시도' 버튼은 일반 FilledButton (정산 내역 탭의 빈/오류 화면과 시각적 결이 다름) — 후속 통일 후보.</li>
+      <li><strong>정산 조회 권한만 보유</strong> — AppBar 지갑 아이콘이 보이지 않음. 월별 요약 / 리스트는 정상 표시.</li>
+      <li><strong>무한 스크롤 race</strong> — 선택 월 리스트 끝에 가까워지면 같은 월의 다음 페이지가 로드됨. 이미 로드 중인 동안에는 중복 호출이 일어나지 않도록 보장 필요 (drift 점검 후보).</li>
+      <li><strong>빈 상태 CTA 없음</strong> — 정산 화면은 월별 요약을 유지하고 상세 내역 section만 비움. 파티 생성으로 점프하지 않는다.</li>
+      <li><strong>요약/리스트 오류</strong> — 요약과 리스트를 별도 provider로 유지하더라도 화면은 하나의 오류/빈 상태 정책을 따른다.</li>
     </ul>
   </section>
 </div>
@@ -1304,15 +1226,17 @@ body.dark-mode .viewport {
     <h2>Implementation source</h2>
     <table class="ref">
       <tbody>
-        <tr><th style="width: 200px;">Widget</th><td><code>SettlementPage</code> + <code>_DashboardTab</code> / <code>_ListTab</code> — <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/features/settlement/settlement_page.dart"><code>apps/app_partner/lib/src/features/settlement/settlement_page.dart</code></a></td></tr>
+        <tr><th style="width: 200px;">Widget</th><td><code>SettlementPage</code> — <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/features/settlement/settlement_page.dart"><code>apps/app_partner/lib/src/features/settlement/settlement_page.dart</code></a></td></tr>
         <tr><th>Route</th><td><code>SettlementRoute</code> · <code>/settlement</code> · <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/routing/app_routes.dart"><code>app_routes.dart</code></a></td></tr>
         <tr><th>Theme</th><td><code>MinglitTheme.partnerTheme</code> — primary <code>MinglitPartnerColors.primary</code>(<code>#6c3ce1</code>). user app(<code>#9900ff</code>)과 다름.</td></tr>
-        <tr><th>Controllers</th><td><code>settlementDashboardControllerProvider</code> (월별 dashboard · loadDashboard · changeMonth) · <code>settlementListControllerProvider</code> (list · changeStatus · loadMore · refresh)</td></tr>
-        <tr><th>Coordinator</th><td><code>settlementCoordinatorProvider</code> — <code>goToDetail(id)</code> · <code>goToBankAccount()</code> · <code>goToPartyCreate()</code> (root GoRouter · Fix #1680)</td></tr>
+        <tr><th>Controllers</th><td><code>settlementDashboardControllerProvider</code> (월별 요약 · loadDashboard · changeMonth) · <code>settlementListControllerProvider</code> (월별 list · loadMore · refresh)</td></tr>
+        <tr><th>Coordinator</th><td><code>settlementCoordinatorProvider</code> — <code>goToDetail(id)</code> · <code>goToBankAccount()</code></td></tr>
         <tr><th>Permission gate</th><td><code>currentMemberPermissionsProvider</code> · <code>SETTLEMENT_EDIT</code> 보유 시만 AppBar 지갑 아이콘 노출 (Fix #1568)</td></tr>
-        <tr><th>Sub-widgets</th><td><code>SettlementCard</code> (list row) · <code>SettlementStatusBadge</code> + <code>SettlementStatus</code> enum (<a href="/specs/settlement_detail_page/index.html">settlement_detail_page</a>에 documented) · <code>StatusFilterChips</code> (8 ChoiceChip · MinglitChipGroup) · <code>_PeriodSelector</code> · <code>_RevenueSummaryCard</code> · <code>_StatusSummaryGrid</code> · <code>_StatusCell</code> · <code>_MonthHeaderWidget</code></td></tr>
-        <tr><th>Empty / Error</th><td><code>MinglitEmptyState</code>(fullPage variant) — <code>shared/packages/mds/core/lib/src/ui/widgets/common/minglit_empty_state.dart</code></td></tr>
-        <tr><th>⚠️ Drift / 후속 후보</th><td>· Dashboard error column은 MinglitEmptyState 미사용 (인라인 Text + FilledButton) — list와 시각적 결 통일 후보<br>· loadMore 가드 위치 점검 (race 가능성 · isLoading 체크)</td></tr>
+        <tr><th>Sub-widgets</th><td><code>_PeriodSelector</code> · <code>_RevenueSummaryCard</code> · <code>SettlementMonthGroup</code> (월별 <code>MinglitSettingsGroup</code> style container) · <code>SettlementTile</code> (정산 내역 <code>MinglitSettingsTile</code> style row) · <code>SettlementPageShimmer</code> · <code>SettlementStatusBadge</code> + <code>SettlementStatus</code> enum (<a href="/specs/settlement_detail_page/index.html">settlement_detail_page</a>에 documented)</td></tr>
+        <tr><th>Status icon / badge map</th><td>아이콘과 badge는 같은 상태색을 공유. PENDING: <code>hourglass_empty</code> + <code>surfaceContainerHighest/onSurfaceVariant</code> · READY: label <strong>지급 예정</strong>, <code>sync</code> + <code>secondaryContainer/secondary</code> · PROCESSING: label <strong>지급 중</strong>, <code>sync</code> + <code>secondaryContainer/secondary</code> · COMPLETED: <code>check_circle</code> + <code>tertiaryContainer/tertiary</code> · FAILED/HOLD: <code>error_outline</code>/<code>pause_circle</code> + <code>errorContainer/error</code> · CANCELED: <code>cancel</code> + <code>surfaceContainerLow/outline</code> + strikethrough · UNKNOWN: <code>help_outline</code> + <code>surfaceContainerHighest/onSurfaceVariant</code></td></tr>
+        <tr><th>Loading</th><td><code>SettlementPageShimmer</code> — 기존 <code>apps/app_partner/lib/src/features/settlement/widgets/settlement_shimmer.dart</code>의 shimmer sweep / skeleton token 패턴을 summary + list layout까지 확장.</td></tr>
+        <tr><th>Empty / Error</th><td>Empty는 상세 내역 section-level card (CTA 없음). Error는 <code>MinglitEmptyState</code>(fullPage variant) — <code>shared/packages/mds/core/lib/src/ui/widgets/common/minglit_empty_state.dart</code></td></tr>
+        <tr><th>⚠️ Drift / 후속 후보</th><td>· 현재 implementation이 <code>TabBar</code> / <code>StatusFilterChips</code> / 기존 <code>SettlementCard</code> 구조라면 본 spec에 맞춰 단일 스크롤 + <code>MinglitSettingsGroup</code>/<code>MinglitSettingsTile</code> 계열로 refactor 필요<br>· 현재 초기 loading은 <code>CircularProgressIndicator</code>라 본 spec의 <code>SettlementPageShimmer</code>로 교체 필요<br>· 현재 빈 상태는 <code>goToPartyCreate()</code> CTA를 노출하므로 section-level empty card로 교체 필요<br>· 현재 <code>SettlementStatus.ready.label</code>은 '정산 확정'이므로 본 spec의 '지급 예정'으로 label 변경 필요<br>· loadMore 가드 위치 점검 (race 가능성 · isLoading 체크)</td></tr>
       </tbody>
     </table>
   </section>
@@ -1324,7 +1248,7 @@ body.dark-mode .viewport {
       <tbody>
         <tr>
           <td><a href="/specs/settlement_detail_page/index.html"><code>SettlementDetailPage</code></a></td>
-          <td>본 spec의 자식 — list 탭의 SettlementCard tap으로 진입. <code>SettlementStatusBadge</code> · status enum · 색상 매핑 single source of truth.</td>
+          <td>본 spec의 자식 — 월별 리스트의 SettlementTile tap으로 진입. <code>SettlementStatusBadge</code> · status enum · 색상 매핑 single source of truth.</td>
         </tr>
         <tr>
           <td><a href="/specs/bank_account_page/index.html"><code>BankAccountPage</code></a></td>
@@ -1336,11 +1260,7 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td><a href="/specs/event_application_manage_page/index.html"><code>EventApplicationManagePage</code></a></td>
-          <td>유사 패턴 — Scaffold + AppBar + TabBar + tab별 list. 본 spec의 List tab과 비교 참고.</td>
-        </tr>
-        <tr>
-          <td><a href="/specs/party_create_wizard_page/index.html"><code>PartyCreateWizardPage</code></a></td>
-          <td>Empty state CTA "첫 이벤트 만들기"의 도착지 (cross-branch root push).</td>
+          <td>비교 참고 — 이 화면은 tabbed list 패턴을 유지하지만 SettlementPage는 단일 월별 스크롤로 분리.</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- 정산 목록 spec을 월별 단일 스크롤 + settings-list 스타일로 정리
- 정산 상세 spec의 상태 라벨/색상, 처리 이력 한글 표기, loading skeleton, CSV sheet 명세를 정리
- 실제 Dart 구현과 남은 drift를 reference에 명시

## Issue lifecycle
No linked issue: conversational MDS settlement spec cleanup requested directly during design review.

## Verification
- curl -I http://127.0.0.1:3013/specs/settlement_page/index.html
- curl -I http://127.0.0.1:3013/specs/settlement_detail_page/index.html
- git diff --check