### PR TITLE
fix(app): align event participant group counts

### DIFF
--- a/apps/app_user/integration_test/cuj/event-operation/participation_status_redesign_test.dart
+++ b/apps/app_user/integration_test/cuj/event-operation/participation_status_redesign_test.dart
@@ -26,6 +26,7 @@ Event _makeEvent({
   int currentParticipants = 4,
   int maxParticipants = 20,
   List<EntryGroup>? entryGroups,
+  List<Ticket>? tickets,
 }) {
   final now = DateTime(2026, 6, 1, 10);
   return Event(
@@ -47,15 +48,17 @@ Event _makeEvent({
       updatedAt: now,
       partner: const Partner(id: 'test-partner', name: '테스트 파트너'),
     ),
-    tickets: [
-      Ticket(
-        id: 'test-ticket',
-        name: '일반 입장권',
-        price: 15000,
-        createdAt: now,
-        updatedAt: now,
-      ),
-    ],
+    tickets:
+        tickets ??
+        [
+          Ticket(
+            id: 'test-ticket',
+            name: '일반 입장권',
+            price: 15000,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        ],
   );
 }
 
@@ -71,25 +74,31 @@ List<EntryGroup> _makeEntryGroups(int count) {
   );
 }
 
+Ticket _makeTicketForGroup(
+  String groupId, {
+  required int soldCount,
+  required int quantity,
+}) {
+  final now = DateTime(2026, 6, 1, 10);
+  return Ticket(
+    id: 'ticket-$groupId',
+    name: '그룹 입장권',
+    price: 15000,
+    quantity: quantity,
+    soldCount: soldCount,
+    targetEntryGroupIds: [groupId],
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
 List<dynamic> _overrides(Event event) {
   return [
     eventDetailControllerProvider(
       _kEventId,
     ).overrideWith(() => _DataController(event)),
-    eventAdmissionControllerProvider(
-      event,
-    ).overrideWith(_GuestController.new),
-    policyRepositoryProvider.overrideWith(
-      (_) => const _FakePolicy(),
-    ),
-    entryGroupParticipantCountsProvider(
-      _kEventId,
-    ).overrideWith(
-      (_) async => {
-        for (var i = 0; i < (event.entryGroups?.length ?? 0); i++)
-          'group-$i': i + 1,
-      },
-    ),
+    eventAdmissionControllerProvider(event).overrideWith(_GuestController.new),
+    policyRepositoryProvider.overrideWith((_) => const _FakePolicy()),
     eventDetailNowProvider.overrideWith(
       (_) =>
           () => DateTime(2026, 6, 1, 10),
@@ -153,7 +162,7 @@ void main() {
     cujCase(
       'happy: 이벤트 상세 → 참가 현황 섹션에 전체 참여 정보 표시',
       app: const EventDetailPage(eventId: _kEventId),
-      overrides: () => _overrides(_makeEvent(currentParticipants: 4)),
+      overrides: () => _overrides(_makeEvent()),
       body: (t) async {
         await _scrollToSection(t);
         // 참여 현황 섹션 타이틀이 렌더링됨
@@ -164,8 +173,7 @@ void main() {
     cujCase(
       'edge: 참여자 0명 이벤트 — 섹션 렌더링, 0/N 표시',
       app: const EventDetailPage(eventId: _kEventId),
-      overrides: () =>
-          _overrides(_makeEvent(currentParticipants: 0, maxParticipants: 20)),
+      overrides: () => _overrides(_makeEvent(currentParticipants: 0)),
       body: (t) async {
         await _scrollToSection(t);
         // 0명인 경우에도 참여 현황 섹션 표시됨
@@ -180,9 +188,7 @@ void main() {
     cujCase(
       'happy: 2그룹 이벤트 — 그룹 카드 2개 렌더링',
       app: const EventDetailPage(eventId: _kEventId),
-      overrides: () => _overrides(
-        _makeEvent(entryGroups: _makeEntryGroups(2)),
-      ),
+      overrides: () => _overrides(_makeEvent(entryGroups: _makeEntryGroups(2))),
       body: (t) async {
         await _scrollToSection(t);
         // 2개 그룹이 있으므로 그룹 라벨(남성/여성) 노출
@@ -193,9 +199,7 @@ void main() {
     cujCase(
       'happy: 3그룹 이상 이벤트 — 그룹 카드 3개 이상 렌더링',
       app: const EventDetailPage(eventId: _kEventId),
-      overrides: () => _overrides(
-        _makeEvent(entryGroups: _makeEntryGroups(3)),
-      ),
+      overrides: () => _overrides(_makeEvent(entryGroups: _makeEntryGroups(3))),
       body: (t) async {
         await _scrollToSection(t);
         // 3개 이상 그룹 — 참여 현황 섹션 존재
@@ -206,9 +210,7 @@ void main() {
     cujCase(
       'edge: 4개 그룹 이벤트 — 페이지 크래시 없이 렌더링',
       app: const EventDetailPage(eventId: _kEventId),
-      overrides: () => _overrides(
-        _makeEvent(entryGroups: _makeEntryGroups(4)),
-      ),
+      overrides: () => _overrides(_makeEvent(entryGroups: _makeEntryGroups(4))),
       body: (t) async {
         await _scrollToSection(t);
         expect(find.text('참여 현황'), findsAtLeast(1));
@@ -221,12 +223,16 @@ void main() {
       'happy: 그룹 카드에 참여 인원 표시',
       app: const EventDetailPage(eventId: _kEventId),
       overrides: () => _overrides(
-        _makeEvent(entryGroups: _makeEntryGroups(1)),
+        _makeEvent(
+          entryGroups: _makeEntryGroups(1),
+          tickets: [_makeTicketForGroup('group-0', soldCount: 8, quantity: 20)],
+        ),
       ),
       body: (t) async {
         await _scrollToSection(t);
-        // 그룹 카드 내 "N명 참여" 텍스트
-        expect(find.textContaining('명 참여'), findsAtLeast(1));
+        // 그룹 카드는 보조 "N명 참여" 캡션 없이 게이지의 current/max만 노출한다.
+        expect(find.text('8/20'), findsAtLeast(1));
+        expect(find.textContaining('명 참여'), findsNothing);
       },
     );
 
@@ -238,37 +244,19 @@ void main() {
           currentParticipants: 10,
           maxParticipants: 10,
           entryGroups: [
-            const EntryGroup(
-              id: 'group-0',
-              eventId: _kEventId,
-              label: '전체',
-            ),
+            const EntryGroup(id: 'group-0', eventId: _kEventId, label: '전체'),
+          ],
+          tickets: [
+            _makeTicketForGroup('group-0', soldCount: 10, quantity: 10),
           ],
         );
-        return [
-          eventDetailControllerProvider(
-            _kEventId,
-          ).overrideWith(() => _DataController(event)),
-          eventAdmissionControllerProvider(
-            event,
-          ).overrideWith(_GuestController.new),
-          policyRepositoryProvider.overrideWith((_) => const _FakePolicy()),
-          // 10명 참여 중
-          entryGroupParticipantCountsProvider(
-            _kEventId,
-          ).overrideWith((_) async => {'group-0': 10}),
-          eventDetailNowProvider.overrideWith(
-            (_) =>
-                () => DateTime(2026, 6, 1, 10),
-          ),
-          currentUserProvider.overrideWith((_) => null),
-          authStateChangesProvider.overrideWith((_) => const Stream.empty()),
-        ];
+        return _overrides(event);
       },
       body: (t) async {
         await _scrollToSection(t);
-        // 10명 참여 중 표시
-        expect(find.textContaining('명 참여'), findsAtLeast(1));
+        // 100% 마감도 단일 current/max 게이지로 표시한다.
+        expect(find.text('10/10'), findsAtLeast(1));
+        expect(find.textContaining('명 참여'), findsNothing);
       },
     );
   });
@@ -277,9 +265,7 @@ void main() {
     cujCase(
       'happy: 참여자 정보 섹션 렌더링 — blur 리스트 토글 (미구현 시 기본 섹션 확인)',
       app: const EventDetailPage(eventId: _kEventId),
-      overrides: () => _overrides(
-        _makeEvent(entryGroups: _makeEntryGroups(2)),
-      ),
+      overrides: () => _overrides(_makeEvent(entryGroups: _makeEntryGroups(2))),
       body: (t) async {
         await _scrollToSection(t);
         // 참여 현황 섹션이 렌더링됨 (blur 리스트 토글은 spec V2 구현 예정)
@@ -292,9 +278,7 @@ void main() {
     cujCase(
       'happy: 참여자 정보 렌더링 — 나이대/뱃지 표시 (spec V2 구현 예정)',
       app: const EventDetailPage(eventId: _kEventId),
-      overrides: () => _overrides(
-        _makeEvent(entryGroups: _makeEntryGroups(2)),
-      ),
+      overrides: () => _overrides(_makeEvent(entryGroups: _makeEntryGroups(2))),
       body: (t) async {
         await _scrollToSection(t);
         // 참여 현황 섹션 렌더링 확인
@@ -319,30 +303,15 @@ void main() {
               gender: 'male',
             ),
           ],
+          tickets: [_makeTicketForGroup('group-0', soldCount: 2, quantity: 10)],
         );
-        return [
-          eventDetailControllerProvider(
-            _kEventId,
-          ).overrideWith(() => _DataController(event)),
-          eventAdmissionControllerProvider(
-            event,
-          ).overrideWith(_GuestController.new),
-          policyRepositoryProvider.overrideWith((_) => const _FakePolicy()),
-          entryGroupParticipantCountsProvider(
-            _kEventId,
-          ).overrideWith((_) async => {'group-0': 2}),
-          eventDetailNowProvider.overrideWith(
-            (_) =>
-                () => DateTime(2026, 6, 1, 10),
-          ),
-          currentUserProvider.overrideWith((_) => null),
-          authStateChangesProvider.overrideWith((_) => const Stream.empty()),
-        ];
+        return _overrides(event);
       },
       body: (t) async {
         await _scrollToSection(t);
-        // 2명 참여 표시 — k-anonymity 비표시 처리는 spec V2 구현 예정
-        expect(find.textContaining('명 참여'), findsAtLeast(1));
+        // k-anonymity 비표시 처리는 spec V2 구현 예정. 현재 카운트는 게이지로만 노출한다.
+        expect(find.text('2/10'), findsAtLeast(1));
+        expect(find.textContaining('명 참여'), findsNothing);
       },
     );
   });
@@ -355,9 +324,7 @@ void main() {
     cujCase(
       'happy: 80% 이상 참여 — 현재 참여 현황 표시 (urgency 뱃지는 V2)',
       app: const EventDetailPage(eventId: _kEventId),
-      overrides: () => _overrides(
-        _makeEvent(currentParticipants: 17, maxParticipants: 20),
-      ),
+      overrides: () => _overrides(_makeEvent(currentParticipants: 17)),
       body: (t) async {
         await _scrollToSection(t);
         // 참여 현황 섹션 렌더링
@@ -376,9 +343,7 @@ void main() {
     cujCase(
       'happy: 비로그인 상태 — 참여 현황 섹션 표시',
       app: const EventDetailPage(eventId: _kEventId),
-      overrides: () => _overrides(
-        _makeEvent(currentParticipants: 4, maxParticipants: 20),
-      ),
+      overrides: () => _overrides(_makeEvent()),
       body: (t) async {
         await _scrollToSection(t);
         // 비로그인 상태에서도 참여 현황 섹션 렌더링
@@ -395,8 +360,6 @@ void main() {
       app: const EventDetailPage(eventId: _kEventId),
       overrides: () => _overrides(
         _makeEvent(
-          currentParticipants: 4,
-          maxParticipants: 20,
           entryGroups: _makeEntryGroups(2),
         ),
       ),
@@ -416,9 +379,7 @@ void main() {
     cujCase(
       'happy: 명단 비공개 이벤트 — 참여 현황 카운트 렌더링',
       app: const EventDetailPage(eventId: _kEventId),
-      overrides: () => _overrides(
-        _makeEvent(currentParticipants: 8, maxParticipants: 20),
-      ),
+      overrides: () => _overrides(_makeEvent(currentParticipants: 8)),
       body: (t) async {
         await _scrollToSection(t);
         // 참여 현황 섹션 렌더링 확인 — 명단 비공개 blur 토글 숨김은 V2 구현 예정
@@ -433,8 +394,6 @@ void main() {
       app: const EventDetailPage(eventId: _kEventId),
       overrides: () => _overrides(
         _makeEvent(
-          currentParticipants: 4,
-          maxParticipants: 20,
           entryGroups: [],
         ),
       ),

--- a/apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart
@@ -1,18 +1,14 @@
 part of 'event_detail_page.dart';
 
-class _EntryConditionsSection extends ConsumerWidget {
+class _EntryConditionsSection extends StatelessWidget {
   const _EntryConditionsSection({required this.event});
 
   final Event event;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final entryGroups = event.entryGroups ?? [];
-    final countsAsync = ref.watch(
-      entryGroupParticipantCountsProvider(event.id),
-    );
-    final counts = countsAsync.value ?? {};
 
     // Fix #172: 다른 섹션(Section 4, 5)과 동일하게 좌우 패딩 추가
     return MinglitSection(
@@ -50,7 +46,6 @@ class _EntryConditionsSection extends ConsumerWidget {
                   (sum, t) => sum + t.quantity,
                 );
                 final showGauge = matchingTickets.isNotEmpty;
-                final participantCount = counts[group.id] ?? 0;
 
                 return Stack(
                   children: [
@@ -65,21 +60,9 @@ class _EntryConditionsSection extends ConsumerWidget {
                           color: theme.colorScheme.outlineVariant,
                         ),
                       ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          EntryGroupDetail(
-                            group: group.toTemplate(),
-                            showVerificationBadges: false,
-                          ),
-                          const SizedBox(height: MinglitSpacing.xsmall),
-                          Text(
-                            '$participantCount명 참여',
-                            style: theme.textTheme.labelSmall?.copyWith(
-                              color: theme.colorScheme.onSurfaceVariant,
-                            ),
-                          ),
-                        ],
+                      child: EntryGroupDetail(
+                        group: group.toTemplate(),
+                        showVerificationBadges: false,
                       ),
                     ),
                     if (showGauge)

--- a/apps/mds/docs/public/specs/event_detail_page/index.html
+++ b/apps/mds/docs/public/specs/event_detail_page/index.html
@@ -234,10 +234,6 @@
   color: var(--color-text-primary);
   margin-bottom: var(--spacing-xxsmall);
 }
-.entry-group-card__count {
-  font-size: var(--typography-font-size-caption);
-  color: var(--color-text-secondary);
-}
 .entry-group-card__gauge {
   position: absolute;
   top: var(--spacing-small);
@@ -247,16 +243,17 @@
   align-items: flex-end;
   gap: 3px;
 }
-.gauge-bar-wrap {
-  width: 80px;
-  height: 6px;
-  border-radius: 3px;
-  background: var(--color-divider);
-  overflow: hidden;
+.gauge-segments {
+  display: flex;
+  gap: 2px;
 }
-.gauge-bar-fill {
-  height: 100%;
-  border-radius: 3px;
+.gauge-segment {
+  width: 10px;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--color-divider);
+}
+.gauge-segment--filled {
   background: var(--color-primary);
 }
 .gauge-label {
@@ -514,6 +511,14 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td>2026-06-01</td>
+        <td>2.2</td>
+        <td>codex</td>
+        <td>
+          <strong>Issue #2409 participant count sync</strong> — §3 입장 그룹 카드에서 좌측 <code>N명 참여</code> 보조 캡션을 제거하고, 우측 <code>MinglitParticipantGauge</code>의 <code>current/max</code>만 단일 참가 현황 표시로 사용하도록 정렬.
+        </td>
+      </tr>
       <tr>
         <td>2026-06-01</td>
         <td>2.1</td>
@@ -942,7 +947,8 @@
     <h2>§3 참가 현황 — sub-anatomy</h2>
     <p class="intro">
       §3 영역의 내부 구조 — "참여 현황" 섹션 헤더 + 입장권(또는 입장 그룹)별 카드 리스트.
-      각 카드에는 좌측에 그룹명 + 현재 참여 인원, 우측에 정원 대비 현재 참여 비율을 보여주는 가로 게이지 바와 "현재/정원" 텍스트가 함께 붙는다.
+      각 카드에는 좌측에 그룹명, 우측에 정원 대비 현재 참여 비율을 보여주는 <code>MinglitParticipantGauge</code>와 <code>current/max</code> 텍스트가 함께 붙는다.
+      그룹 카드 안에서는 <code>N명 참여</code> 보조 캡션을 따로 노출하지 않는다.
       입장 그룹이 정의되지 않은 단순 이벤트는 카드 없이 "N명 / M명" 텍스트 한 줄만 노출된다.
     </p>
     <div class="layout-grid">
@@ -953,7 +959,7 @@
           <span class="blueprint__region-label" style="font-size:10px;">㉠ Section header — "참여 현황"</span>
         </div>
         <div class="blueprint__region blueprint__region--shaded" style="top:56px;left:16px;right:16px;height:64px;">
-          <span class="blueprint__region-label" style="font-size:10px;">㉡ Entry group card #1 — name + count + gauge</span>
+          <span class="blueprint__region-label" style="font-size:10px;">㉡ Entry group card #1 — name + gauge</span>
         </div>
         <div class="blueprint__region blueprint__region--shaded" style="top:136px;left:16px;right:16px;height:64px;">
           <span class="blueprint__region-label" style="font-size:10px;">㉢ Entry group card #2</span>
@@ -975,14 +981,11 @@
       ├─ <em>Entry group card #1</em>                      ← ㉡
       │  └─ <b>Container</b>(border 1px · radius-small · h-margin screenEdge)
       │     └─ Stack
-      │        ├─ Column(crossAxis: start)
-      │        │  ├─ <i>그룹 이름</i> (bodyMedium · w600)
-      │        │  └─ <i>"N명 참여"</i> (bodySmall · text-secondary)
+      │        ├─ <i>그룹 이름</i> (bodyMedium · w600)
       │        └─ <em>Gauge cluster</em> (Positioned top-right)
-      │           ├─ <b>MinglitParticipantGauge</b> — 80×6 알약 바
-      │           │  · 채워진 부분: <i>color-primary</i>
-      │           │  · 빈 부분: <i>color-divider</i>
-      │           └─ <i>"현재/정원"</i> 라벨 (10 · w600 · text-secondary)
+      │           └─ <b>MinglitParticipantGauge</b>
+      │              · 3-segment gauge + <i>"current/max"</i> + people icon
+      │              · 카운트 source: matching ticket sold_count / quantity
       │
       └─ <em>Entry group card #2 …</em>                    ← ㉢
          · 동일 구조, 정원 / 현재 인원만 다름
@@ -1001,9 +1004,8 @@
       <tbody>
         <tr><td>㉠</td><td>Section header</td><td>좌측 정렬 · 섹션 첫 줄</td><td>padding: <code>medium</code> · <code>screenEdge</code> · <code>sm</code> · text <code>bodyMedium</code> w700 <code>color-text-primary</code></td></tr>
         <tr><td>㉡㉢</td><td>Entry group card</td><td>풀폭 (좌우 16 margin) · 내부 Stack</td><td>border 1px <code>color-divider</code> · radius <code>radius-small (8)</code> · padding <code>spacing-small (8)</code> · 카드 사이 <code>spacing-medium (16)</code></td></tr>
-        <tr><td>—</td><td>그룹 이름 / 인원수</td><td>카드 좌측 column</td><td>이름 <code>bodyMedium</code> w600 · 인원수 <code>bodySmall</code> <code>color-text-secondary</code> · 줄 간격 <code>spacing-xxsmall (2)</code></td></tr>
-        <tr><td>—</td><td>Gauge bar</td><td>카드 우측 상단 정렬</td><td>너비 80 · 높이 6 · radius 3 · 채움 <code>color-primary</code> · 배경 <code>color-divider</code></td></tr>
-        <tr><td>—</td><td>"현재/정원" 라벨</td><td>gauge 바로 아래 우측 정렬</td><td>10px · w600 · <code>color-text-secondary</code></td></tr>
+        <tr><td>—</td><td>그룹 이름</td><td>카드 좌측</td><td><code>bodyMedium</code> w600 · <code>color-text-primary</code></td></tr>
+        <tr><td>—</td><td>MinglitParticipantGauge</td><td>카드 우측 상단 정렬</td><td>3-segment gauge · <code>current/max</code> label · people icon · Minglit 컴포넌트 토큰 사용</td></tr>
       </tbody>
     </table>
   </section>
@@ -1535,17 +1537,15 @@
             <div class="minglit-section-header">참여 현황</div>
             <div class="entry-group-card">
               <div class="entry-group-card__name">일반 참여 (남성)</div>
-              <div class="entry-group-card__count">8명 참여</div>
               <div class="entry-group-card__gauge">
-                <div class="gauge-bar-wrap"><div class="gauge-bar-fill" style="width:65%;"></div></div>
+                <div class="gauge-segments"><span class="gauge-segment gauge-segment--filled"></span><span class="gauge-segment gauge-segment--filled"></span><span class="gauge-segment gauge-segment--filled"></span></div>
                 <div class="gauge-label">13/20</div>
               </div>
             </div>
             <div class="entry-group-card">
               <div class="entry-group-card__name">일반 참여 (여성)</div>
-              <div class="entry-group-card__count">10명 참여</div>
               <div class="entry-group-card__gauge">
-                <div class="gauge-bar-wrap"><div class="gauge-bar-fill" style="width:80%;"></div></div>
+                <div class="gauge-segments"><span class="gauge-segment gauge-segment--filled"></span><span class="gauge-segment gauge-segment--filled"></span><span class="gauge-segment gauge-segment--filled"></span></div>
                 <div class="gauge-label">16/20</div>
               </div>
             </div>
@@ -1604,7 +1604,7 @@
               <div style="position:absolute;top:105px;left:0;right:0;bottom:80px;overflow:hidden;">
                 <!-- §3 ending -->
                 <div style="padding:0 16px 12px;font-size:13px;color:var(--color-text-secondary);line-height:1.55;opacity:0.5;border-bottom:1px solid var(--color-divider);">
-                  … 일반 참여 (여성) 16/20명 참여
+                  … 일반 참여 (여성) 16/20
                 </div>
                 <!-- §4 필요 인증 (active) -->
                 <div class="minglit-section-header">필요 인증</div>


### PR DESCRIPTION
## Summary
- Remove the entry group card's secondary `N명 참여` caption so participant status has a single count surface.
- Keep `MinglitParticipantGauge` as the canonical `current/max` display from matching ticket sold count and capacity.
- Update the event detail MDS spec history, §3 sub-anatomy, and state mockup to match Option B from #2409.
- Update participation-status CUJ coverage to assert `current/max` and absence of the stale caption.

Closes #2409

## Verification
- `dart format apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart apps/app_user/integration_test/cuj/event-operation/participation_status_redesign_test.dart`
- `flutter analyze apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart apps/app_user/integration_test/cuj/event-operation/participation_status_redesign_test.dart`
- `git diff --check`
- Attempted `flutter test integration_test/cuj/event-operation/participation_status_redesign_test.dart`, but Android Gradle build failed before test execution with `No space left on device` while writing build/native-lib caches.