### PR TITLE
fix(mds): sync avatar specs

### DIFF
--- a/apps/mds/docs/public/specs/blocked_partners_page/index.html
+++ b/apps/mds/docs/public/specs/blocked_partners_page/index.html
@@ -247,6 +247,12 @@
     </thead>
     <tbody>
       <tr>
+        <td>2026-06-01</td>
+        <td>1.1</td>
+        <td>codex</td>
+        <td><strong>Issue #2399 avatar drift sync</strong> — ListTile leading spec을 Material <code>CircleAvatar</code> 표현에서 live code의 <code>MinglitAvatarImage(radius: 20, url, fallbackIcon: Icons.store)</code> 기준으로 갱신. Fix #1936의 이미지 캐싱 + 에러 fallback 일원화를 spec에도 반영.</td>
+      </tr>
+      <tr>
         <td>2026-05-01</td>
         <td>1.0</td>
         <td>mark-yun</td>
@@ -310,7 +316,7 @@
    ├─ <b>Center</b> + <b>Text</b>('차단된 파트너가 없습니다')   <i>(차단된 파트너 0건)</i>
    └─ <b>ListView.builder</b>(파트너 리스트)                   <i>(차단된 파트너 1건 이상)</i>
       └─ <b>ListTile</b>                                       ← ③
-         ├─ <b>leading: CircleAvatar</b>(image | Icon(store))
+         ├─ <b>leading: MinglitAvatarImage</b>(radius: 20, url, fallbackIcon: Icons.store)
          ├─ <b>title: Text</b>(name)
          └─ <b>trailing: TextButton</b>('차단 해제') → <code>_unblock(id)</code></div>
     </div>
@@ -341,7 +347,7 @@
       <div class="blueprint" style="height: 96px;">
         <div class="blueprint__region blueprint__region--full"></div>
         <div class="blueprint__region blueprint__region--shaded" style="top:12px; left:16px; width:40px; height:40px;">
-          <span class="blueprint__region-label">㉠ leading · CircleAvatar 40px</span>
+          <span class="blueprint__region-label">㉠ leading · MinglitAvatarImage 40px</span>
         </div>
         <div class="blueprint__region blueprint__region--shaded" style="top:24px; left:72px; right:120px; height:24px;">
           <span class="blueprint__region-label">㉡ title · bodyLarge</span>
@@ -353,9 +359,9 @@
 
       <div class="layout-tree"><b>ListTile</b>
 ├─ <em>leading</em>                          ← ㉠
-│  └─ <b>CircleAvatar</b>(40px)
-│     ├─ <b>backgroundImage</b>: NetworkImage(profile_image_url)  <i>(존재 시)</i>
-│     └─ child: <b>Icon</b>(<code>Icons.store</code>)              <i>(이미지 없을 때)</i>
+│  └─ <b>MinglitAvatarImage</b>(radius: 20)
+│     ├─ <b>url</b>: profile_image_url                            <i>(존재 시)</i>
+│     └─ <b>fallbackIcon</b>: <code>Icons.store</code>             <i>(이미지 없거나 로드 실패 시)</i>
 │
 ├─ <em>title</em>                            ← ㉡
 │  └─ <b>Text</b>(name) — <code>bodyLarge</code> · ellipsis
@@ -370,7 +376,7 @@
         <tr><th style="width:60px;">#</th><th style="width:180px;">Region</th><th style="width:220px;">Alignment</th><th>Spacing / tokens</th></tr>
       </thead>
       <tbody>
-        <tr><td>㉠</td><td>leading · CircleAvatar</td><td>vertical center · left 16</td><td>40 × 40 · radius: 50%</td></tr>
+        <tr><td>㉠</td><td>leading · MinglitAvatarImage</td><td>vertical center · left 16</td><td>40 × 40 · radius 20</td></tr>
         <tr><td>㉡</td><td>title</td><td>vertical center · gap: 16 (Material default)</td><td><code>bodyLarge</code> · ellipsis · color-text-primary</td></tr>
         <tr><td>㉢</td><td>trailing · TextButton</td><td>vertical center · right 16 · padding 자체 8/12</td><td>"차단 해제" · color-primary · weight 600</td></tr>
       </tbody>
@@ -469,7 +475,7 @@
           <td>
             · <code>AppBar</code>(plain Material · title: "차단 목록") — ⓐ<br>
             · <code>ListView.builder</code> · <code>ListTile</code> × N — ⓑⓒⓓ<br>
