### PR TITLE
ci(branch): switch promotions to merge commits

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -12,9 +12,9 @@
 | [`check-bluedoc-freshness.sh`](./check-bluedoc-freshness.sh) | PR 에서 새/삭제 파일에 대해 가장 가까운 ancestor BLUEDOC.md 갱신 강제. 통과: 이정표 표 갱신 또는 BLUEDOC 의 `_Reviewed_` 날짜 bump. + 모든 BLUEDOC.md 의 Reviewed 형식 검증 | `pr-gate.check-bluedoc-freshness` (required check) |
 | [`check-pr-issue-reference.sh`](./check-pr-issue-reference.sh) | dev-staging PR 본문에 이슈 종료 의도(`Closes/Fixes/Resolves`) 또는 명시적 비종료 사유(`Refs` + 이유 / `No linked issue`)가 있는지 검사 | `pr-gate.static-checks` |
 | [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | `ios-deploy` action 의 브랜치 분기(`main` vs `non-main`) 회귀 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
-| [`check-android-deploy-workflow-contract.py`](./check-android-deploy-workflow-contract.py) | Android deploy release archive 가 `github.token` + `contents: write` 를 사용하고 PAT caller 계약을 요구하지 않는지 검증 | `pr-gate.static-checks` |
+| [`check-android-deploy-workflow-contract.py`](./check-android-deploy-workflow-contract.py) | Android deploy release archive token 계약 + merge promotion 뒤 snapshot metadata 탐색 회귀 검증 | `pr-gate.static-checks` |
 | [`check-dev-soak-workflow-contract.py`](./check-dev-soak-workflow-contract.py) | dev event-flow cron install + `dev-rc-cut-gate` + `shared-soak-gate` 판정 계약 검증 | `pr-gate.static-checks` |
-| [`check-dev-cut-workflow-contract.py`](./check-dev-cut-workflow-contract.py) | `dev-staging-dev-cut` 의 full-history checkout(`fetch-depth: 0`)과 `shared-notify` 의 `gh run view --repo` 컨텍스트 계약을 검증 | `pr-gate.static-checks` |
+| [`check-dev-cut-workflow-contract.py`](./check-dev-cut-workflow-contract.py) | promotion cut workflow 의 full-history checkout, merge auto-merge mode, `shared-notify` repo 컨텍스트 계약 검증 | `pr-gate.static-checks` |
 | [`check-ios-connectivity-plus-cap.sh`](./check-ios-connectivity-plus-cap.sh) | iOS deploy runner 가 지원할 때까지 `connectivity_plus <7.1.0` resolution 강제 | `pr-gate.guard-ios-connectivity-plus-cap` |
 | [`scan-build-artifact-secrets.py`](./scan-build-artifact-secrets.py) | APK/AAB/`.next` 등 빌드 산출물에서 Supabase service-role secret 패턴을 redacted summary 로 검사 | `pr-gate.scan-build-artifact-secrets` |
 | [`install-dev-event-flow-cron.sh`](./install-dev-event-flow-cron.sh) | dev Supabase `dev-event-flow-simulator` pg_cron 설치/검증 | `deploy-dev-event-flow-cron` |
@@ -34,4 +34,4 @@
 - [.github/BLUEDOC.md](../BLUEDOC.md) — 상위 진입점
 
 ---
-_Reviewed: 2026-05-26 04:47_
+_Reviewed: 2026-06-03 12:18_

--- a/.github/scripts/check-android-deploy-workflow-contract.py
+++ b/.github/scripts/check-android-deploy-workflow-contract.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +36,23 @@ def load_workflow(path: Path) -> dict[str, Any]:
     return data
 
 
+def run_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
 def workflow_call_config(workflow: dict[str, Any]) -> dict[str, Any]:
     # PyYAML 1.1 treats the plain scalar key "on" as boolean True.
     on_config = workflow.get("on", workflow.get(True, {}))
@@ -42,6 +62,25 @@ def workflow_call_config(workflow: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(workflow_call, dict):
         fail("workflow_call block did not parse as a mapping")
     return workflow_call
+
+
+def shared_version_metadata_script() -> str:
+    workflow = load_workflow(SHARED_VERSION_METADATA)
+    jobs = workflow.get("jobs", {})
+    metadata = jobs.get("metadata", {}) if isinstance(jobs, dict) else {}
+    steps = metadata.get("steps", []) if isinstance(metadata, dict) else []
+    if not isinstance(steps, list):
+        fail("shared-version-metadata steps did not parse as a list")
+
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        if step.get("name") == "Compute version metadata":
+            run = step.get("run", "")
+            if isinstance(run, str):
+                return run
+
+    fail("shared-version-metadata is missing 'Compute version metadata' run script")
 
 
 def assert_no_gh_pat_secret_contract(workflow: dict[str, Any], path: Path) -> None:
@@ -101,25 +140,7 @@ def assert_android_callers_do_not_pass_pat() -> None:
 
 
 def assert_main_build_number_monotonic_contract() -> None:
-    workflow = load_workflow(SHARED_VERSION_METADATA)
-    jobs = workflow.get("jobs", {})
-    metadata = jobs.get("metadata", {}) if isinstance(jobs, dict) else {}
-    steps = metadata.get("steps", []) if isinstance(metadata, dict) else []
-    if not isinstance(steps, list):
-        fail("shared-version-metadata steps did not parse as a list")
-
-    script = ""
-    for step in steps:
-        if not isinstance(step, dict):
-            continue
-        if step.get("name") == "Compute version metadata":
-            run = step.get("run", "")
-            if isinstance(run, str):
-                script = run
-            break
-
-    if not script:
-        fail("shared-version-metadata is missing 'Compute version metadata' run script")
+    script = shared_version_metadata_script()
 
     required_snippets = [
         "if [ \"${CHANNEL}\" = \"main\" ]; then",
@@ -138,10 +159,81 @@ def assert_main_build_number_monotonic_contract() -> None:
             )
 
 
+def assert_version_metadata_merge_parent_snapshot_contract() -> None:
+    script = shared_version_metadata_script()
+
+    with tempfile.TemporaryDirectory(prefix="minglit-version-metadata-") as tmp:
+        repo = Path(tmp) / "repo"
+        repo.mkdir()
+
+        def git(*args: str) -> str:
+            result = run_command(["git", *args], cwd=repo)
+            return result.stdout.strip()
+
+        git("init")
+        git("config", "user.email", "ci@example.invalid")
+        git("config", "user.name", "CI")
+        git("checkout", "-b", "dev")
+
+        (repo / "package.json").write_text('{"version":"26.06.03-dev-staging"}\n')
+        git("add", "package.json")
+        git("commit", "-m", "chore: initialize version metadata test")
+
+        git("checkout", "-b", "cut/dev-staging-dev/test")
+        (repo / "snapshot.txt").write_text("snapshot\n")
+        git("add", "snapshot.txt")
+        git("commit", "-m", "chore: bump version to v26.06.03+26060301-dev-staging")
+        snapshot_sha = git("rev-parse", "HEAD")
+        git("tag", "v26.06.03+26060301-dev-staging")
+
+        git("checkout", "dev")
+        (repo / "dev.txt").write_text("first-parent-only commit\n")
+        git("add", "dev.txt")
+        git("commit", "-m", "chore: dev first-parent commit without snapshot tag")
+        git("merge", "--no-ff", "cut/dev-staging-dev/test", "-m", "Merge promotion snapshot")
+        source_sha = git("rev-parse", "HEAD")
+        git("remote", "add", "origin", str(repo))
+
+        output_path = repo / "github-output.txt"
+        summary_path = repo / "github-summary.md"
+        env = os.environ.copy()
+        env.update(
+            {
+                "CHANNEL": "dev",
+                "SOURCE_REF": "HEAD",
+                "GITHUB_OUTPUT": str(output_path),
+                "GITHUB_STEP_SUMMARY": str(summary_path),
+                "GITHUB_REPOSITORY": "local/minglit",
+                "GH_TOKEN": "dummy-token",
+            }
+        )
+        run_command(["bash", "-c", script], cwd=repo, env=env)
+
+        outputs = dict(
+            line.split("=", 1)
+            for line in output_path.read_text(encoding="utf-8").splitlines()
+            if "=" in line
+        )
+        if outputs.get("source_sha") != source_sha:
+            fail("shared-version-metadata test did not inspect the merge commit source SHA")
+        if outputs.get("snapshot_build") != "26060301":
+            fail(
+                "shared-version-metadata must find v*-dev-staging snapshot tags "
+                "reachable through a promotion merge parent"
+            )
+        if outputs.get("build_number") != "26060301":
+            fail("shared-version-metadata must use snapshot build as dev build_number")
+
+        summary = summary_path.read_text(encoding="utf-8")
+        if f"| revision_sha | {snapshot_sha} |" not in summary:
+            fail("shared-version-metadata summary must report the snapshot revision SHA")
+
+
 def main() -> None:
     assert_shared_android_deploy_contract()
     assert_android_callers_do_not_pass_pat()
     assert_main_build_number_monotonic_contract()
+    assert_version_metadata_merge_parent_snapshot_contract()
     print("Android deploy release archive workflow contract OK")
 
 

--- a/.github/scripts/check-dev-cut-workflow-contract.py
+++ b/.github/scripts/check-dev-cut-workflow-contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate dev-staging-dev-cut and shared-notify workflow contracts."""
+"""Validate branch promotion and shared-notify workflow contracts."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 DEV_STAGING_DEV_CUT = ROOT / ".github/workflows/dev-staging-dev-cut.yml"
+RC_MAIN_CUT = ROOT / ".github/workflows/rc-main-cut.yml"
 SHARED_NOTIFY = ROOT / ".github/workflows/shared-notify.yml"
 
 
@@ -33,6 +34,28 @@ def jobs_config(workflow: dict[str, Any], path: Path) -> dict[str, Any]:
     if not isinstance(jobs, dict):
         fail(f"{path} jobs block did not parse as a mapping")
     return jobs
+
+
+def named_step_run(path: Path, job_name: str, step_name: str) -> str:
+    workflow = load_workflow(path)
+    jobs = jobs_config(workflow, path)
+    job = jobs.get(job_name, {})
+    if not isinstance(job, dict):
+        fail(f"{path} must define {job_name} job")
+
+    steps = job.get("steps", [])
+    if not isinstance(steps, list):
+        fail(f"{path} {job_name} steps did not parse as a list")
+
+    for step in steps:
+        if not isinstance(step, dict) or step.get("name") != step_name:
+            continue
+        run = step.get("run", "")
+        if not isinstance(run, str) or not run.strip():
+            fail(f"{path} step '{step_name}' must define a run script")
+        return run
+
+    fail(f"{path} {job_name} is missing step '{step_name}'")
 
 
 def assert_dev_staging_dev_cut_contract() -> None:
@@ -61,6 +84,39 @@ def assert_dev_staging_dev_cut_contract() -> None:
         fail("dev-staging-dev-cut checkout fetch-depth must be 0")
 
 
+def assert_promotion_auto_merge_mode_contract() -> None:
+    promotion_steps = [
+        (
+            DEV_STAGING_DEV_CUT,
+            "create-dev-cut-pr",
+            "Create dev promotion PR and enable auto-merge",
+        ),
+        (
+            RC_MAIN_CUT,
+            "create-main-pr",
+            "Create main promotion PR and enable auto-merge",
+        ),
+    ]
+
+    for path, job_name, step_name in promotion_steps:
+        run = named_step_run(path, job_name, step_name)
+        merge_commands = [
+            " ".join(line.strip().split())
+            for line in run.splitlines()
+            if line.strip().startswith("gh pr merge ")
+        ]
+        if len(merge_commands) != 1:
+            fail(f"{path} must contain exactly one gh pr merge command in '{step_name}'")
+
+        command = merge_commands[0]
+        if "--auto" not in command:
+            fail(f"{path} promotion auto-merge command must include --auto")
+        if "--merge" not in command:
+            fail(f"{path} promotion auto-merge command must use --merge")
+        if "--rebase" in command:
+            fail(f"{path} promotion auto-merge command must not use --rebase")
+
+
 def assert_shared_notify_contract() -> None:
     text = SHARED_NOTIFY.read_text(encoding="utf-8")
     expected = 'gh run view "${GITHUB_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --log-failed'
@@ -70,6 +126,7 @@ def assert_shared_notify_contract() -> None:
 
 def main() -> None:
     assert_dev_staging_dev_cut_contract()
+    assert_promotion_auto_merge_mode_contract()
     assert_shared_notify_contract()
     print("Dev cut workflow contract OK")
 

--- a/.github/workflows/dev-staging-dev-cut.yml
+++ b/.github/workflows/dev-staging-dev-cut.yml
@@ -249,7 +249,7 @@ jobs:
           - Target branch: dev
           - Deploy after merge: dev-deploy on push to dev
           ${CUT_ISSUE_LINE}
-          - Merge mode: rebase, because the active dev ruleset requires linear history.
+          - Merge mode: merge commit, preserving the dev-staging snapshot ancestry in dev.
 
           ${CUT_ISSUE_CLOSER}
 
@@ -264,7 +264,7 @@ jobs:
             --body "${BODY}")"
           PR_NUMBER="${PR_URL##*/}"
 
-          gh pr merge "${PR_NUMBER}" --auto --rebase --delete-branch
+          gh pr merge "${PR_NUMBER}" --auto --merge --delete-branch
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Dry run summary

--- a/.github/workflows/rc-main-cut.yml
+++ b/.github/workflows/rc-main-cut.yml
@@ -177,7 +177,7 @@ jobs:
           - Source branch: ${RC_BRANCH}
           - Source SHA: ${RC_SHA}
           - Required marker: rc-main-cut-pass
-          - Merge mode: rebase, because main requires linear history.
+          - Merge mode: merge commit, preserving the RC ancestry in main.
 
           ${CUT_ISSUE_CLOSER}
 
@@ -193,7 +193,7 @@ jobs:
             --label rc-main-cut-pass)"
           PR_NUMBER="${PR_URL##*/}"
 
