### PR TITLE
ci(ios): extend deploy archive timeout

### DIFF
--- a/.github/actions/ios-deploy/action.yml
+++ b/.github/actions/ios-deploy/action.yml
@@ -267,7 +267,33 @@ runs:
       shell: bash
       working-directory: ./${{ inputs.app-directory }}
       run: |
-        flutter build ipa --release --export-options-plist=ios/ExportOptions-dev.plist \
+        run_with_heartbeat() {
+          "$@" &
+          build_pid=$!
+          (
+            elapsed=0
+            while kill -0 "$build_pid" 2>/dev/null; do
+              sleep 300
+              elapsed=$((elapsed + 300))
+              if kill -0 "$build_pid" 2>/dev/null; then
+                echo "::notice::flutter build ipa still running after ${elapsed}s"
+              fi
+            done
+          ) &
+          heartbeat_pid=$!
+          trap 'kill "$build_pid" "$heartbeat_pid" 2>/dev/null || true' EXIT
+          if wait "$build_pid"; then
+            status=0
+          else
+            status=$?
+          fi
+          kill "$heartbeat_pid" 2>/dev/null || true
+          wait "$heartbeat_pid" 2>/dev/null || true
+          trap - EXIT
+          return "$status"
+        }
+
+        run_with_heartbeat flutter build ipa --release --export-options-plist=ios/ExportOptions-dev.plist \
           --build-name=${{ inputs['build-name'] }} \
           --build-number=${{ inputs['build-number'] }} \
           --dart-define=APP_VERSION=${{ inputs['display-version'] }} \
@@ -286,7 +312,33 @@ runs:
       shell: bash
       working-directory: ./${{ inputs.app-directory }}
       run: |
-        flutter build ipa --release --export-options-plist=ios/ExportOptions.plist \
+        run_with_heartbeat() {
+          "$@" &
+          build_pid=$!
+          (
+            elapsed=0
+            while kill -0 "$build_pid" 2>/dev/null; do
+              sleep 300
+              elapsed=$((elapsed + 300))
+              if kill -0 "$build_pid" 2>/dev/null; then
+                echo "::notice::flutter build ipa still running after ${elapsed}s"
+              fi
+            done
+          ) &
+          heartbeat_pid=$!
+          trap 'kill "$build_pid" "$heartbeat_pid" 2>/dev/null || true' EXIT
+          if wait "$build_pid"; then
+            status=0
+          else
+            status=$?
+          fi
+          kill "$heartbeat_pid" 2>/dev/null || true
+          wait "$heartbeat_pid" 2>/dev/null || true
+          trap - EXIT
+          return "$status"
+        }
+
+        run_with_heartbeat flutter build ipa --release --export-options-plist=ios/ExportOptions.plist \
           --build-name=${{ inputs['build-name'] }} \
           --build-number=${{ inputs['build-number'] }} \
           --dart-define=APP_VERSION=${{ inputs['display-version'] }} \

--- a/.github/scripts/check-ios-deploy-branch-conditions.sh
+++ b/.github/scripts/check-ios-deploy-branch-conditions.sh
@@ -18,14 +18,14 @@ require_file "$WORKFLOW_FILE"
 count_matches() {
   local pattern="$1"
   local file="$2"
-  (rg -n "$pattern" "$file" || true) | wc -l | tr -d ' '
+  (grep -nE "$pattern" "$file" || true) | wc -l | tr -d ' '
 }
 
 # Regression guard: dev-staging (and any non-main branch) must go through
 # development build/signing path, not be silently skipped.
-if rg -n "refs/heads/dev" "$ACTION_FILE" >/dev/null; then
+if grep -nE "refs/heads/dev" "$ACTION_FILE" >/dev/null; then
   echo "ERROR: Found legacy refs/heads/dev checks in $ACTION_FILE"
-  rg -n "refs/heads/dev" "$ACTION_FILE"
+  grep -nE "refs/heads/dev" "$ACTION_FILE"
   exit 1
 fi
 
@@ -35,13 +35,13 @@ required_patterns=(
 )
 
 for pattern in "${required_patterns[@]}"; do
-  if ! rg -F "$pattern" "$ACTION_FILE" >/dev/null; then
+  if ! grep -nF "$pattern" "$ACTION_FILE" >/dev/null; then
     echo "ERROR: Missing required branch condition pattern: $pattern"
     exit 1
   fi
 done
 
-timeout_minutes="$( (rg -n "^[[:space:]]*timeout-minutes:[[:space:]]*[0-9]+" "$WORKFLOW_FILE" || true) \
+timeout_minutes="$( (grep -nE "^[[:space:]]*timeout-minutes:[[:space:]]*[0-9]+" "$WORKFLOW_FILE" || true) \
   | head -n1 \
   | sed -E 's/.*timeout-minutes:[[:space:]]*([0-9]+).*/\1/')"
 
@@ -78,7 +78,7 @@ fi
 
 if (( direct_build_invocation_count > 0 )); then
   echo "ERROR: Direct 'flutter build ipa --release' invocation detected; use run_with_heartbeat wrapper"
-  rg -n "^[[:space:]]*flutter build ipa --release" "$ACTION_FILE"
+  grep -nE "^[[:space:]]*flutter build ipa --release" "$ACTION_FILE"
   exit 1
 fi
 

--- a/.github/scripts/check-ios-deploy-branch-conditions.sh
+++ b/.github/scripts/check-ios-deploy-branch-conditions.sh
@@ -2,11 +2,24 @@
 set -euo pipefail
 
 ACTION_FILE=".github/actions/ios-deploy/action.yml"
