### PR TITLE
fix(ci): exempt app/dependabot in PR issue-reference check

### DIFF
--- a/.github/scripts/check-pr-issue-reference.sh
+++ b/.github/scripts/check-pr-issue-reference.sh
@@ -34,7 +34,7 @@ title=$(jq -r '.pull_request.title // ""' "$GITHUB_EVENT_PATH")
 body=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
 
 case "$author" in
-  dependabot[bot]|minglit-release-bot[bot])
+  dependabot[bot]|app/dependabot|minglit-release-bot[bot])
     echo "Bot-authored PR by $author; skipping PR issue reference check."
     exit 0
     ;;


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## What
- Extend `check-pr-issue-reference.sh` bot exemption to include `app/dependabot` author format.

## Why
- Dependabot PRs in this repository are authored as `app/dependabot`, which was not covered by the existing exemption and caused false CI failures in `pr-gate-core / static-checks`.

## Verification
- Ran the script locally with a mock pull_request payload authored by `app/dependabot`; it exits successfully with the bot-skip message.

No linked issue: CI guardrail false positive fix for automated dependency PRs; handled as direct maintenance patch.