-            · leading: <code>CircleAvatar</code>(<code>NetworkImage</code> | <code>Icon(Icons.store)</code>) — ⓑ<br>
+            · leading: <code>MinglitAvatarImage</code>(<code>url</code> | <code>fallbackIcon: Icons.store</code>) — ⓑ<br>
             · title: <code>Text</code>(<code>bodyLarge</code> · ellipsis) — ⓒ<br>
             · trailing: <code>TextButton</code>("차단 해제") — ⓓ
           </td>
@@ -478,7 +484,7 @@
           <td class="state-mini__aspect">토큰</td>
           <td>
             · color: <code>color-surface</code> (Scaffold + AppBar bg), <code>color-text-primary</code> (title · AppBar title), <code>color-divider</code> (avatar fallback bg), <code>color-primary</code> (TextButton fg "차단 해제"), <code>color-text-secondary</code> (avatar fallback icon)<br>
-            · radius: avatar 50% (CircleAvatar)<br>
+            · radius: avatar 20 (<code>MinglitAvatarImage.radius</code>)<br>
             · spacing: ListTile 기본 (좌우 16 · 상하 자동 64), AppBar 56<br>
             · typography: <code>bodyLarge</code> (16/400/1.45 · title), AppBar title 18/700
           </td>
@@ -775,6 +781,10 @@
         <tr>
           <th>File path</th>
           <td><a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_user/lib/src/features/settings/blocked_partners_page.dart"><code>apps/app_user/lib/src/features/settings/blocked_partners_page.dart</code></a></td>
+        </tr>
+        <tr>
+          <th>Avatar widget</th>
+          <td><code>MinglitAvatarImage</code> (kit-shared) · <code>radius: 20</code> · <code>url: profile_image_url</code> · <code>fallbackIcon: Icons.store</code></td>
         </tr>
         <tr>
           <th>Repository</th>

--- a/apps/mds/docs/public/specs/event_detail_page/index.html
+++ b/apps/mds/docs/public/specs/event_detail_page/index.html
@@ -515,6 +515,14 @@
     </thead>
     <tbody>
       <tr>
+        <td>2026-06-01</td>
+        <td>2.1</td>
+        <td>codex</td>
+        <td>
+          <strong>Issue #2399 avatar drift sync</strong> — §1 partner row avatar를 live code의 <code>MinglitAvatarImage(radius: MinglitRadius.input, url, fallbackIcon: Icons.store)</code> 기준으로 갱신. 기존 <code>CircleAvatar</code> 표현은 Fix #1936 이후 stale.
+        </td>
+      </tr>
+      <tr>
         <td>2026-05-01</td>
         <td>2.0</td>
         <td>mark-yun</td>
@@ -635,7 +643,7 @@
    │           │     │     └─ tabs: 기본 정보 / 상세 소개 / 참가 현황 / 필요 인증 / 환불 정책
    │           │     │
    │           │     ├─ <b>SliverToBoxAdapter</b>: §1 기본 정보     ← ③
-   │           │     │  ├─ partner row (CircleAvatar + name + chevron)
+   │           │     │  ├─ partner row (MinglitAvatarImage + name + chevron)
    │           │     │  ├─ title Text(headlineSmall bold)
    │           │     │  ├─ <b>_InfoTile</b> — 날짜·시간·진행 시간
    │           │     │  ├─ <b>_InfoTile</b> — 장소 이름·주소
@@ -725,7 +733,7 @@
       ├─ <em>Partner row</em> (if partner != null)              ← ㉠
       │  └─ <b>GestureDetector</b>(opaque · onTap: pushPartnerDetail)
       │     └─ Row
-      │        ├─ <b>CircleAvatar</b>(radius: <i>radius-input = 12</i>) — 24×24
+      │        ├─ <b>MinglitAvatarImage</b>(radius: <i>MinglitRadius.input = 12</i>, fallbackIcon: Icons.store) — 24×24
       │        ├─ Gap: <i>spacing-small (8)</i>
       │        ├─ Flexible Text(<i>titleSmall · onSurfaceVariant</i>)
       │        ├─ Gap: <i>spacing-xsmall (4)</i>
@@ -2036,6 +2044,7 @@
         <tr><td><strong>Widget class</strong></td><td><code>EventDetailPage</code> + <code>_EventDetailContent</code> + <code>_BottomTicketBar</code> (모두 같은 파일에 part of)</td></tr>
         <tr><td><strong>File path</strong></td><td><a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_user/lib/src/features/event/detail/event_detail_page.dart"><code>apps/app_user/lib/src/features/event/detail/event_detail_page.dart</code></a></td></tr>
         <tr><td><strong>Part files</strong></td><td><code>event_detail_content.dart</code> · <code>event_bottom_ticket_bar.dart</code> · <code>event_entry_conditions_section.dart</code> · <code>event_verification_section.dart</code> · <code>event_refund_policy_section.dart</code> · <code>event_quill_viewer.dart</code> · <code>event_info_tile.dart</code> · <code>event_detail_content_skeleton.dart</code></td></tr>
