### PR TITLE
fix(ci): wait for supabase before dev cron smoke

### DIFF
--- a/.github/scripts/check-dev-soak-workflow-contract.py
+++ b/.github/scripts/check-dev-soak-workflow-contract.py
@@ -99,6 +99,8 @@ def assert_dev_cron_deploy_contract() -> None:
     required_wait_fragments = [
         'wait_for_deploy="false"',
         "changed_files=",
+        "grep -Eq",
+        '<<< "${changed_files}"',
         "supabase/(migrations|functions)",
         "Skipping deploy-supabase wait.",
     ]

--- a/.github/workflows/deploy-dev-event-flow-cron.yml
+++ b/.github/workflows/deploy-dev-event-flow-cron.yml
@@ -54,7 +54,7 @@ jobs:
               changed_files="$(git show --pretty='' --name-only "${TARGET_SHA}" || true)"
             fi
 
-            if printf '%s\n' "${changed_files}" | grep -Eq '^(supabase/(migrations|functions)/|env-manifest\.json$)'; then
+            if grep -Eq '^(supabase/(migrations|functions)/|env-manifest\.json$)' <<< "${changed_files}"; then
               wait_for_deploy="true"
             fi
           fi


### PR DESCRIPTION
## Summary
- Avoid broken-pipe false negatives in deploy-dev-event-flow-cron changed-file detection
- Keep the dev cron workflow waiting for deploy-supabase when Supabase functions or env manifest changed
- Extend the dev soak workflow contract check to require the non-piped grep form

Fixes #2953

## Verification
- python3 .github/scripts/check-dev-soak-workflow-contract.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-dev-event-flow-cron.yml"); puts "workflow yaml ok"'
- Reproduced the dev promotion diff locally and confirmed wait_for_deploy=true
- git diff --check