### PR TITLE
ci: move dev-staging version bump to cut workflow

### DIFF
--- a/.github/scripts/check-android-deploy-workflow-contract.py
+++ b/.github/scripts/check-android-deploy-workflow-contract.py
@@ -123,10 +123,12 @@ def assert_main_build_number_monotonic_contract() -> None:
 
     required_snippets = [
         "if [ \"${CHANNEL}\" = \"main\" ]; then",
+        "if [ \"${SNAPSHOT_BUILD_INT}\" -lt 100000 ]; then",
         "LEGACY_SEED=$((10#${YY} * 1000000 + 10#${MM} * 10000))",
-        "BUILD_NUMBER=$((LEGACY_SEED + PR_NUMBER_INT))",
-        "if [ \"${BUILD_NUMBER}\" -le \"${PR_NUMBER_INT}\" ]; then",
+        "BUILD_NUMBER=$((LEGACY_SEED + SNAPSHOT_BUILD_INT))",
+        "BUILD_NUMBER_RULE=\"snapshot_build_number\"",
         "echo \"build_number=${BUILD_NUMBER}\"",
+        "echo \"snapshot_build=${SNAPSHOT_BUILD}\"",
     ]
     for snippet in required_snippets:
         if snippet not in script:

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -34,7 +34,8 @@
 - `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 얇은 wrapper 로 시작한다. 내부에서는 `pr-gate.yml` reusable core 를 호출하고, wrapper job 이 최종 required check context 를 제공한다.
 - `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 `shared-pr-source-guard` 로 직접 PR 을 차단한다. 정상 진입점은 `dev-staging` 이고, 예외는 branch별 approved hotfix 뿐이다.
 - `monitor-dev-staging-health` 는 required check 가 아니다. 6시간마다 `dev-staging` HEAD 에서 EF unit/integration + user/partner CUJ 를 돌려 nightly 전에 회귀를 발견하고, 결과를 `dev-staging-health/*` commit status 로 남긴다.
-- `dev-staging-dev-cut-gate` 가 날짜 기반 dev-staging version-bump PR 을 만들고, 그 PR 번호를 mobile build number 로 사용한다. merge 후 `vYY.MM.DD+BUILD_PR-dev-staging` tag 를 생성한다. `dev`/`rc`/`main` promotion 은 source-controlled version 변경 없이 처리한다.
+- `dev-staging-dev-cut-gate` 는 수동 candidate inspect 전용이며 per-merge mutation 을 하지 않는다. 날짜 기반 dev-staging version bump/tag 는 하루 1회 `dev-staging-dev-cut` 이 직접 수행한다.
+- `dev-staging-dev-cut` 은 release bot 으로 protected `dev-staging` 에 version bump commit 을 fast-forward push 하고 `vYY.MM.DD+YYMMDDNN-dev-staging` tag 를 만든 뒤, 해당 tag SHA 를 `dev` 로 promote 한다. `dev`/`rc`/`main` promotion 은 source-controlled version 변경 없이 처리한다.
 - `dev-rc-cut-gate` 는 cut 직전 evaluator 다. 내부에서 `shared-soak-gate` 를 호출해 `dev-soak/*` status 와 `deploy-dev-event-flow-cron` candidate install run 을 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
 - Release gate 는 true evidence 기반이다. required success status/run history/git lineage 가 없으면 `unknown` 이며, failure issue 가 없다는 이유만으로 `dev-rc-cut-pass` 또는 `rc-main-cut-pass` 를 쓰지 않는다.
 - `dev-rc-cut` 은 latest `dev-rc-cut-pass` dev commit 에서 `rc/YYYY-Wxx` branch 를 만들고 `promo/rc-*` tag 를 생성한다. RC branch 에 version bump commit 을 만들지 않는다.
@@ -53,7 +54,8 @@
 - deploy entry 는 후속 단계에서 `[branch]-deploy` 로 통일한다 (`dev-deploy`, `rc-deploy`, `main-deploy`). `monitor-event-flow-*` 는 deploy 가 아니라 지속 batch signal 이다.
 - `set-dev-soak-status` / `set-rc-soak-status` 는 workflow 와 AI agent 가 사용하는 공개 status write API 다. 내부에서는 `shared-set-commit-status` 를 호출한다.
 - protected branch/tag 에 직접 push 하는 workflow 는 `minglit-release-bot` GitHub App token 을 사용한다. App credential 은 `minglit_env/{stage}/github.env` 파일에서 먼저 읽고, 공통 token mint 는 `.github/actions/release-bot-token` 에서 처리한다.
-- `version-bump` 는 source-controlled version file 변경용 reusable 이며 현재 일반 promotion 중에서는 `dev-staging-dev-cut-gate` 의 version-bump PR 안에서만 사용한다. 앱 deploy version 은 `shared-version-metadata` 가 latest version-bump PR number 를 찾아 Android/iOS build command 에 주입한다.
+- `version-bump` 는 source-controlled version file 변경용 reusable/legacy building block 이다. active dev-staging daily cut 은 `dev-staging-dev-cut` 안에서 `scripts/bump-version.sh` 를 직접 실행한다.
+- 앱 deploy version 은 `shared-version-metadata` 가 latest dev-staging snapshot build number 를 찾아 Android/iOS build command 에 주입한다.
 
 ## 컨벤션
 

--- a/.github/workflows/dev-staging-dev-cut-gate.yml
+++ b/.github/workflows/dev-staging-dev-cut-gate.yml
@@ -1,12 +1,10 @@
 name: dev-staging-dev-cut-gate
 
 on:
-  push:
-    branches: [dev-staging]
   workflow_dispatch:
     inputs:
-      snapshot_sha:
-        description: Optional dev-staging snapshot SHA to version. Defaults to the workflow ref.
+      candidate_ref:
+        description: dev-staging ref/SHA to inspect. Defaults to origin/dev-staging.
         required: false
         type: string
 
@@ -15,254 +13,38 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
-  create-version-bump-pr:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (
-        !startsWith(github.event.head_commit.message || '', 'chore: bump version') &&
-        !startsWith(github.event.head_commit.message || '', 'chore(graphify): auto-update') &&
-        !contains(github.event.head_commit.message || '', '[skip ci]')
-      )
+  inspect:
     runs-on: ubuntu-latest
-    outputs:
-      pr_number: ${{ steps.bump-pr.outputs.pr_number }}
-      version: ${{ steps.bump-pr.outputs.version }}
-      tag_name: ${{ steps.bump-pr.outputs.tag_name }}
-
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.snapshot_sha || github.sha }}
           fetch-depth: 0
-          persist-credentials: false
 
-      - name: Generate release bot token
-        id: release-bot
-        uses: ./.github/actions/release-bot-token
-        with:
-          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
-          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
-
-      - name: Create version bump PR
-        id: bump-pr
+      - name: Inspect candidate
         env:
-          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
-          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
-          SNAPSHOT_SHA_INPUT: ${{ inputs.snapshot_sha || '' }}
-          HEAD_MESSAGE: ${{ github.event.head_commit.message || '' }}
+          CANDIDATE_REF: ${{ inputs.candidate_ref || 'origin/dev-staging' }}
         run: |
           set -euo pipefail
+          git fetch origin dev-staging --tags --force
 