+        <tr><td><strong>Partner avatar widget</strong></td><td><code>MinglitAvatarImage</code> (kit-shared) in <code>event_detail_content.dart</code> · <code>radius: MinglitRadius.input</code> · <code>url: partnerProfileImageUrl</code> · <code>fallbackIcon: Icons.store</code> · <code>fallbackIconSize: MinglitIconSize.xsmall</code></td></tr>
         <tr><td><strong>Controller / Provider</strong></td><td><code>eventDetailControllerProvider(eventId)</code> · <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_user/lib/src/features/event/logic/event_detail_controller.dart"><code>event_detail_controller.dart</code></a></td></tr>
         <tr><td><strong>Coordinator</strong></td><td><code>eventCoordinatorProvider</code> · <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_user/lib/src/features/event/logic/event_coordinator.dart"><code>event_coordinator.dart</code></a> — pushPartnerDetail · pushLogin · 등</td></tr>
         <tr><td><strong>Admission state</strong></td><td><code>eventAdmissionControllerProvider(event)</code> — see <a href="/specs/event_bottom_ticket_bar/index.html">EventBottomTicketBar spec</a></td></tr>

--- a/apps/mds/docs/public/specs/home_page/index.html
+++ b/apps/mds/docs/public/specs/home_page/index.html
@@ -696,6 +696,14 @@ body.dark-mode .visual-gallery .chip-bar__divider {
     </thead>
     <tbody>
       <tr>
+        <td>2026-06-01</td>
+        <td>1.1</td>
+        <td>codex</td>
+        <td>
+          <strong>Issue #2399 avatar drift sync</strong> — authenticated AppBar profile action을 live code의 <code>IconButton(icon: MinglitAvatarImage(radius: 14, url, fallbackIconSize: 14))</code> 기준으로 갱신. 기존 <code>CircleAvatar</code> 표현은 Fix #1936 이후 stale.
+        </td>
+      </tr>
+      <tr>
         <td>2026-05-01</td>
         <td>1.0</td>
         <td>mark-yun</td>
@@ -774,7 +782,7 @@ body.dark-mode .visual-gallery .chip-bar__divider {
       │  ├─ actions: <b>BugReportAction</b> (dev)
       │  │           <b>IconButton</b> search (tooltip "검색")
       │  │           <b>IconButton</b> notifications (tooltip "알림")  <i>(authenticated)</i>
-      │  │           <b>CircleAvatar</b> 28px profile (wrap IconButton tooltip "마이페이지")  <i>(authenticated)</i>
+      │  │           <b>IconButton</b>(icon: MinglitAvatarImage radius 14, tooltip "마이페이지")  <i>(authenticated)</i>
       │  │           <b>IconButton</b> person_outline (tooltip "마이페이지")  <i>(unauthenticated)</i>
       │  └─ backgroundColor: surface
       │
@@ -872,8 +880,8 @@ body.dark-mode .visual-gallery .chip-bar__divider {
    │  ├─ [dev] <b>BugReportAction</b> (visibleForTesting)
    │  ├─ <b>IconButton</b>(Icons.search, 22, tooltip "검색") — 40×40 hit zone
    │  ├─ <b>IconButton</b>(Icons.notifications_outlined, 22, tooltip "알림") <i>— authenticated only</i>
-   │  └─ <b>CircleAvatar</b>(28, wrap tooltip "마이페이지") <i>or</i> <b>IconButton</b>(person_outline, 22, tooltip "마이페이지")
-   │     <i>— authenticated → 프로필 사진 / unauthenticated → 사람 아이콘</i>
+   │  └─ <b>IconButton</b>(icon: MinglitAvatarImage radius 14, tooltip "마이페이지") <i>or</i> <b>IconButton</b>(person_outline, 22, tooltip "마이페이지")
+   │     <i>— authenticated → 프로필 사진 또는 fallback icon / unauthenticated → 사람 아이콘</i>
    │
    └─ Padding(right: <i>spacing-small = 8px</i>)
 
@@ -894,7 +902,7 @@ body.dark-mode .visual-gallery .chip-bar__divider {
         <tr><td>—</td><td>AppBar 외부</td><td>height 56 · 풀폭</td><td>left: <code>spacing-screen-edge (16px)</code> · right: <code>spacing-small (8px)</code> · bottom: <code>1px color-divider</code></td></tr>
         <tr><td>㉠</td><td>Logo</td><td>좌측 정렬 · 자연 너비 (flex 0)</td><td>height: 36px · width: auto · 좌측 가장자리에서 16px</td></tr>
         <tr><td>—</td><td>Spacer</td><td>flex grow (남는 공간 흡수)</td><td>로고 우측 끝 ↔ 액션 좌측 끝 사이 가변 폭</td></tr>
-        <tr><td>㉡</td><td>Actions</td><td>우측 끝 정렬 · margin-left: auto로 push</td><td>icon 사이 gap: 0 (각 IconButton의 40×40 hit zone에 자체 padding) · icon 시각 사이즈: 22 · avatar: 28</td></tr>
+        <tr><td>㉡</td><td>Actions</td><td>우측 끝 정렬 · margin-left: auto로 push</td><td>icon 사이 gap: 0 (각 IconButton의 40×40 hit zone에 자체 padding) · icon 시각 사이즈: 22 · avatar: MinglitAvatarImage radius 14 (28×28)</td></tr>
       </tbody>
     </table>
   </section>
@@ -1732,6 +1740,7 @@ active 상태: bg=primary 0.08 · border=primary · color=primary · w600</div>
     <table class="ref">
       <tbody>
         <tr><th style="width: 200px;">Widget</th><td><code>HomePage</code> — <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_user/lib/src/features/home/home_page.dart"><code>apps/app_user/lib/src/features/home/home_page.dart</code></a></td></tr>
+        <tr><th>AppBar avatar widget</th><td><code>MinglitAvatarImage</code> (kit-shared) inside <code>IconButton</code> · <code>radius: 14</code> · <code>url: user.userMetadata['avatar_url']</code> · <code>fallbackIconSize: 14</code></td></tr>
         <tr><th>Route</th><td><code>HomeRoute</code> · <code>/</code> · <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_user/lib/src/routing/app_routes.dart"><code>app_routes.dart</code></a></td></tr>
         <tr><th>Feed provider</th><td><code>recommendationFeedProvider</code> — pgvector 기반 개인화 (loading / data / error AsyncValue 분기 — 5 page state로 노출)</td></tr>
         <tr><th>Auth gate</th><td><code>currentUserProvider</code> — null 시 guest state 노출</td></tr>

--- a/apps/mds/docs/public/specs/my_page/index.html
+++ b/apps/mds/docs/public/specs/my_page/index.html
@@ -283,6 +283,14 @@ body.dark-mode .my-group__card { background: var(--color-dark-surface); }
     </thead>
     <tbody>
       <tr>
+        <td>2026-06-01</td>
+        <td>1.2</td>
+        <td>codex</td>
+        <td>
+          <strong>Issue #2399 avatar drift sync</strong> — Profile tile avatar를 live code의 <code>MinglitAvatarImage(radius: 24, url, backgroundColor, fallbackIconColor)</code> 기준으로 갱신. 기존 <code>CircleAvatar</code> 표현은 Fix #1936 이후 stale.
+        </td>
+      </tr>
+      <tr>
         <td>2026-05-03</td>
         <td>1.1</td>
         <td>mark-yun</td>
@@ -438,7 +446,7 @@ body.dark-mode .my-group__card { background: var(--color-dark-surface); }
                 <div class="my-group">
                   <div class="my-group__card">
                     <div class="profile-tile">
-                    <!-- CircleAvatar(radius: 24) · primaryContainer bg · Icons.person fallback -->
+                    <!-- MinglitAvatarImage(radius: 24) · primaryContainer bg · primary fallback icon color -->
                     <div class="profile-tile__avatar">
                       <svg viewBox="0 0 24 24" fill="currentColor" width="22" height="22"><path d="M12 12c2.2 0 4-1.8 4-4s-1.8-4-4-4-4 1.8-4 4 1.8 4 4 4zm0 2c-2.7 0-8 1.3-8 4v2h16v-2c0-2.7-5.3-4-8-4z"/></svg>
                     </div>
@@ -513,7 +521,7 @@ body.dark-mode .my-group__card { background: var(--color-dark-surface); }
           <td>
             · <code>MinglitTheme.simpleAppBar(title: '마이페이지', showBackButton: false)</code><br>
             · <code>ListView</code> + <code>EdgeInsets.symmetric(vertical: MinglitSpacing.medium)</code><br>
-            · <code>_ProfileTile</code> (private widget · CircleAvatar radius 24 + Icons.person fallback · displayName · email · Icons.chevron_right · 탭 시 <a href="/specs/account_management_page/index.html">계정 관리</a> 화면으로 push)<br>
+            · <code>_ProfileTile</code> (private widget · <code>MinglitAvatarImage</code> radius 24 + avatarUrl + primaryContainer fallback · displayName · email · Icons.chevron_right · 탭 시 <a href="/specs/account_management_page/index.html">계정 관리</a> 화면으로 push)<br>
             · <a href="/components#MinglitSettingsGroup"><code>MinglitSettingsGroup</code></a> × 6 (1 ProfileGroup + 5 SettingsGroup · header + tile list · 그룹 카드)<br>
             · <a href="/components#MinglitSettingsTile"><code>MinglitSettingsTile</code></a> (leading icon + title + optional subtitle + chevron · destructive variant · trailing 옵션)<br>
             · <code>ThemeSettingsTile</code> (별도 widget · 테마 설정 tile — 시스템/dark/light 분기)<br>
@@ -524,7 +532,7 @@ body.dark-mode .my-group__card { background: var(--color-dark-surface); }
         <tr>
           <td class="state-mini__aspect">토큰</td>
           <td>
-            · color: <code>color-surface</code> (scaffold bg), <code>color-background</code> (그룹 카드 surface), <code>color-text-primary</code> (tile title · profile name), <code>color-text-secondary</code> (subtitle · email · 그룹 헤더 · chevron · leading icon), <code>color-divider</code> (tile 사이 full-width hairline), <code>color-primary</code> (avatar bg)<br>
+            · color: <code>color-surface</code> (scaffold bg), <code>color-background</code> (그룹 카드 surface), <code>color-text-primary</code> (tile title · profile name), <code>color-text-secondary</code> (subtitle · email · 그룹 헤더 · chevron · leading icon), <code>color-divider</code> (tile 사이 full-width hairline), <code>color-primaryContainer</code> (avatar fallback bg), <code>color-primary</code> (avatar fallback icon)<br>
             · spacing: <code>spacing-medium</code> (16 · body v-padding · 그룹 h-padding · tile h-padding · icon ↔ title gap), <code>spacing-large</code> (24 · 그룹 사이 gap), <code>spacing-small</code> (8 · 헤더 v-padding · subtitle tile padding), <code>spacing-xsmall</code> (헤더 h-padding)<br>
             · radius: <code>radius-card</code> (그룹 카드 corner)<br>
             · typography: appBarTitle (18/600), 그룹 헤더(13 · 500 · uppercase · letter-spacing 0.5), tile title (14), tile subtitle (12), profile name (16/700), profile email (12)
@@ -678,6 +686,7 @@ body.dark-mode .my-group__card { background: var(--color-dark-surface); }
     <table class="ref">
       <tbody>
         <tr><th style="width: 200px;">Widget</th><td><code>MyPage</code> — <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_user/lib/src/features/home/my_page.dart"><code>apps/app_user/lib/src/features/home/my_page.dart</code></a></td></tr>
+        <tr><th>Profile avatar widget</th><td><code>MinglitAvatarImage</code> (kit-shared) · <code>radius: 24</code> · <code>url: avatarUrl</code> · <code>backgroundColor: colorScheme.primaryContainer</code> · <code>fallbackIconColor: colorScheme.primary</code></td></tr>
         <tr><th>Route</th><td><code>MyPageRoute</code> · <code>/my</code> · <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_user/lib/src/routing/app_routes.dart"><code>app_routes.dart</code></a></td></tr>
         <tr><th>Auth gate</th><td><code>currentUserProvider</code> — null 시 auth guard prompt 노출. HomePage 측에서도 인증 사용자만 아바타 표시 → 일반 진입은 항상 default state.</td></tr>
         <tr><th>SettingsGroup atom</th><td><a href="/components#MinglitSettingsGroup"><code>MinglitSettingsGroup</code></a> (kit-shared · components 등록됨) — uppercase header(13 · 500 · letter-spacing 0.5) outside + 둥근 카드(<code>color-background</code> bg · <code>radius-card</code>) · 카드는 <code>spacing-medium</code> 좌우 padding 안에 위치 (NOT edge-to-edge)</td></tr>


### PR DESCRIPTION
## Summary
- update blocked partner, my page, home page, and event detail specs from stale CircleAvatar wording to MinglitAvatarImage
- add history/reference rows that point to the live avatar widget usage
- keep implementation unchanged because the code already uses the shared avatar component

## Tests
- npm run lint
- npm run build
- git diff --check

Closes #2399.