+WORKFLOW_FILE=".github/workflows/shared-ios-deploy.yml"
 
-if [[ ! -f "$ACTION_FILE" ]]; then
-  echo "ERROR: Missing $ACTION_FILE"
-  exit 1
-fi
+require_file() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo "ERROR: Missing $file"
+    exit 1
+  fi
+}
+
+require_file "$ACTION_FILE"
+require_file "$WORKFLOW_FILE"
+
+count_matches() {
+  local pattern="$1"
+  local file="$2"
+  (rg -n "$pattern" "$file" || true) | wc -l | tr -d ' '
+}
 
 # Regression guard: dev-staging (and any non-main branch) must go through
 # development build/signing path, not be silently skipped.
@@ -28,4 +41,45 @@ for pattern in "${required_patterns[@]}"; do
   fi
 done
 
-echo "OK: iOS deploy branch conditions validated (main vs non-main)"
+timeout_minutes="$( (rg -n "^[[:space:]]*timeout-minutes:[[:space:]]*[0-9]+" "$WORKFLOW_FILE" || true) \
+  | head -n1 \
+  | sed -E 's/.*timeout-minutes:[[:space:]]*([0-9]+).*/\1/')"
+
+if [[ -z "$timeout_minutes" ]]; then
+  echo "ERROR: Could not detect timeout-minutes in $WORKFLOW_FILE"
+  exit 1
+fi
+
+if (( timeout_minutes < 120 )); then
+  echo "ERROR: shared-ios-deploy timeout-minutes must be >= 120 (found: $timeout_minutes)"
+  exit 1
+fi
+
+heartbeat_wrapper_count="$(count_matches "run_with_heartbeat\\(\\)" "$ACTION_FILE")"
+heartbeat_invocation_count="$(count_matches "run_with_heartbeat flutter build ipa --release" "$ACTION_FILE")"
+wait_capture_count="$(count_matches 'if wait "\$build_pid"; then' "$ACTION_FILE")"
+status_return_count="$(count_matches 'return "\$status"' "$ACTION_FILE")"
+direct_build_invocation_count="$(count_matches "^[[:space:]]*flutter build ipa --release" "$ACTION_FILE")"
+
+if (( heartbeat_wrapper_count < 2 )); then
+  echo "ERROR: Expected heartbeat wrapper in both dev/main build steps (found: $heartbeat_wrapper_count)"
+  exit 1
+fi
+
+if (( heartbeat_invocation_count < 2 )); then
+  echo "ERROR: Expected run_with_heartbeat flutter build ipa in both dev/main build steps (found: $heartbeat_invocation_count)"
+  exit 1
+fi
+
+if (( wait_capture_count < 2 )) || (( status_return_count < 2 )); then
+  echo "ERROR: Heartbeat wrapper must preserve flutter build exit code via wait/return (wait: $wait_capture_count, return: $status_return_count)"
+  exit 1
+fi
+
+if (( direct_build_invocation_count > 0 )); then
+  echo "ERROR: Direct 'flutter build ipa --release' invocation detected; use run_with_heartbeat wrapper"
+  rg -n "^[[:space:]]*flutter build ipa --release" "$ACTION_FILE"
+  exit 1
+fi
+
+echo "OK: iOS deploy workflow contract validated (branch, timeout, heartbeat, exit-code)"

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -123,6 +123,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: python3 .github/scripts/check-dev-cut-workflow-contract.py
 
+      - name: Check iOS deploy workflow contract
+        if: ${{ !cancelled() }}
+        run: bash .github/scripts/check-ios-deploy-branch-conditions.sh
+
       - name: Verify androidx.test runner/orchestrator version alignment
         if: ${{ !cancelled() }}
         # Fix #1780: runner와 orchestrator는 동일 major.minor 계열이어야 함 — Gradle

--- a/.github/workflows/shared-ios-deploy.yml
+++ b/.github/workflows/shared-ios-deploy.yml
@@ -80,7 +80,7 @@ jobs:
   ios-deploy:
     needs: [version]
     runs-on: macos-15  # Fix #2371: connectivity_plus 7.1.1 requires iOS 18 SDK / Xcode 16+.
-    timeout-minutes: 60
+    timeout-minutes: 120
     environment: ${{ inputs.deploy-stage == 'main' && 'production' || 'preview' }}
     permissions:
       contents: read


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## Summary
- increase the shared iOS deploy job timeout from 60 to 120 minutes
- wrap `flutter build ipa` in a lightweight 5-minute heartbeat for both dev and main IPA builds
- preserve the underlying build exit code so real Xcode/Flutter failures still fail the job

## Why
Run 26754986127 cancelled both iOS deploy jobs while web and Android succeeded. The User and Partner logs both passed signing/provisioning/CocoaPods and then sat in `flutter build ipa` / Xcode archive until the 60-minute job timeout cancelled them.

Fixes #2962.
Fixes #2963.
Fixes #2964.

## Verification
- `git diff --check`
- `bash .github/scripts/check-ios-deploy-branch-conditions.sh`
- `node` YAML parse for `.github/workflows/shared-ios-deploy.yml` and `.github/actions/ios-deploy/action.yml`
- `bash -n` syntax check for the heartbeat helper body
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`

## Residual Risk
- If Xcode archive is truly hung or now exceeds 120 minutes, the next deploy will still fail, but the heartbeat will make the long-running phase explicit in logs.
- This does not optimize iOS archive performance; it only removes the current too-short job timeout and improves observability.

No UI changes.