-          gh pr merge "${PR_NUMBER}" --auto --rebase --delete-branch
+          gh pr merge "${PR_NUMBER}" --auto --merge --delete-branch
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Dry run summary

--- a/.github/workflows/shared-version-metadata.yml
+++ b/.github/workflows/shared-version-metadata.yml
@@ -87,31 +87,34 @@ jobs:
           REVISION_SHA=""
           git fetch --tags --force
 
-          for sha in $(git rev-list --first-parent -n 80 HEAD); do
-            candidate="$(git tag --points-at "${sha}" \
-              | sed -nE 's/^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}\+([0-9]+)-dev-staging$/\1/p' \
-              | sort -n \
-              | tail -n 1)"
+          SNAPSHOT_SEARCH_LIMIT=300
+          update_snapshot_build() {
+            local candidate="$1"
+            local revision_sha="$2"
             if [[ "${candidate}" =~ ^[0-9]+$ ]]; then
-              SNAPSHOT_BUILD="${candidate}"
-              REVISION_SHA="${sha}"
-              break
+              if [ -z "${SNAPSHOT_BUILD}" ] || [ "$((10#${candidate}))" -gt "$((10#${SNAPSHOT_BUILD}))" ]; then
+                SNAPSHOT_BUILD="${candidate}"
+                REVISION_SHA="${revision_sha}"
+              fi
             fi
+          }
+
+          for sha in $(git rev-list -n "${SNAPSHOT_SEARCH_LIMIT}" HEAD); do
+            while read -r candidate; do
+              [ -n "${candidate}" ] || continue
+              update_snapshot_build "${candidate}" "${sha}"
+            done < <(git tag --points-at "${sha}" \
+              | sed -nE 's/^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}\+([0-9]+)-dev-staging$/\1/p')
 
             message="$(git log -1 --format=%B "${sha}")"
             candidate="$(printf '%s\n' "${message}" | sed -nE 's/.*chore: bump version to v[0-9]{2}\.[0-9]{2}\.[0-9]{2}\+([0-9]+)-dev-staging.*/\1/p' | head -n 1)"