-          SNAPSHOT_SHA="$(git rev-parse HEAD)"
-          VERSION_DATE="$(TZ=Asia/Seoul date +%y.%m.%d)"
-          VERSION="${VERSION_DATE}-dev-staging"
-          RUN_DATE="$(TZ=Asia/Seoul date +%Y-%m-%d)"
-          SHORT_SHA="${SNAPSHOT_SHA:0:8}"
-          BRANCH_NAME="version-bump/dev-staging/${RUN_DATE}-${SHORT_SHA}"
-          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
-            BRANCH_NAME="${BRANCH_NAME}-${GITHUB_RUN_ID}"
-          fi
-
-          SOURCE_PR_NUM="$(gh api \
-              "repos/${GITHUB_REPOSITORY}/commits/${SNAPSHOT_SHA}/pulls" \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              --jq '.[0].number // empty' || true)"
-
-          if [ -z "${SOURCE_PR_NUM}" ]; then
-            SOURCE_PR_NUM="$(printf '%s\n' "${HEAD_MESSAGE}" | sed -nE 's/.*\(#([0-9]+)\).*/\1/p' | head -n 1)"
-          fi
-
-          PREVIOUS_TAG="$(git for-each-ref \
-            --sort=-creatordate \
-            --format='%(refname:short)' \
-            'refs/tags/v*-dev-staging' | head -n 1)"
-
-          INCLUDED_PRS=""
-          if [ -n "${PREVIOUS_TAG}" ]; then
-            INCLUDED_PRS="$(git log --first-parent --format=%s "${PREVIOUS_TAG}..HEAD" \
-              | sed -nE 's/.*\(#([0-9]+)\).*/#\1/p' \
-              | sort -u \
-              | awk 'BEGIN { first = 1 } { if (!first) printf ", "; printf "%s", $0; first = 0 } END { if (!first) print "" }')"
-          fi
-          if [ -z "${INCLUDED_PRS}" ] && [[ "${SOURCE_PR_NUM}" =~ ^[0-9]+$ ]]; then
-            INCLUDED_PRS="#${SOURCE_PR_NUM}"
-          fi
-          if [ -z "${INCLUDED_PRS}" ]; then
-            INCLUDED_PRS="none detected"
-          fi
-
-          OPEN_PRS="$(gh pr list \
-            --base dev-staging \
-            --state open \
-            --json number,headRefName \
-            --jq '.[] | select(.headRefName | startswith("version-bump/dev-staging/")) | .number')"
-          for pr in ${OPEN_PRS}; do
-            echo "Closing stale version bump PR #${pr}"
-            gh pr close "${pr}" \
-              --comment "Superseded by snapshot ${SNAPSHOT_SHA}; dev-staging moved before this bump merged." \
-              --delete-branch || true
-          done
-
-          git config user.name "minglit-release-bot"
-          git config user.email "minglit-release-bot@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
-          # Create a temporary diff so GitHub can allocate the bump PR number.
-          bash scripts/bump-version.sh "${VERSION}" 1
-          git add -A
-          git commit -m "chore: prepare version bump for v${VERSION}"
-          git push origin "HEAD:refs/heads/${BRANCH_NAME}"
-
-          PR_BODY="$(cat <<EOF
-          Bumps dev-staging source version for the snapshot at \`${SNAPSHOT_SHA}\`.
-
-          - Version name: \`${VERSION}\`
-          - Build number: assigned from this version-bump PR number
-          - Snapshot SHA: \`${SNAPSHOT_SHA}\`
-          - Previous snapshot tag: \`${PREVIOUS_TAG:-none}\`
-          - Included PRs: ${INCLUDED_PRS}
-          - Source PR from triggering commit: ${SOURCE_PR_NUM:+#${SOURCE_PR_NUM}}
-
-          After this PR is created, the workflow amends this branch so Flutter build numbers equal this PR number.
-
-          No linked issue: automated dev-staging version-bump PR generated by dev-staging-dev-cut-gate.
-          EOF
-          )"
-
-          PR_URL="$(gh pr create \
-            --base dev-staging \
-            --head "${BRANCH_NAME}" \
-            --title "chore: bump version to v${VERSION}" \
-            --body "${PR_BODY}")"
-          PR_NUMBER="${PR_URL##*/}"
-          TAG_NAME="v${VERSION_DATE}+${PR_NUMBER}-dev-staging"
-
-          bash scripts/bump-version.sh "${VERSION}" "${PR_NUMBER}"
-          git add -A
-          git commit --amend -m "chore: bump version to ${TAG_NAME}"
-          git push --force-with-lease origin "HEAD:refs/heads/${BRANCH_NAME}"
-
-          UPDATED_BODY="$(cat <<EOF
-          Bumps dev-staging source version for the snapshot at \`${SNAPSHOT_SHA}\`.
-
-          - Version name: \`${VERSION}\`
-          - Build number: \`${PR_NUMBER}\` (this version-bump PR)
-          - Tag after merge: \`${TAG_NAME}\`
-          - Snapshot SHA: \`${SNAPSHOT_SHA}\`
-          - Previous snapshot tag: \`${PREVIOUS_TAG:-none}\`
-          - Included PRs: ${INCLUDED_PRS}
-          - Source PR from triggering commit: ${SOURCE_PR_NUM:+#${SOURCE_PR_NUM}}
-
-          The tag is created after this PR merges to \`dev-staging\`.
-
-          No linked issue: automated dev-staging version-bump PR generated by dev-staging-dev-cut-gate.
-          EOF
-          )"
-
-          gh pr edit "${PR_NUMBER}" \
-            --title "chore: bump version to ${TAG_NAME}" \
-            --body "${UPDATED_BODY}"
-          gh pr merge "${PR_NUMBER}" --auto --squash --delete-branch
+          CANDIDATE_SHA="$(git rev-parse "${CANDIDATE_REF}")"
+          TAG_NAME="$(git tag --points-at "${CANDIDATE_SHA}" \
+            | grep -E '^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}\+[0-9]+-dev-staging$' \
+            | sort -V \
+            | tail -n 1 || true)"
 
           {
-            echo "pr_number=${PR_NUMBER}"
-            echo "version=${VERSION}"
-            echo "tag_name=${TAG_NAME}"
-          } >> "$GITHUB_OUTPUT"
-
-          {
-            echo "## dev-staging version bump PR"
+            echo "## dev-staging-dev-cut-gate"
+            echo ""
+            echo "This workflow no longer creates per-merge version-bump PRs."
             echo ""
             echo "| Field | Value |"
             echo "|---|---|"
-            echo "| snapshot_sha | ${SNAPSHOT_SHA} |"
-            echo "| version | ${VERSION} |"
-            echo "| build_number | ${PR_NUMBER} |"
-            echo "| tag_name | ${TAG_NAME} |"
-            echo "| pr | #${PR_NUMBER} |"
-            echo "| included_prs | ${INCLUDED_PRS} |"
+            echo "| candidate_ref | ${CANDIDATE_REF} |"
+            echo "| candidate_sha | ${CANDIDATE_SHA} |"
+            echo "| snapshot_tag | ${TAG_NAME:-none} |"
+            echo "| active cut workflow | dev-staging-dev-cut |"
           } >> "$GITHUB_STEP_SUMMARY"
-
-  tag-version-bump:
-    if: >-
-      github.event_name == 'push' &&
-      startsWith(github.event.head_commit.message || '', 'chore: bump version to v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.sha }}
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Generate release bot token
-        id: release-bot
-        uses: ./.github/actions/release-bot-token
-        with:
-          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
-          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
-
-      - name: Tag merged version bump
-        env:
-          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
-          HEAD_MESSAGE: ${{ github.event.head_commit.message || '' }}
-        run: |
-          set -euo pipefail
-
-          VERSION="$(python3 - <<'PY'
-          import json
-          with open('package.json') as f:
-              print(json.load(f)['version'])
-          PY
-          )"
-          BUILD_NUMBER="$(printf '%s\n' "${HEAD_MESSAGE}" | sed -nE 's/.*\+#?([0-9]+)-dev-staging.*/\1/p' | head -n 1)"
-          if [ -z "${BUILD_NUMBER}" ]; then
-            BUILD_NUMBER="$(printf '%s\n' "${HEAD_MESSAGE}" | sed -nE 's/.*\(#([0-9]+)\).*/\1/p' | head -n 1)"
-          fi
-          if ! [[ "${BUILD_NUMBER}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Unable to determine version-bump PR number from merge commit."
-            exit 1
-          fi
-          if [[ "${VERSION}" != *-dev-staging ]]; then
-            echo "::error::Expected package.json version to end with -dev-staging, got ${VERSION}."
-            exit 1
-          fi
-
-          BASE_VERSION="${VERSION%-dev-staging}"
-          TAG_NAME="v${BASE_VERSION}+${BUILD_NUMBER}-dev-staging"
-
-          git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists; skipping."
-            exit 0
-          fi
-
-          git tag "${TAG_NAME}" "${GITHUB_SHA}"
-          git push origin "refs/tags/${TAG_NAME}"
-          echo "Tagged ${GITHUB_SHA} as ${TAG_NAME}"
-
-  notify-failure:
-    needs: [create-version-bump-pr, tag-version-bump]
-    if: always()
-    permissions:
-      actions: read
-      contents: read
-      issues: write
-      statuses: write
-    uses: ./.github/workflows/shared-notify.yml
-    with:
-      failed: >-
-        ${{
-          (
-            (needs.create-version-bump-pr.result != 'success' && needs.create-version-bump-pr.result != 'skipped') ||
-            (needs.tag-version-bump.result != 'success' && needs.tag-version-bump.result != 'skipped')
-          )
-        }}
-      workflow_name: 'Dev-Staging Dev Cut Gate'
-      severity: 'P1-high'
-      job_results: '{"create-version-bump-pr":"${{ needs.create-version-bump-pr.result }}","tag-version-bump":"${{ needs.tag-version-bump.result }}"}'

--- a/.github/workflows/dev-staging-dev-cut.yml
+++ b/.github/workflows/dev-staging-dev-cut.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: Optional v*-dev-staging tag to promote instead of the latest one.
+        description: Optional v*-dev-staging tag to promote. If omitted, the workflow bumps and tags current dev-staging.
         required: false
         type: string
       dry_run:
-        description: Plan only; do not push branch, create PR, or enable auto-merge.
+        description: Plan only; do not push version bump/tag/branch, create PR, or enable auto-merge.
         required: false
         type: boolean
         default: false
@@ -29,10 +29,10 @@ jobs:
   create-dev-cut-pr:
     runs-on: ubuntu-latest
     outputs:
-      skipped: ${{ steps.plan.outputs.skipped }}
+      skipped: ${{ steps.prepare.outputs.skipped }}
       pr_number: ${{ steps.pr.outputs.pr_number }}
-      tag_name: ${{ steps.plan.outputs.tag_name }}
-      branch_name: ${{ steps.plan.outputs.branch_name }}
+      tag_name: ${{ steps.prepare.outputs.tag_name }}
+      branch_name: ${{ steps.prepare.outputs.branch_name }}
 
     steps:
       - uses: actions/checkout@v6
@@ -47,10 +47,10 @@ jobs:
           fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
           fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
 
-      - name: Plan dev promotion
-        id: plan
+      - name: Prepare dev-staging snapshot
+        id: prepare
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
           RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
           REQUESTED_TAG: ${{ inputs.tag_name || '' }}
           DRY_RUN: ${{ inputs.dry_run || false }}
@@ -71,28 +71,85 @@ jobs:
             exit 0
           fi
 
+          ACTION="promote requested tag"
+          VERSION=""
+          BUILD_NUMBER=""
+          BUMPED=false
+
           if [ -n "${REQUESTED_TAG}" ]; then
             TAG_NAME="${REQUESTED_TAG}"
+            if ! git rev-parse -q --verify "refs/tags/${TAG_NAME}" >/dev/null; then
+              echo "::error::Tag ${TAG_NAME} does not exist."
+              exit 1
+            fi
+            TAG_SHA="$(git rev-list -n 1 "${TAG_NAME}")"
+            if ! git merge-base --is-ancestor "${TAG_SHA}" origin/dev-staging; then
+              echo "::error::Tag ${TAG_NAME} (${TAG_SHA}) is not reachable from origin/dev-staging."
+              exit 1
+            fi
           else
-            TAG_NAME="$(git for-each-ref \
-              --sort=-creatordate \
-              --format='%(refname:short)' \
-              'refs/tags/v*-dev-staging' | head -n 1)"
-          fi
+            SNAPSHOT_SHA="$(git rev-parse origin/dev-staging)"
+            if git merge-base --is-ancestor "${SNAPSHOT_SHA}" origin/dev; then
+              echo "origin/dev already contains origin/dev-staging (${SNAPSHOT_SHA}); skipping."
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
 
-          if [ -z "${TAG_NAME}" ]; then
-            echo "::error::No v*-dev-staging tag found to promote."
-            exit 1
-          fi
-          if ! git rev-parse -q --verify "refs/tags/${TAG_NAME}" >/dev/null; then
-            echo "::error::Tag ${TAG_NAME} does not exist."
-            exit 1
-          fi
+            EXISTING_HEAD_TAG="$(git tag --points-at "${SNAPSHOT_SHA}" \
+              | grep -E '^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}\+[0-9]+-dev-staging$' \
+              | sort -V \
+              | tail -n 1 || true)"
+            if [ -n "${EXISTING_HEAD_TAG}" ]; then
+              TAG_NAME="${EXISTING_HEAD_TAG}"
+              TAG_SHA="${SNAPSHOT_SHA}"
+              VERSION="$(printf '%s\n' "${TAG_NAME}" | sed -nE 's/^v([^+]+)\+[0-9]+-dev-staging$/\1-dev-staging/p')"
+              BUILD_NUMBER="$(printf '%s\n' "${TAG_NAME}" | sed -nE 's/^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}\+([0-9]+)-dev-staging$/\1/p')"
+              ACTION="reuse existing dev-staging snapshot tag"
+            else
+              VERSION_DATE="$(TZ=Asia/Seoul date +%y.%m.%d)"
+              BUILD_PREFIX="$(TZ=Asia/Seoul date +%y%m%d)"
+              VERSION="${VERSION_DATE}-dev-staging"
+              LATEST_BUILD="$(git tag -l "v${VERSION_DATE}+${BUILD_PREFIX}*-dev-staging" \
+                | sed -nE "s/^v${VERSION_DATE}\+([0-9]+)-dev-staging$/\1/p" \
+                | sort -n \
+                | tail -n 1)"
+              if [ -n "${LATEST_BUILD}" ]; then
+                BUILD_NUMBER="$((10#${LATEST_BUILD} + 1))"
+              else
+                BUILD_NUMBER="${BUILD_PREFIX}01"
+              fi
+              if [ "${BUILD_NUMBER}" -gt 2100000000 ]; then
+                echo "::error::Build number ${BUILD_NUMBER} exceeds Android versionCode max."
+                exit 1
+              fi
 
-          TAG_SHA="$(git rev-list -n 1 "${TAG_NAME}")"
-          if ! git merge-base --is-ancestor "${TAG_SHA}" origin/dev-staging; then
-            echo "::error::Tag ${TAG_NAME} (${TAG_SHA}) is not reachable from origin/dev-staging."
-            exit 1
+              TAG_NAME="v${VERSION_DATE}+${BUILD_NUMBER}-dev-staging"
+              if git rev-parse -q --verify "refs/tags/${TAG_NAME}" >/dev/null; then
+                echo "::error::Tag ${TAG_NAME} already exists; refusing to overwrite."
+                exit 1
+              fi
+
+              ACTION="direct dev-staging version bump, tag, and promote"
+              if [ "${DRY_RUN}" = "true" ]; then
+                TAG_SHA="${SNAPSHOT_SHA}"
+              else
+                git config user.name "minglit-release-bot"
+                git config user.email "minglit-release-bot@users.noreply.github.com"
+                git checkout -B dev-staging origin/dev-staging
+                bash scripts/bump-version.sh "${VERSION}" "${BUILD_NUMBER}"
+                if git diff --quiet; then
+                  echo "::error::Version bump produced no file changes."
+                  exit 1
+                fi
+                git add -A
+                git commit -m "chore: bump version to ${TAG_NAME}"
+                TAG_SHA="$(git rev-parse HEAD)"
+                git push origin HEAD:refs/heads/dev-staging
+                git tag "${TAG_NAME}" "${TAG_SHA}"
+                git push origin "refs/tags/${TAG_NAME}"
+                BUMPED=true
+              fi
+            fi
           fi
 
           if git merge-base --is-ancestor "${TAG_SHA}" origin/dev; then
@@ -113,6 +170,8 @@ jobs:
           echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
           echo "tag_sha=${TAG_SHA}" >> "$GITHUB_OUTPUT"
           echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
+          echo "build_number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "bumped=${BUMPED}" >> "$GITHUB_OUTPUT"
 
           {
             echo "## dev-staging-dev-cut plan"
@@ -120,18 +179,21 @@ jobs:
             echo "| Field | Value |"
             echo "|---|---|"
             echo "| dry_run | ${DRY_RUN} |"
+            echo "| action | ${ACTION} |"
+            echo "| version | ${VERSION:-from requested tag} |"
+            echo "| build_number | ${BUILD_NUMBER:-from requested tag} |"
             echo "| tag_name | ${TAG_NAME} |"
             echo "| tag_sha | ${TAG_SHA} |"
             echo "| branch_name | ${BRANCH_NAME} |"
-            echo "| action | create PR ${BRANCH_NAME} -> dev |"
+            echo "| bumped_dev_staging | ${BUMPED} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Push dev promotion branch
-        if: steps.plan.outputs.skipped != 'true' && inputs.dry_run != true
+        if: steps.prepare.outputs.skipped != 'true' && inputs.dry_run != true
         env:
           RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
-          TAG_SHA: ${{ steps.plan.outputs.tag_sha }}
-          BRANCH_NAME: ${{ steps.plan.outputs.branch_name }}
+          TAG_SHA: ${{ steps.prepare.outputs.tag_sha }}
+          BRANCH_NAME: ${{ steps.prepare.outputs.branch_name }}
         run: |
           set -euo pipefail
           git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -140,32 +202,32 @@ jobs:
 
       - name: Track dev promotion issue
         id: cut-issue
-        if: steps.plan.outputs.skipped != 'true'
+        if: steps.prepare.outputs.skipped != 'true'
         uses: ./.github/actions/cut-issue
         with:
           github-token: ${{ github.token }}
           operation: upsert
           gate-key: dev-staging-dev
-          subject-id: ${{ steps.plan.outputs.tag_name }}
-          title: 'cut-gate(dev-staging-dev): ${{ steps.plan.outputs.tag_name }}'
+          subject-id: ${{ steps.prepare.outputs.tag_name }}
+          title: 'cut-gate(dev-staging-dev): ${{ steps.prepare.outputs.tag_name }}'
           status: ${{ inputs.dry_run == true && 'ready' || 'promoting' }}
-          summary: 'dev-staging -> dev promotion is planned for `${{ steps.plan.outputs.tag_name }}`.'
+          summary: 'dev-staging -> dev promotion is planned for `${{ steps.prepare.outputs.tag_name }}`.'
           details: |
-            - Source tag: `${{ steps.plan.outputs.tag_name }}`
-            - Source SHA: `${{ steps.plan.outputs.tag_sha }}`
-            - Promotion branch: `${{ steps.plan.outputs.branch_name }}`
+            - Source tag: `${{ steps.prepare.outputs.tag_name }}`
+            - Source SHA: `${{ steps.prepare.outputs.tag_sha }}`
+            - Promotion branch: `${{ steps.prepare.outputs.branch_name }}`
             - Target branch: `dev`
             - Deploy after merge: `dev-deploy` on `push` to `dev`
             - Dry run: `${{ inputs.dry_run || false }}`
 
       - name: Create dev promotion PR and enable auto-merge
         id: pr
-        if: steps.plan.outputs.skipped != 'true' && inputs.dry_run != true
+        if: steps.prepare.outputs.skipped != 'true' && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
-          TAG_NAME: ${{ steps.plan.outputs.tag_name }}
-          TAG_SHA: ${{ steps.plan.outputs.tag_sha }}
-          BRANCH_NAME: ${{ steps.plan.outputs.branch_name }}
+          TAG_NAME: ${{ steps.prepare.outputs.tag_name }}
+          TAG_SHA: ${{ steps.prepare.outputs.tag_sha }}
+          BRANCH_NAME: ${{ steps.prepare.outputs.branch_name }}
           CUT_ISSUE_NUMBER: ${{ steps.cut-issue.outputs.issue-number }}
           CUT_ISSUE_URL: ${{ steps.cut-issue.outputs.issue-url }}
         run: |
@@ -206,9 +268,9 @@ jobs:
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Dry run summary
-        if: steps.plan.outputs.skipped != 'true' && inputs.dry_run == true
+        if: steps.prepare.outputs.skipped != 'true' && inputs.dry_run == true
         run: |
-          echo "Dry-run complete. No branch, PR, or auto-merge was created."
+          echo "Dry-run complete. No version bump, tag, branch, PR, or auto-merge was created."
 
   notify-failure:
     needs: [create-dev-cut-pr]

--- a/.github/workflows/shared-version-metadata.yml
+++ b/.github/workflows/shared-version-metadata.yml
@@ -28,8 +28,11 @@ on:
         description: GitHub Release title suffix.
         value: ${{ jobs.metadata.outputs.release_name }}
       pr_number:
-        description: Version-bump PR number used as the monotonic build number.
+        description: Backward-compatible alias for snapshot_build.
         value: ${{ jobs.metadata.outputs.pr_number }}
+      snapshot_build:
+        description: Monotonic snapshot build number parsed from the dev-staging snapshot tag or bump commit.
+        value: ${{ jobs.metadata.outputs.snapshot_build }}
       source_sha:
         description: Resolved source SHA.
         value: ${{ jobs.metadata.outputs.source_sha }}
@@ -47,6 +50,7 @@ jobs:
       release_tag: ${{ steps.metadata.outputs.release_tag }}
       release_name: ${{ steps.metadata.outputs.release_name }}
       pr_number: ${{ steps.metadata.outputs.pr_number }}
+      snapshot_build: ${{ steps.metadata.outputs.snapshot_build }}
       source_sha: ${{ steps.metadata.outputs.source_sha }}
     steps:
       - uses: actions/checkout@v6
@@ -79,23 +83,34 @@ jobs:
           PY
           )"
           BASE_VERSION="${ROOT_VERSION%-dev-staging}"
-          BUMP_PR_NUM=""
+          SNAPSHOT_BUILD=""
           REVISION_SHA=""
+          git fetch --tags --force
 
           for sha in $(git rev-list --first-parent -n 80 HEAD); do
+            candidate="$(git tag --points-at "${sha}" \
+              | sed -nE 's/^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}\+([0-9]+)-dev-staging$/\1/p' \
+              | sort -n \
+              | tail -n 1)"
+            if [[ "${candidate}" =~ ^[0-9]+$ ]]; then
+              SNAPSHOT_BUILD="${candidate}"
+              REVISION_SHA="${sha}"
+              break
+            fi
+
             message="$(git log -1 --format=%B "${sha}")"
             candidate="$(printf '%s\n' "${message}" | sed -nE 's/.*chore: bump version to v[0-9]{2}\.[0-9]{2}\.[0-9]{2}\+([0-9]+)-dev-staging.*/\1/p' | head -n 1)"
 
             if [[ "${candidate}" =~ ^[0-9]+$ ]]; then
-              BUMP_PR_NUM="${candidate}"
+              SNAPSHOT_BUILD="${candidate}"
               REVISION_SHA="${sha}"
               break
             fi
           done
 
-          # Backward compatibility for builds cut before version-bump PR numbers
-          # were embedded in the squash title.
-          if [ -z "${BUMP_PR_NUM}" ]; then
+          # Backward compatibility for builds cut before snapshot build numbers
+          # were embedded in tags or bump commit titles.
+          if [ -z "${SNAPSHOT_BUILD}" ]; then
             for sha in $(git rev-list --first-parent -n 80 HEAD); do
               candidate="$(gh api \
                 "repos/${GITHUB_REPOSITORY}/commits/${sha}/pulls" \
@@ -108,43 +123,44 @@ jobs:
               fi
 
               if [[ "${candidate}" =~ ^[0-9]+$ ]]; then
-                BUMP_PR_NUM="${candidate}"
+                SNAPSHOT_BUILD="${candidate}"
                 REVISION_SHA="${sha}"
                 break
               fi
             done
           fi
 
-          if ! [[ "${BUMP_PR_NUM}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Unable to determine version-bump PR number for ${SOURCE_SHA} (${SOURCE_REF})."
+          if ! [[ "${SNAPSHOT_BUILD}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Unable to determine snapshot build number for ${SOURCE_SHA} (${SOURCE_REF})."
             exit 1
           fi
 
-          PR_NUMBER_INT="${BUMP_PR_NUM}"
-          if ! [[ "${PR_NUMBER_INT}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid version-bump PR number '${PR_NUMBER_INT}'."
+          SNAPSHOT_BUILD_INT="${SNAPSHOT_BUILD}"
+          if ! [[ "${SNAPSHOT_BUILD_INT}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid snapshot build number '${SNAPSHOT_BUILD_INT}'."
             exit 1
           fi
 
           if [ "${CHANNEL}" = "main" ]; then
             VERSION_NAME="${BASE_VERSION}"
-            YY="$(printf '%s' "${BASE_VERSION}" | cut -d. -f1)"
-            MM="$(printf '%s' "${BASE_VERSION}" | cut -d. -f2)"
-            if ! [[ "${YY}" =~ ^[0-9]{2}$ && "${MM}" =~ ^[0-9]{2}$ ]]; then
-              echo "::error::BASE_VERSION '${BASE_VERSION}' must start with YY.MM for main channel."
-              exit 1
+            if [ "${SNAPSHOT_BUILD_INT}" -lt 100000 ]; then
+              YY="$(printf '%s' "${BASE_VERSION}" | cut -d. -f1)"
+              MM="$(printf '%s' "${BASE_VERSION}" | cut -d. -f2)"
+              if ! [[ "${YY}" =~ ^[0-9]{2}$ && "${MM}" =~ ^[0-9]{2}$ ]]; then
+                echo "::error::BASE_VERSION '${BASE_VERSION}' must start with YY.MM for legacy main channel build."
+                exit 1
+              fi
+              LEGACY_SEED=$((10#${YY} * 1000000 + 10#${MM} * 10000))
+              BUILD_NUMBER=$((LEGACY_SEED + SNAPSHOT_BUILD_INT))
+              BUILD_NUMBER_RULE="legacy_seed_plus_snapshot_build"
+            else
+              BUILD_NUMBER="${SNAPSHOT_BUILD_INT}"
+              BUILD_NUMBER_RULE="snapshot_build_number"
             fi
-            LEGACY_SEED=$((10#${YY} * 1000000 + 10#${MM} * 10000))
-            BUILD_NUMBER=$((LEGACY_SEED + PR_NUMBER_INT))
-            if [ "${BUILD_NUMBER}" -le "${PR_NUMBER_INT}" ]; then
-              echo "::error::Computed main build_number must exceed PR number (${PR_NUMBER_INT})."
-              exit 1
-            fi
-            BUILD_NUMBER_RULE="legacy_seed_plus_version_bump_pr"
           else
             VERSION_NAME="${BASE_VERSION}-${CHANNEL}"
-            BUILD_NUMBER="${PR_NUMBER_INT}"
-            BUILD_NUMBER_RULE="version_bump_pr_number"
+            BUILD_NUMBER="${SNAPSHOT_BUILD_INT}"
+            BUILD_NUMBER_RULE="snapshot_build_number"
           fi
 
           {
@@ -153,7 +169,8 @@ jobs:
             echo "build_number=${BUILD_NUMBER}"
             echo "release_tag=build-${CHANNEL}-v${VERSION_NAME}+${BUILD_NUMBER}"
             echo "release_name=${CHANNEL} v${VERSION_NAME} (${BUILD_NUMBER})"
-            echo "pr_number=${BUMP_PR_NUM}"
+            echo "pr_number=${SNAPSHOT_BUILD}"
+            echo "snapshot_build=${SNAPSHOT_BUILD}"
             echo "source_sha=${SOURCE_SHA}"
           } >> "$GITHUB_OUTPUT"
 
@@ -166,7 +183,7 @@ jobs:
             echo "| source_ref | ${SOURCE_REF} |"
             echo "| source_sha | ${SOURCE_SHA} |"
             echo "| revision_sha | ${REVISION_SHA} |"
-            echo "| version_bump_pr | #${BUMP_PR_NUM} |"
+            echo "| snapshot_build | ${SNAPSHOT_BUILD} |"
             echo "| base_version | ${BASE_VERSION} |"
             echo "| version_name | ${VERSION_NAME} |"
             echo "| build_number | ${BUILD_NUMBER} |"

--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -8,10 +8,9 @@
 flowchart LR
   agent[Agent / Human PR] --> dsg[dev-staging-pr-gate]
   dsg --> ds[dev-staging]
-  ds --> dss[dev-staging-dev-cut-gate]
-  dss --> dstag["v*-dev-staging tag"]
+  ds --> nc[dev-staging-dev-cut]
+  nc --> dstag["v*-dev-staging tag"]
 
-  dstag --> nc[dev-staging-dev-cut]
   nc --> npg[dev-pr-gate]
   npg --> dev[dev]
 
@@ -46,8 +45,8 @@ flowchart LR
 |------|----------------|------|
 | dev-staging PR | `dev-staging-pr-gate` | feature/agent PR 의 빠른 CI gate |
 | dev-staging 지속 검증 | `monitor-dev-staging-health` | 6시간마다 EF unit/integration + user/partner CUJ 로 nightly 전 회귀 감지 |
-| dev-staging → dev cut gate | `dev-staging-dev-cut-gate` | dev 로 promote 할 coherent dev-staging snapshot 을 `v*-dev-staging` tag 로 선별 |
-| dev-staging → dev cut | `dev-staging-dev-cut` + `dev-pr-gate` | gate 가 선별한 snapshot 을 dev PR 로 promote |
+| dev-staging → dev cut gate | `dev-staging-dev-cut-gate` | 수동 candidate inspect 전용. per-merge mutation 없음 |
+| dev-staging → dev cut | `dev-staging-dev-cut` + `dev-pr-gate` | daily cut 시점에 coherent snapshot 을 직접 bump/tag 하고 dev PR 로 promote |
 | dev → rc cut gate | `dev-rc-cut-gate` | 24h dev soak status + dev cron install run 확인 후 `dev-rc-cut-pass` status 부여 |
 | dev deploy/validation | `dev-deploy` | dev 환경 deploy/validation orchestrator. 이벤트 플로우 시뮬레이터는 dev Supabase pg_cron 으로 별도 운영 |
 | dev → rc cut | `dev-rc-cut` | latest `dev-rc-cut-pass` commit 에서 `rc/YYYY-Wxx` 생성 |
@@ -103,10 +102,10 @@ flowchart LR
 - dev soak 판정의 source-of-truth 는 GitHub Issue/label 이 아니라 commit status context + workflow run history 다 ([dev-soak-status-model.md](./dev-soak-status-model.md))
 - cut-gate Issue 는 사람이 진행 상태를 추적하기 위한 projection 이다. 생성/갱신/닫기는 `.github/actions/cut-issue` 와 `close-cut-issue-on-pr-merge` 가 담당하며, promotion 판정 SSOT 로 사용하지 않는다
 - 모든 branch linear ON — dev-staging: squash, dev/rc/main: rebase
-- Protected branch 직접 push 는 human 금지. dev-staging version bump, promotion branch/tag, RC cleanup 은 `minglit-release-bot` 전용 token + Ruleset bypass 로만 허용
+- Protected branch 직접 push 는 human 금지. dev-staging daily cut version bump, promotion branch/tag, RC cleanup 은 `minglit-release-bot` 전용 token + Ruleset bypass 로만 허용
 - `deploy-dev-event-flow-cron` 은 `dev` push 에서만 `dev-event-flow-simulator` pg_cron 을 설치한다. `monitor-event-flow-*` 는 수동 smoke 이며, RC cron 은 RC project 준비 후 별도 설치한다
 - main 머지 = backend + mobile 모두 prod deploy. backend prod deploy 는 `main-deploy` 에서 한 번에 수행한다
-- 소스 파일 version bump 는 `dev-staging-dev-cut-gate` 가 만든 version-bump PR 에만 남긴다. 날짜 버전(`YY.MM.DD`) + version-bump PR 번호 build number 를 사용하고, `dev`/`rc`/`main` 은 branch state 를 바꾸지 않고 deploy workflow 가 metadata 를 build-time 에 주입한다
+- 소스 파일 version bump 는 `dev-staging-dev-cut` 이 promote 할 dev-staging snapshot 에만 남긴다. release bot 이 protected `dev-staging` 에 직접 bump commit 을 fast-forward push 하고, 날짜 버전(`YY.MM.DD`) + snapshot build number(`YYMMDDNN`) tag 를 붙인다. `dev`/`rc`/`main` 은 branch state 를 바꾸지 않고 deploy workflow 가 metadata 를 build-time 에 주입한다
 - `main-deploy` 는 prod deploy execution 을 담당한다. main push 에서 version bump commit 을 만들지 않고, release asset/tag/marker 는 deploy metadata 를 기준으로 생성한다
 - 모바일 배포 산출물(APK/AAB/IPA)은 GitHub Release asset 이 canonical archive 다. Actions artifact 는 테스트 리포트/스크린샷/로그 같은 단기 디버깅 산출물에만 사용한다
 - 일반 PR 은 `dev-staging` 으로만 진입한다. `dev`, `rc/*`, `main` 직접 PR 은 promotion 또는 승인된 hotfix 만 허용한다 ([hotfix-policy.md](./hotfix-policy.md))

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -50,7 +50,7 @@ RC hotfix 는 dev-staging-first 가 기본이다. active RC 에만 먼저 들어
 | 머지 방향 | base ← head | 트리거 | 머지 방식 | 요구 체크 |
 |-----------|-------------|--------|-----------|-----------|
 | feature/agent → dev-staging | `dev-staging` ← `feat/*`, `fix/*`, `chore/*`, `docs/*` | PR + auto-merge | **squash** | `dev-staging-pr-gate` |
-| dev-staging → dev | `dev` ← `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` at latest `v*-dev-staging` tag | daily cron `dev-staging-dev-cut` | rebase (linear snapshot) | `dev-pr-gate` |
+| dev-staging → dev | `dev` ← `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` at daily cut-time `v*-dev-staging` tag | daily cron `dev-staging-dev-cut` | rebase (linear snapshot) | `dev-pr-gate` |
 | hotfix → dev | `dev` ← `dev/hotfix/*` | approved hotfix only | rebase | `dev-pr-gate` |
 | hotfix → rc | `rc/YYYY-Wxx` ← dev-staging fix cherry-pick branch | dev-staging-first approved hotfix only | rebase | `rc-pr-gate` |
 | rc → main | `main` ← `rc/YYYY-Wxx` | `rc-main-cut` 이 5일 무커밋 시 PR 생성 + auto-merge | rebase + ff | `main-pr-gate` |
@@ -71,7 +71,7 @@ Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가
 
 | Tag / Status | 시점 | 예시 | 부여자 |
 |--------------|------|------|--------|
-| `v{ver}+{build}-dev-staging` (tag) | dev-staging-dev-cut-gate | `v26.05.27+2832-dev-staging` | workflow |
+| `v{ver}+{build}-dev-staging` (tag) | dev-staging-dev-cut direct bump commit | `v26.06.01+26060101-dev-staging` | workflow |
 | `dev-rc-cut-pass` (commit status) | dev-rc-cut-gate green 시 dev commit 에 | (status only, tag 없음) | workflow |
 | `promo/rc-YYYY-Wxx` (tag) | dev-rc-cut 직후 | `promo/rc-2026-W20` | workflow |
 | `promo/main-YYYY-Wxx` (tag) | main 머지 직후 | `promo/main-2026-W20` | workflow |
@@ -104,7 +104,7 @@ monitor-dev-staging-health:
 # 개념 — backend + mobile 모두 prod
 main-deploy (on push to main):
   steps:
-    - compute deploy-time version metadata: YY.MM.DD + version-bump PR build number
+    - compute deploy-time version metadata: YY.MM.DD + snapshot build number
     - tag promo/main-Wxx + Sentry marker
     - Firebase RC `latest_version` = computed version 자동 update
   parallel:

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -4,7 +4,7 @@
 
 ## 4가지 workflow
 
-1. **`dev-staging-dev-cut`** — daily cron, dev-staging tip 의 snapshot 으로 PR 생성
+1. **`dev-staging-dev-cut`** — daily cron, dev-staging tip 을 직접 bump/tag 한 뒤 그 snapshot 으로 PR 생성
 2. **`dev-pr-gate`** — snapshot PR 머지 전 검증 (defensive)
 3. **`dev-rc-cut-gate`** — cut 직전 evaluator. 24h soak + commit status + cron install run 확인 후 `dev-rc-cut-pass` set
 4. **`dev-deploy` / cron install** — dev 환경 deploy/smoke 가 필요할 때 수행. 이벤트 플로우 시뮬레이터는 dev pg_cron 으로 별도 운영
@@ -16,15 +16,19 @@
 - **cron**: 매일 KST 02:00 (TBD)
 - **manual**: `workflow_dispatch`
 - 동작:
-  1. 가장 최근 `v*-dev-staging` 태그 (dev-staging 의 latest coherent snapshot) 찾기
-  2. PR 생성: `ci(dev-staging-dev-cut): promote v26.05.27+2832-dev-staging to dev` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}` at that tag)
-  3. `dev-pr-gate` 자동 발동
-  4. 통과 시 auto-merge (rebase — active `dev` ruleset 의 linear history 와 호환)
+  1. open `cut/dev-staging-dev/*` PR 이 있으면 skip
+  2. `tag_name` 입력이 있으면 해당 `v*-dev-staging` tag 를 promote 대상으로 사용
+  3. 입력이 없으면 현재 `origin/dev-staging` HEAD 에 `YY.MM.DD-dev-staging+YYMMDDNN` version bump commit 을 만들고 release bot 이 protected `dev-staging` 에 fast-forward push
+  4. 같은 commit 에 `vYY.MM.DD+YYMMDDNN-dev-staging` tag 생성
+  5. PR 생성: `ci(dev-staging-dev-cut): promote v26.06.01+26060101-dev-staging to dev` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}` at that tag)
+  6. `dev-pr-gate` 자동 발동
+  7. 통과 시 auto-merge (rebase — active `dev` ruleset 의 linear history 와 호환)
 
 ### 슬립 처리
 
 - 이미 dev 가 최신 dev-staging 과 동기화돼 있으면 (= 새 commit 없음) skip
 - 이전 dev-staging-dev-cut 이 still in progress (드물) → 이번 cron skip + Slack 알림
+- partial run 으로 dev-staging HEAD 에 이미 `v*-dev-staging` tag 가 있으면 새 bump 를 만들지 않고 그 tag 를 재사용
 
 ## `dev-pr-gate`
 

--- a/docs/infra/branch-strategy/dev-staging-pipeline.md
+++ b/docs/infra/branch-strategy/dev-staging-pipeline.md
@@ -1,11 +1,11 @@
 # Dev-Staging Pipeline
 
-AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 진입점. 일반 PR + auto-merge 로 처리하고, `dev-staging-pr-gate` 가 가벼운 검증, 머지 후 `dev-staging-dev-cut-gate` 가 version-bump PR 을 생성한다.
+AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 진입점. 일반 PR + auto-merge 로 처리하고, `dev-staging-pr-gate` 가 가벼운 검증을 담당한다. source version bump 와 `v*-dev-staging` tag 는 PR 머지마다 만들지 않고, 하루 1회 `dev-staging-dev-cut` 이 promote 할 snapshot 에만 만든다.
 
 ## 두 가지 workflow
 
 1. **`dev-staging-pr-gate`** — PR 머지 전
-2. **`dev-staging-dev-cut-gate`** — PR 머지 직후 (version-bump PR 생성, merge 후 tag)
+2. **`dev-staging-dev-cut`** — daily cut 시점 (direct version bump commit + tag + dev promotion PR)
 
 ## PR + Auto-Merge
 
@@ -22,7 +22,7 @@ AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 �
     ↓
 [통과 시 squash merge to dev-staging]
     ↓
-[dev-staging-dev-cut-gate 자동 발동]
+[daily dev-staging-dev-cut 이 최신 dev-staging snapshot 선별]
 ```
 
 ### 왜 merge queue 를 보류하나
@@ -81,24 +81,27 @@ AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 �
 
 **현재 상태**: TODO — AST 검출 로직 + 예외 라벨 운영 룰 + 분기별 우회 통계.
 
-## `dev-staging-dev-cut-gate`
+## `dev-staging-dev-cut`
 
-PR 머지 직후 자동 발동. 운영 복구용으로 `workflow_dispatch` 도 제공하며, 수동 실행 시 version 을 찍을 snapshot SHA 를 입력할 수 있다.
+하루 1회 KST 02:00에 실행된다. `tag_name` 입력이 있으면 기존 `v*-dev-staging` tag 를 promote 하고, 입력이 없으면 현재 `origin/dev-staging` HEAD 에 직접 version bump commit 을 만들고 그 commit 에 tag 를 찍은 뒤 동일 SHA 를 dev 로 promote 한다.
 
 ```
-1. KST 기준 날짜로 versionName 계산: `YY.MM.DD-dev-staging`
-2. 기존 open `version-bump/dev-staging/*` PR 이 있으면 stale 로 close
-3. 임시 version bump branch 생성 후 PR 생성
-4. 생성된 version-bump PR 번호를 build number 로 사용해 branch commit amend
-5. `dev-staging-pr-gate` 통과 시 auto-merge
-6. merge commit 에 tag `vYY.MM.DD+{version-bump PR#}-dev-staging` 생성
+1. open `cut/dev-staging-dev/*` PR 이 있으면 중복 cut 방지를 위해 skip
+2. `origin/dev-staging` HEAD 가 이미 `dev` 에 포함되어 있으면 skip
+3. HEAD 에 기존 `vYY.MM.DD+BUILD-dev-staging` tag 가 있으면 재사용
+4. tag 가 없으면 KST 날짜로 versionName `YY.MM.DD-dev-staging` 계산
+5. build number `YYMMDDNN` 계산 (`NN` = 같은 날짜 snapshot sequence)
+6. release bot 이 protected `dev-staging` 에 version bump commit 을 fast-forward push
+7. 같은 commit 에 tag `vYY.MM.DD+YYMMDDNN-dev-staging` 생성
+8. tag SHA 에서 `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` branch 생성
+9. dev promotion PR 생성 + auto-merge(rebase)
 ```
 
-Protected `dev-staging` 에 직접 bump commit 을 push 하지 않는다. release bot 은 version-bump branch push, PR 생성/auto-merge, tag push 에만 사용한다.
+Protected `dev-staging` 직접 push 는 human 금지다. 예외는 `minglit-release-bot` 이 `dev-staging-dev-cut` 안에서 version bump commit 을 fast-forward push 하는 경우뿐이다. push 가 거부되면 dev-staging 이 cut 중 변경된 것이므로 새 HEAD 기준으로 다음 run 에서 다시 계산한다.
 
-Tag `vYY.MM.DD+{build}-dev-staging` 는 다음 단계의 `dev-staging-dev-cut` workflow 가 query 해서 "가장 최근 dev-staging 의 coherent snapshot" 찾는 데 사용.
+Tag `vYY.MM.DD+{build}-dev-staging` 는 dev promotion PR, deploy metadata, RC/main artifact version 이 같은 coherent snapshot 을 가리키게 하는 anchor 다.
 
-> **구현 결정**: source PR 번호는 build number 로 쓰지 않는다. GitHub PR 번호는 생성 순서라 merge 순서를 보장하지 않기 때문이다. version-bump PR 번호만 build number 로 사용한다.
+> **구현 결정**: source PR 번호와 version-bump PR 번호는 build number 로 쓰지 않는다. PR 번호는 생성 순서라 merge/promote 순서를 보장하지 않는다. build number 는 promote 된 snapshot 의 KST 날짜 + sequence (`YYMMDDNN`) 로 계산한다.
 
 ## Error-Backoff
 

--- a/docs/infra/branch-strategy/rc-promotion.md
+++ b/docs/infra/branch-strategy/rc-promotion.md
@@ -54,7 +54,7 @@ Hotfix PR 머지 직후에는 RC branch 에 version bump commit 을 추가하지
 4. 새 RC HEAD 기준으로 5일 soak clock 이 다시 시작
 ```
 
-RC artifact version 은 `shared-version-metadata(channel=rc)` 가 latest RC HEAD 의 version-bump PR 번호로 계산한다.
+RC artifact version 은 `shared-version-metadata(channel=rc)` 가 latest RC HEAD 의 dev-staging snapshot build number 로 계산한다.
 
 ## `rc-deploy`
 
@@ -98,7 +98,7 @@ Mark 님 직감대로 hotfix loop 으로 RC lifecycle 이 길어지는 게 일�
 | 검증 | 도구 |
 |------|------|
 | 누적 회귀 | rc 의 nightly 재실행 (선택 — RC 별도 nightly schedule TBD) |
-| 내부 dogfooding | 내부 직원 cohort 가 `YY.MM.DD-rc+BUILD_PR#` 빌드 사용 |
+| 내부 dogfooding | 내부 직원 cohort 가 `YY.MM.DD-rc+BUILD` 빌드 사용 |
 | Real-data 이슈 | RC 전용 Supabase branch (`rc-YYYY-Wxx`) |
 | 외부 의존성 동작 (실 결제, 실 메시지) | 내부 사용자가 실제로 사용해보며 검증 |
 

--- a/docs/infra/branch-strategy/specs/branch-spec.md
+++ b/docs/infra/branch-strategy/specs/branch-spec.md
@@ -160,7 +160,7 @@ Protected branch 에 대한 direct push 는 human 에게 허용하지 않는다.
 |------|----|
 | Actor | `minglit-release-bot` (GitHub App 권장, 대안: fine-grained PAT 전용 bot account) |
 | Token source | GitHub App installation token minted from `minglit_env/{stage}/github.env` (`MINGLIT_RELEASE_BOT_APP_ID` + `MINGLIT_RELEASE_BOT_PRIVATE_KEY_BASE64`) |
-| 사용 workflow | `dev-staging-dev-cut-gate`, `dev-staging-dev-cut`, `dev-rc-cut`, `rc-hotfix-apply`, `rc-main-cut`, `main-deploy` |
+| 사용 workflow | `dev-staging-dev-cut`, `dev-rc-cut`, `rc-hotfix-apply`, `rc-main-cut`, `main-deploy` |
 | Ruleset bypass | `dev-staging`, `dev`, `rc/**`, `main`, protected tag push (`v*`, `promo/**`) |
 | Human 사용 | 금지. 로컬/수동 CLI 에서 token 사용 금지 |
 | Audit | 모든 bot push 는 workflow run URL, actor, target ref, tag 목록을 PR/issue 또는 job summary 에 남김 |

--- a/docs/infra/branch-strategy/specs/execution-plan.md
+++ b/docs/infra/branch-strategy/specs/execution-plan.md
@@ -22,14 +22,14 @@
 | Spec workflow | 기존 매핑 | 작업 분류 |
 |---------------|----------|----------|
 | `pr-gate-core` (reusable) | `pr-gate` 의 step 들을 reusable workflow_call 로 추출 + stage parameter 추가 | **refactor** |
-| `version-bump` (reusable) | source-controlled dev-staging snapshot version bump | **refactor** |
+| `version-bump` (reusable) | legacy/building block for source-controlled version file changes. Active daily cut uses direct `scripts/bump-version.sh` inside `dev-staging-dev-cut` | **refactor** |
 | `shared-set-commit-status` | commit status write 공통 reusable | **신규** |
 | `set-dev-soak-status`, `set-rc-soak-status` | stage별 soak status write API (`workflow_call` + `workflow_dispatch`) | **신규** |
 | dev soak monitor/status model | 기존 `monitor-event-flow-*`, real-device workflow, AI agent signal 을 `dev-soak/*` commit status 로 통합 | **신규 (조합)** |
 | `auto-issue` (reusable) | (없음) | **신규** |
 | `cherry-pick-pr` (reusable) | (없음) | **신규** |
 | `dev-staging-pr-gate` | `pr-gate` 를 dev-staging base 로 재사용 (stage=dev-staging) | **신규 (얇은 wrapper)** |
-| `dev-staging-dev-cut-gate` | dev-staging post-merge version bump/tag orchestration | **신규 (조합)** |
+| `dev-staging-dev-cut-gate` | manual candidate inspect. No per-merge mutation | **신규 (경량)** |
 | `dev-staging-dev-cut` | (없음) | **신규** |
 | `dev-pr-gate` | `dev-staging-pr-gate` 와 동일 (stage=dev) | **신규 (얇은 wrapper)** |
 | `dev-rc-cut-gate` | 기존 `rc-gate` rename + `dev-rc-cut-pass` status set. full suite 는 후속 gate 확장 | **rename/refactor** |
@@ -72,7 +72,7 @@
 |------|------|------|
 | 2a | `pr-gate.yml` 단일 파일 유지하면서 내부 jobs 를 `workflow_call` 받게 변경 + stage parameter 추가. `pr-gate-core` 별도 파일 아님 | PR 흐름 동일, 내부 jobs reusable 化 |
 | 2b | stage 별 `extra_steps` 지원 (dev-staging / rc / main) | 기존 동작 동일 |
-| 2c | `version-bump` reusable extract | dev-staging snapshot bump caller 가 reusable 호출하게 변경 |
+| 2c | dev-staging cut-time version bump 정리 | `dev-staging-dev-cut` 이 daily cut 시점에 direct bump/tag 후 promote. per-merge version-bump PR 제거 |
 | 2d | `minglit-release-bot` 생성 + App ID/private key 등록 + workflow permission 최소화 | protected branch/tag push 를 human 대신 bot 으로 수행 |
 | 2e | `auto-issue` reusable 추가 | 신규 — 기존 영향 없음 |
 | 2f | **`ci-result` 폐기** — branch protection 의 required check 를 각 branch 의 `*-pr-gate` 로 변경 | `dev-staging` 부터 적용, dev/rc/main 은 해당 workflow 가 각 branch 에 도달한 뒤 적용 |

--- a/docs/infra/branch-strategy/specs/release-bot.md
+++ b/docs/infra/branch-strategy/specs/release-bot.md
@@ -84,8 +84,8 @@ git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 
 | Workflow | 사용 이유 |
 |----------|-----------|
-| `dev-staging-dev-cut-gate` | dev-staging version bump/tag |
-| `dev-staging-dev-cut` | immutable nightly branch 생성, dev PR 생성 |
+| `dev-staging-dev-cut-gate` | manual candidate inspect (read-only) |
+| `dev-staging-dev-cut` | dev-staging version bump/tag, immutable nightly branch 생성, dev PR 생성 |
 | `shared-set-commit-status` | commit status 를 쓰는 low-level reusable |
 | `set-dev-soak-status` | dev soak signal 을 `dev-soak/*` context 로 매핑 |
 | `set-rc-soak-status` | rc soak signal 을 `rc-soak/*` context 로 매핑 |

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -32,15 +32,15 @@
 
 ### `version-bump`
 
-`bump-version.sh` 실행 + commit. dev-staging 에서는 direct push 하지 않고 version-bump PR 안에서 사용한다.
+`bump-version.sh` 실행 + commit. 현재 active path 에서는 `dev-staging-dev-cut` 이 cut-time direct bump 로 수행하며, reusable 은 legacy/building block 으로 유지한다.
 
 | 항목 | 값 |
 |------|----|
 | Trigger | `workflow_call` |
-| Inputs | `version`: YY.MM.DD[-stage], optional `build_number`: version-bump PR number |
+| Inputs | `version`: YY.MM.DD[-stage], optional `build_number`: snapshot build number |
 | Outputs | `commit_sha`, `tag_name` |
 | 핵심 steps | `bash scripts/bump-version.sh {version} {build_number}` · commit |
-| Called by | `dev-staging-dev-cut-gate` |
+| Called by | legacy/manual bump flows. Active daily cut 은 `dev-staging-dev-cut` 내부에서 `scripts/bump-version.sh` 를 직접 실행 |
 
 `dev`/`rc`/`main` promotion 은 version bump commit 을 만들지 않는다. 앱/스토어/릴리즈 에셋에 노출되는 version 은 deploy workflow 가 `shared-version-metadata` 로 계산해 build command 에 주입한다.
 
@@ -52,11 +52,11 @@ Deploy artifact version metadata 를 계산하는 reusable workflow.
 |------|----|
 | Trigger | `workflow_call` |
 | Inputs | `channel`: dev\|rc\|main, `source-ref`: ref/SHA |
-| Outputs | `base_version`, `version_name`, `build_number`, `release_tag`, `release_name`, `pr_number`, `source_sha` |
-| 규칙 | `version_name = YY.MM.DD[-channel]`, `build_number = version-bump PR number` |
+| Outputs | `base_version`, `version_name`, `build_number`, `release_tag`, `release_name`, `snapshot_build`, `source_sha` (`pr_number` 는 backward-compatible alias) |
+| 규칙 | `version_name = YY.MM.DD[-channel]`, `build_number = dev-staging snapshot build number` |
 | Called by | `shared-android-deploy`, `shared-ios-deploy`, 후속 `rc-deploy` |
 
-source-ref 의 first-parent history 에서 latest version-bump squash commit 을 찾고, commit title/tag 에 포함된 version-bump PR number 를 build number 로 사용한다. source PR 번호는 release note/trace metadata 로만 사용한다.
+source-ref 의 first-parent history 에서 latest `vYY.MM.DD+BUILD-dev-staging` tag 또는 matching bump commit 을 찾고, `BUILD` 를 deploy build number 로 사용한다. source PR 번호는 release note/trace metadata 로만 사용한다.
 
 ### `shared-set-commit-status`
 
@@ -165,12 +165,12 @@ Cross-branch cherry-pick PR 자동 생성.
 
 | 항목 | 값 |
 |------|----|
-| Trigger | `push` to `dev-staging` (PR squash merge 후) |
-| Inputs | (from event) PR number, merged SHA |
-| Outputs | version-bump PR + tag `v{YY.MM.DD}+{BUILD_PR#}-dev-staging` after merge |
-| Steps | (1) skip generated bump/graphify commits (2) close stale open `version-bump/dev-staging/*` PRs (3) create version-bump PR from current snapshot (4) amend bump commit so Flutter build number equals that PR number (5) enable auto-merge (6) on bump PR merge, create dev-staging snapshot tag |
+| Trigger | `workflow_dispatch` |
+| Inputs | optional `candidate_ref` |
+| Outputs | candidate SHA + existing snapshot tag summary |
+| Steps | (1) fetch dev-staging/tags (2) resolve candidate (3) report whether candidate already has `v{YY.MM.DD}+{BUILD}-dev-staging` tag |
 
-`dev-staging-dev-cut-gate` 는 dev-staging merge 마다 실행되므로 cut tracking issue 를 만들지 않는다. 하루 1회 실제 promotion 을 만드는 `dev-staging-dev-cut` 이 tracking issue 를 `status/promoting` 으로 생성/갱신한다.
+`dev-staging-dev-cut-gate` 는 per-merge mutation 을 하지 않는다. 하루 1회 실제 promotion 을 만드는 `dev-staging-dev-cut` 이 version bump/tag, cut tracking issue, promotion PR 을 담당한다.
 
 ### dev-staging → dev
 
@@ -182,7 +182,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Inputs | optional `tag_name` (`v*-dev-staging`) |
 | Outputs | PR number (dev-staging → dev) or skip |
 | PR title | `ci(dev-staging-dev-cut): promote {tag_name} to dev` |
-| Steps | (1) 이전 `dev-staging-dev-cut` PR open 이면 skip + Slack (2) 가장 최근 `v*-dev-staging` tag SHA 조회, 또는 입력 `tag_name` 사용 (3) dev 가 그 SHA 를 이미 포함하면 skip ("no new commits") (4) `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` promotion branch 를 tag SHA 에서 생성 (5) cut tracking issue 를 `status/promoting` 으로 갱신 (6) `gh pr create` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}`) + issue close marker + auto-merge 활성화 (`rebase`, active dev ruleset 의 linear history 와 호환) |
+| Steps | (1) 이전 `dev-staging-dev-cut` PR open 이면 skip (2) 입력 `tag_name` 이 있으면 해당 tag 를 promote 대상으로 사용 (3) 입력이 없으면 `origin/dev-staging` HEAD 가 이미 dev 에 포함됐는지 확인 (4) HEAD 에 기존 snapshot tag 가 있으면 재사용 (5) tag 가 없으면 `YY.MM.DD-dev-staging` + `YYMMDDNN` build number 로 version bump commit 을 만들고 release bot 이 protected `dev-staging` 에 fast-forward push (6) 같은 commit 에 `vYY.MM.DD+YYMMDDNN-dev-staging` tag push (7) `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` promotion branch 를 tag SHA 에서 생성 (8) cut tracking issue 를 `status/promoting` 으로 갱신 (9) `gh pr create` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}`) + issue close marker + auto-merge 활성화 (`rebase`, active dev ruleset 의 linear history 와 호환) |
 
 #### `dev-pr-gate`
 
@@ -246,7 +246,7 @@ Cross-branch cherry-pick PR 자동 생성.
 
 #### RC hotfix post-merge behavior
 
-RC branch 에 version bump commit/tag 를 만들던 이전 설계. 최신 정책에서는 RC hotfix merge 후에도 branch state 를 바꾸지 않는다. RC deploy artifact version 은 `shared-version-metadata(channel=rc)` 가 latest version-bump PR number 로 계산한다.
+RC branch 에 version bump commit/tag 를 만들던 이전 설계. 최신 정책에서는 RC hotfix merge 후에도 branch state 를 바꾸지 않는다. RC deploy artifact version 은 `shared-version-metadata(channel=rc)` 가 latest dev-staging snapshot build number 로 계산한다.
 
 #### `rc-deploy`
 
@@ -320,8 +320,8 @@ RC branch 에 version bump commit/tag 를 만들던 이전 설계. 최신 정책
        ↓
 [dev-staging-pr-gate] ──auto-merge──▶ dev-staging push
                                                 ↓
-                                         [dev-staging-dev-cut-gate]
-                                                ↓ tag v{YY.MM.DD}+{BUILD_PR#}-dev-staging
+                                         [daily dev-staging-dev-cut]
+                                                ↓ direct bump + tag v{YY.MM.DD}+{BUILD}-dev-staging
 
 [daily KST 02:00]
     ↓
@@ -371,7 +371,7 @@ Promotion/deploy entry workflows support `workflow_dispatch` dry-run where mutat
 
 | Workflow | Dry-run behavior |
 |----------|------------------|
-| `dev-staging-dev-cut` | selects `v*-dev-staging`, computes cut branch, skips branch push/PR/auto-merge |
+| `dev-staging-dev-cut` | computes/reuses dev-staging snapshot tag, computes cut branch, skips version bump/tag/branch push/PR/auto-merge |
 | `dev-rc-cut-gate` | evaluates soak/run/status inputs, skips `dev-soak/*` and `dev-rc-cut-pass` status writes |
 | `dev-rc-cut` | selects source SHA/RC week, skips RC branch push/promo tag |
 | `rc-main-cut-gate` | selects RC branch and evaluates soak, skips `rc-main-cut-pass` status write |

--- a/docs/infra/branch-strategy/versioning.md
+++ b/docs/infra/branch-strategy/versioning.md
@@ -9,42 +9,42 @@
 | `YY` | 연도 2자리 | `26` |
 | `MM` | 월 2자리 | `05` |
 | `DD` | KST 기준 snapshot 날짜 | `27` |
-| `BUILD_PR#` | version-bump PR 번호 | `2832` |
+| `BUILD` | snapshot build number (`YYMMDDNN`) | `26060101` |
 
 - deploy artifact versionName: `YY.MM.DD[-channel]` — 예: `26.05.27-dev`, `26.05.27-rc`, `26.05.27`
-- mobile build number / Android versionCode: `BUILD_PR#` — 예: `2832`
-- full identity/tag: `vYY.MM.DD+BUILD_PR#[-channel]` — 예: `v26.05.27+2832-dev-staging`
+- mobile build number / Android versionCode: `BUILD` — 예: `26060101`
+- full identity/tag: `vYY.MM.DD+BUILD[-channel]` — 예: `v26.06.01+26060101-dev-staging`
 
-`BUILD_PR#` 는 source PR 번호가 아니라 **version-bump PR 번호**다. GitHub source PR 번호는 생성 순서라 merge 순서를 보장하지 않으므로 build number 로 쓰지 않는다.
+`BUILD` 는 PR 번호가 아니다. `dev-staging-dev-cut` 이 promote 하는 snapshot 기준으로 KST 날짜 `YYMMDD` + 같은 날짜 sequence `NN` 을 붙여 만든다. GitHub PR 번호는 생성 순서라 merge/promote 순서를 보장하지 않으므로 build number 로 쓰지 않는다.
 
 ## 단계별 채널 suffix
 
 | Stage | Suffix | 예시 |
 |-------|--------|------|
-| dev-staging source snapshot | `-dev-staging` | `26.05.27-dev-staging+2832` (Flutter), `26.05.27-dev-staging` (packages) |
-| dev artifact | `-dev` | `26.05.27-dev+2832` |
-| rc artifact | `-rc` | `26.05.27-rc+2832` |
-| main artifact | 없음 | `26.05.27+2832` |
+| dev-staging source snapshot | `-dev-staging` | `26.06.01-dev-staging+26060101` (Flutter), `26.06.01-dev-staging` (packages) |
+| dev artifact | `-dev` | `26.06.01-dev+26060101` |
+| rc artifact | `-rc` | `26.06.01-rc+26060101` |
+| main artifact | 없음 | `26.06.01+26060101` |
 
-**원칙**: 날짜는 snapshot 을 설명하고, build number 는 version-bump PR 을 설명한다. 포함된 source PR 목록과 snapshot SHA 는 version-bump PR body/tag 로 추적한다.
+**원칙**: 날짜와 build number 는 promote 된 snapshot 을 설명한다. 포함된 source PR 목록은 git first-parent history 와 promotion PR body, snapshot SHA 는 `v*-dev-staging` tag 로 추적한다.
 
 ## Version Bump 위치
 
 | Workflow | When | What |
 |----------|------|------|
-| `dev-staging-dev-cut-gate` | dev-staging PR 머지 직후 | version-bump PR 생성. PR 번호를 build number 로 사용하고 merge 후 `v{YY.MM.DD}+{BUILD_PR#}-dev-staging` tag |
-| `dev-staging-dev-cut` | daily snapshot 생성 시 | version 변경 없음 |
+| `dev-staging-dev-cut-gate` | 수동 점검 | active mutation 없음. candidate ref 의 snapshot tag 존재 여부만 inspect |
+| `dev-staging-dev-cut` | daily snapshot 생성 시 | protected `dev-staging` 에 release bot 이 직접 version bump commit 을 fast-forward push 하고 `v{YY.MM.DD}+{BUILD}-dev-staging` tag 생성 후 dev PR promote |
 | `dev-rc-cut` | RC 브랜치 생성 시 | version 변경 없음. `rc/YYYY-Wxx` branch + `promo/rc-YYYY-Wxx` tag 만 생성 |
-| RC hotfix merge | RC hotfix 머지 직후 | version 변경 없음. RC deploy metadata 가 latest version-bump PR number 를 사용 |
+| RC hotfix merge | RC hotfix 머지 직후 | version 변경 없음. RC deploy metadata 가 latest snapshot build number 를 사용 |
 | `main-deploy` | main push 직후 | version 변경 없음. deploy-time metadata + release asset/tag/marker 생성 |
 
-`dev-staging-dev-cut-gate` 는 protected branch 에 직접 bump commit 을 push 하지 않는다. version-bump PR 을 만들고 `dev-staging-pr-gate` + auto-merge 를 통과시킨다. `dev`/`rc`/`main` 에 자동 version commit 을 만들지 않는다.
+`dev-staging-dev-cut` 의 release-bot direct push 는 protected branch human direct push 금지의 유일한 source version bump 예외다. `dev`/`rc`/`main` 에 자동 version commit 을 만들지 않는다.
 
 ## Tag 컨벤션
 
 | Tag / Status | 시점 | 예시 | 부여자 |
 |--------------|------|------|--------|
-| `v{ver}+{build}-dev-staging` (tag) | version-bump PR merge 후 | `v26.05.27+2832-dev-staging` | workflow |
+| `v{ver}+{build}-dev-staging` (tag) | `dev-staging-dev-cut` version bump commit 직후 | `v26.06.01+26060101-dev-staging` | workflow |
 | `dev-rc-cut-pass` (commit status) | dev 머지 후 dev-rc-cut-gate green | (status only, tag 없음) | workflow |
 | `promo/rc-YYYY-Wxx` (tag) | dev-rc-cut 직후 | `promo/rc-2026-W20` | workflow |
 | `promo/main-YYYY-Wxx` (tag) | main 머지 직후 (동시) | `promo/main-2026-W20` | workflow |
@@ -63,12 +63,12 @@
 
 | 상태 | 의미 |
 |------|------|
-| `26.05.27-dev-staging+2832` | dev-staging source snapshot version/tag |
-| `26.05.27-dev+2832` | dev branch deploy artifact version |
-| `26.05.27-rc+2832` | rc branch deploy artifact version |
-| `26.05.27+2832` | main branch deploy artifact version |
+| `26.06.01-dev-staging+26060101` | dev-staging source snapshot version/tag |
+| `26.06.01-dev+26060101` | dev branch deploy artifact version |
+| `26.06.01-rc+26060101` | rc branch deploy artifact version |
+| `26.06.01+26060101` | main branch deploy artifact version |
 
-source-controlled `26.05.DD-dev-staging` 과 deploy artifact `26.05.DD[-channel]` 는 같은 snapshot date 를 공유한다. build number 는 version-bump PR number 로 고정된다.
+source-controlled `26.MM.DD-dev-staging` 과 deploy artifact `26.MM.DD[-channel]` 는 같은 snapshot date 를 공유한다. build number 는 snapshot tag 의 `BUILD` 로 고정된다.
 
 ## 버전 관리 제외 대상 (기존 유지)
 
@@ -79,7 +79,7 @@ source-controlled `26.05.DD-dev-staging` 과 deploy artifact `26.05.DD[-channel]
 ## 결정해야 할 것
 
 - `RELEASE.md` 작성 (tag regex single source)
-- Android Play Console 기존 versionCode 가 version-bump PR number 보다 큰 경우 migration rule
+- legacy PR-number build tag 에서 `YYMMDDNN` build number 로 넘어가는 transition monitoring
 
 ## 관련
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -66,8 +66,8 @@ if [ "$MM_DEC" -lt 1 ] || [ "$MM_DEC" -gt 12 ]; then
     exit 1
 fi
 
-# Calculate versionCode. New release automation passes the version-bump PR
-# number explicitly so mobile build numbers stay monotonic by bump PR order.
+# Calculate versionCode. Release automation may pass a cut-time snapshot build
+# number explicitly so mobile build numbers stay monotonic by promoted snapshot.
 if [ -n "$BUILD_NUMBER_INPUT" ]; then
     if ! [[ "$BUILD_NUMBER_INPUT" =~ ^[0-9]+$ ]] || [ "$((10#$BUILD_NUMBER_INPUT))" -lt 1 ]; then
         echo -e "${RED}Error: Invalid build_number: $BUILD_NUMBER_INPUT (must be >= 1)${NC}"

--- a/scripts/test-bump-version.sh
+++ b/scripts/test-bump-version.sh
@@ -130,6 +130,13 @@ bash "$BUMP_SCRIPT" 26.08.1 > /dev/null 2>&1
 if grep -q "version: 26.08.1+26080001" apps/app_user/pubspec.yaml; then assert_pass "versionCode 26080001 (month 08)"; else assert_fail "versionCode 26080001 (month 08)"; fi
 echo ""
 
+echo -e "${BLUE}TEST 3c: Explicit snapshot build number (26.06.01-dev-staging + 26060101)${NC}"
+setup_test_dir 3c
+bash "$BUMP_SCRIPT" 26.06.01-dev-staging 26060101 > /dev/null 2>&1
+if grep -q "version: 26.06.01-dev-staging+26060101" apps/app_user/pubspec.yaml; then assert_pass "explicit snapshot build number"; else assert_fail "explicit snapshot build number"; fi
+if grep -q '"version": "26.06.01-dev-staging"' package.json; then assert_pass "root dev-staging snapshot version"; else assert_fail "root dev-staging snapshot version"; fi
+echo ""
+
 echo -e "${BLUE}TEST 4: Invalid input rejection - wrong format (1.0.0)${NC}"
 setup_test_dir 4
 if bash "$BUMP_SCRIPT" 1.0.0 > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- move dev-staging source version bump/tagging from per-merge cut-gate into daily dev-staging-dev-cut
- replace version-bump PR build numbers with cut-time snapshot build numbers (YYMMDDNN)
- update branch-strategy/workflow docs and deploy metadata compatibility

## Verification
- python3 .github/scripts/check-android-deploy-workflow-contract.py
- bash scripts/test-bump-version.sh
- YAML parse check for modified workflows

No graphify manual update: graphify sync is handled by workflow on dev-staging.

No linked issue: branch-strategy workflow cleanup requested directly in chat; no GitHub issue exists.
