### PR TITLE
fix(payment): sync purchase history card with MDS v1.3

### DIFF
--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
@@ -58,8 +58,23 @@ class PurchaseHistoryCard extends StatelessWidget {
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
                 ),
-                // Fix #638: StatusBadge를 공용 위젯으로 승격하여 재사용
-                StatusBadge(status: application.status),
+                Row(
+                  children: [
+                    Text(
+                      '상세 보기',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(width: MinglitSpacing.xxsmall),
+                    Icon(
+                      Icons.chevron_right,
+                      size: 14,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ],
+                ),
               ],
             ),
             const SizedBox(height: MinglitSpacing.medium),
@@ -86,6 +101,10 @@ class PurchaseHistoryCard extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      // Fix #2952: v1.3 spec - status badge belongs above title
+                      // within the info row, not in the header trailing slot.
+                      StatusBadge(status: application.status),
+                      const SizedBox(height: MinglitSpacing.xxsmall),
                       Text(
                         eventName,
                         style: theme.textTheme.titleMedium?.copyWith(

--- a/apps/app_user/test/src/features/payment/ui/purchase_history_card_test.dart
+++ b/apps/app_user/test/src/features/payment/ui/purchase_history_card_test.dart
@@ -237,5 +237,57 @@ void main() {
       expect(find.text('문의하기'), findsNothing);
       expect(find.text('예매 취소'), findsNothing);
     });
+
+    testWidgets('카드 헤더에 상세 보기 affordance를 노출하고 상태 배지는 info row에서 유지한다', (
+      tester,
+    ) async {
+      final mockHistory = [
+        EventApplication(
+          id: 'app3',
+          eventId: 'event3',
+          ticketId: 'ticket3',
+          userId: 'user1',
+          status: 'paid',
+          paymentAmount: 42000,
+          paidAt: DateTime(2026, 4, 2),
+          createdAt: DateTime(2026, 4, 2),
+          updatedAt: DateTime(2026, 4, 2),
+          event: Event(
+            id: 'event3',
+            partyId: 'party3',
+            startTime: DateTime(2030, 5, 3, 20),
+            endTime: DateTime(2030, 5, 3, 22),
+            createdAt: DateTime(2026, 4, 2),
+            updatedAt: DateTime(2026, 4, 2),
+            title: 'Spec v1.3 Event',
+          ),
+          ticket: Ticket(
+            id: 'ticket3',
+            name: '프리미엄 티켓',
+            createdAt: DateTime(2026, 4, 2),
+            updatedAt: DateTime(2026, 4, 2),
+          ),
+        ),
+      ];
+
+      when(
+        () => mockEventRepository.getMyPurchaseHistory('user1'),
+      ).thenAnswer((_) async => mockHistory);
+
+      await tester.pumpWidget(
+        createTestWidget([
+          currentUserProvider.overrideWith((ref) => mockUser),
+          eventRepositoryProvider.overrideWithValue(mockEventRepository),
+        ]),
+      );
+
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('상세 보기'), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+      expect(find.text('결제완료'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- `PurchaseHistoryCard`를 MDS `purchase_history_page` v1.3 레이아웃에 맞게 조정했습니다.
  - 헤더 우측을 `StatusBadge`에서 `상세 보기 + chevron` affordance로 변경
  - `StatusBadge`를 info row(썸네일 오른쪽 텍스트 컬럼) 상단으로 이동
- 회귀 테스트에 새 assertion을 추가해 `상세 보기` affordance와 상태 배지 노출을 검증했습니다.
- 이번 mds-change 범위 중 `event_matching_results_screen`은 현재 `MatchResultsContent` 구현/테스트가 핵심 계약(연락처 전체 노출, single/multi 분기, 저장 CTA)에 부합해 코드 변경 없이 유지했습니다.

## Why
- Closes #2952

## Design Spec Citations (UI Gate)
- 화면 spec: `apps/mds/docs/public/specs/purchase_history_page/index.html`
  - `Layout > Blueprint & tree` 섹션의 `PurchaseHistoryCard` 구조
  - `PurchaseHistoryCard sub-anatomy` 섹션의
    - `1. Header (date · 상세 보기)`
    - `2. Info row (...) StatusBadge ... title 위`
- 컴포넌트 spec: `apps/mds/docs/src/lib/components.ts`
  - `StatusBadge`(MinglitBadge 기반 status 요약 배지) 사용 계약

## Verification
- `flutter test test/src/features/payment/ui/purchase_history_card_test.dart test/src/common/widgets/match_results_content_test.dart`