-
-            if [[ "${candidate}" =~ ^[0-9]+$ ]]; then
-              SNAPSHOT_BUILD="${candidate}"
-              REVISION_SHA="${sha}"
-              break
-            fi
+            update_snapshot_build "${candidate}" "${sha}"
           done
 
           # Backward compatibility for builds cut before snapshot build numbers
           # were embedded in tags or bump commit titles.
           if [ -z "${SNAPSHOT_BUILD}" ]; then
-            for sha in $(git rev-list --first-parent -n 80 HEAD); do
+            for sha in $(git rev-list -n "${SNAPSHOT_SEARCH_LIMIT}" HEAD); do
               candidate="$(gh api \
                 "repos/${GITHUB_REPOSITORY}/commits/${sha}/pulls" \
                 -H "Accept: application/vnd.github+json" \
@@ -122,9 +125,8 @@ jobs:
                 candidate="$(git log -1 --format=%B "${sha}" | sed -nE 's/.*\(#([0-9]+)\).*/\1/p' | head -n 1)"
               fi
 
+              update_snapshot_build "${candidate}" "${sha}"
               if [[ "${candidate}" =~ ^[0-9]+$ ]]; then
-                SNAPSHOT_BUILD="${candidate}"
-                REVISION_SHA="${sha}"
                 break
               fi
             done

--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -101,7 +101,7 @@ flowchart LR
 - dev/rc release 판정은 **true evidence 기반**이다. failure issue/status 가 없다는 것은 `unknown` 이며 pass 가 아니다. cut-gate 는 명시적인 success status, required workflow run history, git lineage 같은 positive evidence 만 소비한다
 - dev soak 판정의 source-of-truth 는 GitHub Issue/label 이 아니라 commit status context + workflow run history 다 ([dev-soak-status-model.md](./dev-soak-status-model.md))
 - cut-gate Issue 는 사람이 진행 상태를 추적하기 위한 projection 이다. 생성/갱신/닫기는 `.github/actions/cut-issue` 와 `close-cut-issue-on-pr-merge` 가 담당하며, promotion 판정 SSOT 로 사용하지 않는다
-- 모든 branch linear ON — dev-staging: squash, dev/rc/main: rebase
+- 일반 작업 PR 은 dev-staging 에서 squash 로 정리한다. Branch promotion PR 은 source branch ancestry 보존을 위해 merge commit 을 사용하며, dev/rc/main 에 linear history 를 강제하지 않는다
 - Protected branch 직접 push 는 human 금지. dev-staging daily cut version bump, promotion branch/tag, RC cleanup 은 `minglit-release-bot` 전용 token + Ruleset bypass 로만 허용
 - `deploy-dev-event-flow-cron` 은 `dev` push 에서만 `dev-event-flow-simulator` pg_cron 을 설치한다. `monitor-event-flow-*` 는 수동 smoke 이며, RC cron 은 RC project 준비 후 별도 설치한다
 - main 머지 = backend + mobile 모두 prod deploy. backend prod deploy 는 `main-deploy` 에서 한 번에 수행한다

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -7,7 +7,7 @@
 ```
   agents ──PR + auto-merge──▶ dev-staging
                               │
-                              └─daily dev-staging-dev-cut linear snapshot PR──▶ dev
+                              └─daily dev-staging-dev-cut merge-commit snapshot PR──▶ dev
                                                               │
                                                               ├─▶ dev-rc-cut-gate (post-merge 자동)
                                                               │      │
@@ -50,22 +50,22 @@ RC hotfix 는 dev-staging-first 가 기본이다. active RC 에만 먼저 들어
 | 머지 방향 | base ← head | 트리거 | 머지 방식 | 요구 체크 |
 |-----------|-------------|--------|-----------|-----------|
 | feature/agent → dev-staging | `dev-staging` ← `feat/*`, `fix/*`, `chore/*`, `docs/*` | PR + auto-merge | **squash** | `dev-staging-pr-gate` |
-| dev-staging → dev | `dev` ← `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` at daily cut-time `v*-dev-staging` tag | daily cron `dev-staging-dev-cut` | rebase (linear snapshot) | `dev-pr-gate` |
-| hotfix → dev | `dev` ← `dev/hotfix/*` | approved hotfix only | rebase | `dev-pr-gate` |
-| hotfix → rc | `rc/YYYY-Wxx` ← dev-staging fix cherry-pick branch | dev-staging-first approved hotfix only | rebase | `rc-pr-gate` |
-| rc → main | `main` ← `rc/YYYY-Wxx` | `rc-main-cut` 이 5일 무커밋 시 PR 생성 + auto-merge | rebase + ff | `main-pr-gate` |
-| hotfix → main | `main` ← `main/hotfix/*` | approved + release-manager hotfix only | rebase + ff | `main-pr-gate` |
+| dev-staging → dev | `dev` ← `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` at daily cut-time `v*-dev-staging` tag | daily cron `dev-staging-dev-cut` | merge commit (snapshot ancestry 보존) | `dev-pr-gate` |
+| hotfix → dev | `dev` ← `dev/hotfix/*` | approved hotfix only | approved hotfix merge | `dev-pr-gate` |
+| hotfix → rc | `rc/YYYY-Wxx` ← dev-staging fix cherry-pick branch | dev-staging-first approved hotfix only | approved hotfix merge | `rc-pr-gate` |
+| rc → main | `main` ← `rc/YYYY-Wxx` | `rc-main-cut` 이 5일 무커밋 시 PR 생성 + auto-merge | merge commit (RC ancestry 보존) | `main-pr-gate` |
+| hotfix → main | `main` ← `main/hotfix/*` | approved + release-manager hotfix only | approved hotfix merge | `main-pr-gate` |
 
 ## Branch Protection 설정
 
 | 브랜치 | direct push | linear | required check | merge 종류 |
 |--------|-------------|--------|----------------|------------|
 | `dev-staging` | 금지 (release bot 예외) | **ON** | `dev-staging-pr-gate` | squash |
-| `dev` | 금지 | **ON** | `dev-pr-gate` | rebase (linear snapshot) |
-| `rc/YYYY-Wxx` | 금지 | **ON** | `rc-pr-gate` | rebase |
-| `main` | 금지 (release bot 예외) | **ON** | `main-pr-gate` | rebase |
+| `dev` | 금지 | **OFF** | `dev-pr-gate` | merge commit for promotion |
+| `rc/YYYY-Wxx` | 금지 | **OFF** | `rc-pr-gate` | approved hotfix merge |
+| `main` | 금지 (release bot 예외) | **OFF** | `main-pr-gate` | merge commit for promotion |
 
-Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가지). `dev` 는 active ruleset 의 linear history 와 맞추기 위해 `dev-staging-dev-cut` promotion 도 rebase 를 사용한다. Protected branch 직접 push 는 `minglit-release-bot` 의 dev-staging version bump, promotion branch/tag, RC cleanup 에만 Ruleset bypass 로 허용한다.
+Global linear history 정책은 폐기한다. 일반 작업 PR 은 `dev-staging` 에서 squash 로 정리하고, branch promotion PR 은 source branch ancestry 를 보존하기 위해 merge commit 을 사용한다. Protected branch 직접 push 는 `minglit-release-bot` 의 dev-staging version bump, promotion branch/tag, RC cleanup 에만 Ruleset bypass 로 허용한다.
 
 ## Promotion Tag 컨벤션
 

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -22,7 +22,7 @@
   4. 같은 commit 에 `vYY.MM.DD+YYMMDDNN-dev-staging` tag 생성
   5. PR 생성: `ci(dev-staging-dev-cut): promote v26.06.01+26060101-dev-staging to dev` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}` at that tag)
   6. `dev-pr-gate` 자동 발동
-  7. 통과 시 auto-merge (rebase — active `dev` ruleset 의 linear history 와 호환)
+  7. 통과 시 auto-merge (merge commit — dev-staging snapshot ancestry 보존)
 
 ### 슬립 처리
 

--- a/docs/infra/branch-strategy/dev-staging-pipeline.md
+++ b/docs/infra/branch-strategy/dev-staging-pipeline.md
@@ -94,7 +94,7 @@ AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 �
 6. release bot 이 protected `dev-staging` 에 version bump commit 을 fast-forward push
 7. 같은 commit 에 tag `vYY.MM.DD+YYMMDDNN-dev-staging` 생성
 8. tag SHA 에서 `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` branch 생성
-9. dev promotion PR 생성 + auto-merge(rebase)
+9. dev promotion PR 생성 + auto-merge(merge commit, snapshot ancestry 보존)
 ```
 
 Protected `dev-staging` 직접 push 는 human 금지다. 예외는 `minglit-release-bot` 이 `dev-staging-dev-cut` 안에서 version bump commit 을 fast-forward push 하는 경우뿐이다. push 가 거부되면 dev-staging 이 cut 중 변경된 것이므로 새 HEAD 기준으로 다음 run 에서 다시 계산한다.

--- a/docs/infra/branch-strategy/main-promotion.md
+++ b/docs/infra/branch-strategy/main-promotion.md
@@ -18,7 +18,7 @@
 | RC first-parent lineage 의 `dev-rc-cut-pass` source 확인 | RC 가 검증된 dev cut source 에서 출발했는지 |
 | `rc-main-cut-pass` 자동 마커 | `rc-main-cut-gate` 가 5일 무커밋 + pre-main signal 확인 후 부여 |
 
-GitHub Ruleset 의 required check 는 `main-pr-gate` 하나로 둔다. `dev-rc-cut-pass`, `expand-migrate-contract`, `rc-main-cut-pass` 는 PR head SHA 와 별도 commit/label 상태가 섞일 수 있으므로 `main-pr-gate` 내부 검증으로 처리한다. `dev-rc-cut-pass` 는 RC HEAD 직접 status 가 아니라 RC first-parent lineage 안의 source commit status 로 확인한다. 모든 check 통과 시 workflow 가 auto-merge (rebase + fast-forward) 한다. 어느 하나라도 실패 시 PR hold + Slack 알림 → human 개입 (edge case).
+GitHub Ruleset 의 required check 는 `main-pr-gate` 하나로 둔다. `dev-rc-cut-pass`, `expand-migrate-contract`, `rc-main-cut-pass` 는 PR head SHA 와 별도 commit/label 상태가 섞일 수 있으므로 `main-pr-gate` 내부 검증으로 처리한다. `dev-rc-cut-pass` 는 RC HEAD 직접 status 가 아니라 RC first-parent lineage 안의 source commit status 로 확인한다. 모든 check 통과 시 workflow 가 auto-merge (merge commit, RC ancestry 보존) 한다. 어느 하나라도 실패 시 PR hold + Slack 알림 → human 개입 (edge case).
 
 `main-pr-gate` 는 true evidence 만 인정한다. `rc-main-cut-pass` 또는 required RC pre-main signal 이 없으면 상태는 `unknown` 이며, open blocker issue 가 없다는 이유만으로 main promotion 을 통과시키지 않는다.
 

--- a/docs/infra/branch-strategy/rc-promotion.md
+++ b/docs/infra/branch-strategy/rc-promotion.md
@@ -115,7 +115,7 @@ Mark 님 직감대로 hotfix loop 으로 RC lifecycle 이 길어지는 게 일�
             │
             ├─▶ [rc-pr-gate]
             │
-            ├─▶ [merge to rc (rebase)]
+            ├─▶ [merge to rc (approved hotfix merge)]
             │
             ├─▶ [rc-deploy: RC env 재적용]
             │

--- a/docs/infra/branch-strategy/specs/branch-spec.md
+++ b/docs/infra/branch-strategy/specs/branch-spec.md
@@ -47,7 +47,7 @@
 | Required status checks | `dev-pr-gate` (dev-staging snapshot PR 또는 approved `dev/hotfix/*`) |
 | Required reviewers | 0 |
 | Require conversation resolution | yes |
-| Require linear history | **yes** (nightly snapshot PR 만 들어옴, snapshot 자체가 linear) |
+| Require linear history | **no** (promotion merge commit 이 dev-staging snapshot ancestry 를 보존) |
 | Allowed merge methods | merge commit (snapshot 보존용) |
 | Bypass roles | `minglit-release-bot` only for promotion/version metadata push |
 
@@ -65,8 +65,8 @@
 | Required PR labels | GitHub Ruleset 직접 요구 없음. `main-pr-gate` 가 `rc-main-cut-pass` marker 또는 main hotfix labels 를 검증 |
 | Required reviewers | 0 (workflow auto-merge) |
 | Require conversation resolution | yes |
-| Require linear history | **yes** |
-| Allowed merge methods | **rebase only** (rebase + fast-forward) |
+| Require linear history | **no** |
+| Allowed merge methods | merge commit (RC promotion ancestry 보존용) |
 | Auto-delete head branch on merge | yes (`rc/*` branch 는 main merge 후 삭제, 이력은 protected tag 로 보존) |
 | Bypass roles | `minglit-release-bot` for promotion tag / cleanup, release manager only for catastrophic incident response |
 
@@ -84,8 +84,8 @@
 | Required status checks | `rc-pr-gate` (approved `rc/hotfix/*` PR 에 대해) |
 | Required reviewers | 0 |
 | Require conversation resolution | yes |
-| Require linear history | yes |
-| Allowed merge methods | rebase only |
+| Require linear history | no |
+| Allowed merge methods | approved hotfix merge |
 | Auto-delete head branch on merge | yes (hotfix branch 자동 삭제) |
 | Bypass roles | `minglit-release-bot` only for RC branch creation/deletion and promotion tag push |
 

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -182,7 +182,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Inputs | optional `tag_name` (`v*-dev-staging`) |
 | Outputs | PR number (dev-staging → dev) or skip |
 | PR title | `ci(dev-staging-dev-cut): promote {tag_name} to dev` |
-| Steps | (1) 이전 `dev-staging-dev-cut` PR open 이면 skip (2) 입력 `tag_name` 이 있으면 해당 tag 를 promote 대상으로 사용 (3) 입력이 없으면 `origin/dev-staging` HEAD 가 이미 dev 에 포함됐는지 확인 (4) HEAD 에 기존 snapshot tag 가 있으면 재사용 (5) tag 가 없으면 `YY.MM.DD-dev-staging` + `YYMMDDNN` build number 로 version bump commit 을 만들고 release bot 이 protected `dev-staging` 에 fast-forward push (6) 같은 commit 에 `vYY.MM.DD+YYMMDDNN-dev-staging` tag push (7) `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` promotion branch 를 tag SHA 에서 생성 (8) cut tracking issue 를 `status/promoting` 으로 갱신 (9) `gh pr create` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}`) + issue close marker + auto-merge 활성화 (`rebase`, active dev ruleset 의 linear history 와 호환) |
+| Steps | (1) 이전 `dev-staging-dev-cut` PR open 이면 skip (2) 입력 `tag_name` 이 있으면 해당 tag 를 promote 대상으로 사용 (3) 입력이 없으면 `origin/dev-staging` HEAD 가 이미 dev 에 포함됐는지 확인 (4) HEAD 에 기존 snapshot tag 가 있으면 재사용 (5) tag 가 없으면 `YY.MM.DD-dev-staging` + `YYMMDDNN` build number 로 version bump commit 을 만들고 release bot 이 protected `dev-staging` 에 fast-forward push (6) 같은 commit 에 `vYY.MM.DD+YYMMDDNN-dev-staging` tag push (7) `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` promotion branch 를 tag SHA 에서 생성 (8) cut tracking issue 를 `status/promoting` 으로 갱신 (9) `gh pr create` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}`) + issue close marker + auto-merge 활성화 (`merge commit`, dev-staging snapshot ancestry 보존) |
 
 #### `dev-pr-gate`
 

--- a/docs/infra/branch-strategy/test-strategy.md
+++ b/docs/infra/branch-strategy/test-strategy.md
@@ -89,7 +89,7 @@ RC 의 hotfix 만 받음. 기본은 dev-staging 에 먼저 머지된 fix commit/
 - `expand-migrate-contract` 다시 검증 (RC 5일 동안 dev 가 더 나갔을 수 있음)
 - RC first-parent lineage 안의 `dev-rc-cut-pass` source commit 확인
 
-모든 check 통과 시 workflow auto-merge (rebase + ff).
+모든 check 통과 시 workflow auto-merge (merge commit, RC ancestry 보존).
 
 ### Flag staged rollout 메트릭 게이트
 

--- a/docs/infra/branch-strategy/versioning.md
+++ b/docs/infra/branch-strategy/versioning.md
@@ -56,7 +56,7 @@
 조회:
 - `git tag -l 'v*-dev-staging'` (dev-staging coherent snapshot)
 - `git tag -l 'promo/main-*'` (weekly main promotion event)
-- `git log --first-parent main` (main 의 promotion 이벤트, rebase 라 사실상 linear)
+- `git log --first-parent main` (main 의 promotion merge 이벤트)
 - `gh api repos/.../commits/{sha}/status` (dev-rc-cut-pass 확인)
 
 ## 동일 build number 가 여러 단계 등장하는 의미


### PR DESCRIPTION
Refs #2975

Non-closing reason: tracking issue covers the follow-up promotion test and the old cut PR cleanup, so this PR should not close it yet.

## Summary
- Switch dev-staging -> dev and rc -> main promotion auto-merge from rebase to merge commit.
- Update branch strategy docs to retire global linear-history promotion policy.
- Keep regular dev-staging PRs on the existing squash lane while preserving promotion source ancestry.

## Verification
- git diff --check
- ruby YAML parse for dev-staging-dev-cut.yml and rc-main-cut.yml
- python3 .github/scripts/check-dev-cut-workflow-contract.py
- python3 .github/scripts/check-dev-soak-workflow-contract.py

## Follow-up
- Repository settings/rulesets must allow merge commits and disable linear-history enforcement for promotion target branches before the new promotion workflow can auto-merge.