### PR TITLE
docs(mds): clarify partner help sheet scope

### DIFF
--- a/apps/mds/docs/BLUEDOC.md
+++ b/apps/mds/docs/BLUEDOC.md
@@ -27,11 +27,15 @@ Minglit Design System 의 **시각 SSOT + 문서 사이트**. 화면 spec, 컴�
 ## 자주 쓰는 명령
 
 ```bash
+# repo root 에서
+npm install --package-lock=false --cache .npm-cache
+npm run dev --workspace=apps/mds/docs      # http://localhost:3003
+npm run lint --workspace=apps/mds/docs
+npm run build --workspace=apps/mds/docs
+
+# apps/mds/docs 에서
 npm run dev      # http://localhost:3003
-npm run lint
-npm run build
-npm run tokens:sync
-npm run icons:sync && npm run icons:sync-data
+npm run tokens:sync && npm run icons:sync && npm run icons:sync-data
 ```
 
 ## 관련
@@ -43,4 +47,4 @@ npm run icons:sync && npm run icons:sync-data
 - [`../../../scripts/mds_render_coverage.dart`](../../../scripts/mds_render_coverage.dart) — MDS spec ↔ emulator render coverage
 
 ---
-_Reviewed: 2026-05-31 18:24_
+_Reviewed: 2026-06-03 12:18_

--- a/apps/mds/docs/public/specs/event_application_manage_page/index.html
+++ b/apps/mds/docs/public/specs/event_application_manage_page/index.html
@@ -518,7 +518,7 @@ body.dark-mode .viewport {
   <section class="doc">
     <h2>Help bottom sheet sub-anatomy <em style="color: var(--color-text-secondary); font-size: 13px;">(MinglitHelpSheet 컴포넌트 후보)</em></h2>
     <p class="intro">
-      info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 파트너 앱 모든 주요 화면에서 같은 chrome 재사용 — 화면별 sections 콘텐츠만 다름.
+      info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 현재 적용 화면(홈·파티 관리·신청관리·정산)은 같은 chrome을 재사용하며, 화면별 sections 콘텐츠만 다름.
     </p>
     <table class="ref">
       <thead>
@@ -1036,7 +1036,7 @@ body.dark-mode .viewport {
             </div>
           </td>
           <td class="state-mini__aspect">조건</td>
-          <td>AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 파트너 앱 전체 일관 패턴 (모든 주요 화면에서 info → 컨텍스트 도움말).</td>
+          <td>AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 현재 적용 화면(홈·파티 관리·신청관리·정산)의 일관 패턴 (info → 컨텍스트 도움말).</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>

--- a/apps/mds/docs/public/specs/event_application_manage_page/index.html
+++ b/apps/mds/docs/public/specs/event_application_manage_page/index.html
@@ -501,7 +501,7 @@ body.dark-mode .viewport {
   <section class="doc">
     <h2>AppBar sub-anatomy</h2>
     <p class="intro">
-      파트너 앱 simpleAppBar — centered title + 우측 actions(info). 글로벌 일관 패턴이라 모든 파트너 화면이 동일 구조를 따른다 (info icon은 화면별 컨텍스트 도움말 sheet 트리거).
+      현재 적용 화면(홈·파티 관리·신청관리·정산)의 simpleAppBar 도움말 패턴 — centered title + 우측 actions(info). 이 화면들은 같은 AppBar info 도움말 구조를 사용한다.
     </p>
     <table class="ref">
       <thead>
@@ -509,7 +509,7 @@ body.dark-mode .viewport {
       </thead>
       <tbody>
         <tr><td>① Title (centered)</td><td>중앙 정렬 · 1줄</td><td>"신청관리" · <code>--typography-font-size-app-bar-title</code> 18 · w600 · <code>color-text-primary</code>.</td></tr>
-        <tr><td>② Info action (trailing)</td><td>우측 · 40×40 hit-region</td><td>info_outline 22×22 · 탭 시 <strong>도움말 bottom sheet</strong> 진입 (State 7). 파트너 앱 모든 화면에 동일 패턴 적용 — 각 화면별 컨텍스트 도움말 콘텐츠는 호출 측에서 정의.</td></tr>
+        <tr><td>② Info action (trailing)</td><td>우측 · 40×40 hit-region</td><td>info_outline 22×22 · 탭 시 <strong>도움말 bottom sheet</strong> 진입 (State 7). 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 각 화면별 컨텍스트 도움말 콘텐츠는 호출 측에서 정의한다.</td></tr>
         <tr><td>—</td><td>AppBar bg</td><td><code>--color-surface</code> · surfaceTint transparent · border-bottom 없음.</td></tr>
       </tbody>
     </table>
@@ -1076,7 +1076,7 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td class="state-mini__aspect">노트</td>
-          <td>📝 화면별 sections 콘텐츠(도움말 Q&amp;A)는 추후 별도 이슈로 디자인 결정 예정. 파트너 앱 모든 화면이 동일 info 아이콘 → bottom sheet 패턴을 따른다.</td>
+          <td>📝 화면별 sections 콘텐츠(도움말 Q&amp;A)는 호출 측에서 정의한다. 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 신규·리뉴얼 파트너 화면은 동일 info 아이콘 → bottom sheet 패턴을 채택한다.</td>
         </tr>
       </tbody>
     </table>

--- a/apps/mds/docs/public/specs/event_application_manage_page/index.md
+++ b/apps/mds/docs/public/specs/event_application_manage_page/index.md
@@ -53,12 +53,12 @@ AppBar(가운데 '신청관리' + 하단 3탭) + 탭별 body + 하단 Navigation
 
 ## AppBar sub-anatomy
 
-파트너 앱 simpleAppBar — centered title + 우측 actions(info). 글로벌 일관 패턴이라 모든 파트너 화면이 동일 구조를 따른다 (info icon은 화면별 컨텍스트 도움말 sheet 트리거).
+현재 적용 화면(홈·파티 관리·신청관리·정산)의 simpleAppBar 도움말 패턴 — centered title + 우측 actions(info). 이 화면들은 같은 AppBar info 도움말 구조를 사용한다.
 
 | Region | Alignment | Notes |
 |---|---|---|
 | ① Title (centered) | 중앙 정렬 · 1줄 | "신청관리" · --typography-font-size-app-bar-title 18 · w600 · color-text-primary. |
-| ② Info action (trailing) | 우측 · 40×40 hit-region | info_outline 22×22 · 탭 시 도움말 bottom sheet 진입 (State 7). 파트너 앱 모든 화면에 동일 패턴 적용 — 각 화면별 컨텍스트 도움말 콘텐츠는 호출 측에서 정의. |
+| ② Info action (trailing) | 우측 · 40×40 hit-region | info_outline 22×22 · 탭 시 도움말 bottom sheet 진입 (State 7). 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 각 화면별 컨텍스트 도움말 콘텐츠는 호출 측에서 정의한다. |
 | — | AppBar bg | --color-surface · surfaceTint transparent · border-bottom 없음. |
 
 ## Help bottom sheet sub-anatomy _(MinglitHelpSheet 컴포넌트 후보)_
@@ -180,12 +180,12 @@ info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 파트너 앱 
 
 | 항목 | 내용 |
 |---|---|
-| 조건 | AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 파트너 앱 전체 일관 패턴 (모든 주요 화면에서 info → 컨텍스트 도움말). |
+| 조건 | AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 현재 적용 화면(홈·파티 관리·신청관리·정산)의 일관 패턴 (info → 컨텍스트 도움말). |
 | 사용자 액션 | ① "확인" 버튼 탭 — sheet dismiss, 원래 화면으로 복귀 (primary path).② handle 드래그 다운 / scrim 탭 — 동일하게 dismiss (gesture path · 보조).③ sheet 내부 스크롤 — 도움말 항목이 많을 때 세로 스크롤 (max-height 75% · scrollable body · CTA는 sheet 하단 고정). |
 | 에지케이스 | · 도움말 항목이 길어 max-height 초과 시 sheet 내부 스크롤 (scaffold body는 잠금).· keyboard가 올라오는 입력 시나리오는 본 sheet에 없음 — 입력 도구 X.· 다중 sheet 진입 (info 안에서 또 info 등) 금지 — sheet 위 sheet stacking 안 함. |
 | 컴포넌트 (제안) | · MinglitHelpSheet (mds_core 신규 컴포넌트 후보) — 파트너 앱 일관 패턴화.· props: title: String · sections: List<HelpSection>.· 화면별 도움말 내용은 호출 측에서 정의 — sheet 컴포넌트는 chrome만 책임.· 진입: showModalBottomSheet(isScrollControlled · barrierColor · shape rounded top). |
 | 토큰 | · scrim: rgba(0,0,0,0.45)· sheet bg --color-background · 상단 모서리 radius-card· handle 36×4 · radius 2 · --color-divider· header 16/700 primary · CTA "확인" — bottom sticky · height 48 · partner-primary filled · 15/700 white · margin medium· section title 14/700 primary · section body 13 secondary · line-height 1.55· max-height 75vh |
-| 노트 | 📝 화면별 sections 콘텐츠(도움말 Q&A)는 추후 별도 이슈로 디자인 결정 예정. 파트너 앱 모든 화면이 동일 info 아이콘 → bottom sheet 패턴을 따른다. |
+| 노트 | 📝 화면별 sections 콘텐츠(도움말 Q&A)는 호출 측에서 정의한다. 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 신규·리뉴얼 파트너 화면은 동일 info 아이콘 → bottom sheet 패턴을 채택한다. |
 
 🔄
 

--- a/apps/mds/docs/public/specs/event_application_manage_page/index.md
+++ b/apps/mds/docs/public/specs/event_application_manage_page/index.md
@@ -63,7 +63,7 @@ AppBar(가운데 '신청관리' + 하단 3탭) + 탭별 body + 하단 Navigation
 
 ## Help bottom sheet sub-anatomy _(MinglitHelpSheet 컴포넌트 후보)_
 
-info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 파트너 앱 모든 주요 화면에서 같은 chrome 재사용 — 화면별 sections 콘텐츠만 다름.
+info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 현재 적용 화면(홈·파티 관리·신청관리·정산)은 같은 chrome을 재사용하며, 화면별 sections 콘텐츠만 다름.
 
 | Region | Alignment | Notes |
 |---|---|---|

--- a/apps/mds/docs/public/specs/partner_home_page/index.html
+++ b/apps/mds/docs/public/specs/partner_home_page/index.html
@@ -1130,7 +1130,7 @@ body.dark-mode .viewport {
   <section class="doc">
     <h2>Help bottom sheet sub-anatomy <em style="color: var(--color-text-secondary); font-size: 13px;">(MinglitHelpSheet 컴포넌트 후보)</em></h2>
     <p class="intro">
-      info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 파트너 앱 모든 주요 화면에서 같은 chrome 재사용 — 화면별 sections 콘텐츠만 다름.
+      info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 현재 적용 화면(홈·파티 관리·신청관리·정산)은 같은 chrome을 재사용하며, 화면별 sections 콘텐츠만 다름.
     </p>
     <table class="ref">
       <thead>
@@ -2286,7 +2286,7 @@ body.dark-mode .viewport {
             </div>
           </td>
           <td class="state-mini__aspect">조건</td>
-          <td>AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 파트너 앱 전체 일관 패턴.</td>
+          <td>AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 현재 적용 화면(홈·파티 관리·신청관리·정산)의 일관 도움말 패턴.</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>

--- a/apps/mds/docs/public/specs/partner_home_page/index.html
+++ b/apps/mds/docs/public/specs/partner_home_page/index.html
@@ -1119,7 +1119,7 @@ body.dark-mode .viewport {
       </thead>
       <tbody>
         <tr><td>① Brand (leading)</td><td>좌측 정렬</td><td>minglit 로고 + "PARTNER" suffix · 탭 동작 없음 · 홈 식별자 역할.</td></tr>
-        <tr><td>② Info action (1st trailing)</td><td>우측 · 40×40 hit-region</td><td>info_outline 22×22 · 탭 시 <strong>도움말 bottom sheet</strong> 진입 (State 8). 파트너 앱 모든 화면에 동일 패턴 적용.</td></tr>
+        <tr><td>② Info action (1st trailing)</td><td>우측 · 40×40 hit-region</td><td>info_outline 22×22 · 탭 시 <strong>도움말 bottom sheet</strong> 진입 (State 8). 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 신규·리뉴얼 파트너 화면은 같은 패턴을 채택한다.</td></tr>
         <tr><td>③ Bug report (2nd trailing · dev only)</td><td>우측 · 40×40 hit-region</td><td>개발 빌드 한정 — BugReportAction 컴포넌트.</td></tr>
         <tr><td>④ Notification (3rd trailing)</td><td>우측 · 40×40 hit-region</td><td>notifications_outlined 22×22 · 미읽음 배지(뱃지) 오버레이 가능.</td></tr>
         <tr><td>—</td><td>AppBar bg</td><td><code>--color-surface</code> · surfaceTint transparent · border-bottom 없음.</td></tr>
@@ -2315,7 +2315,7 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td class="state-mini__aspect">노트</td>
-          <td>📝 화면별 sections 콘텐츠(도움말 Q&amp;A)는 추후 별도 이슈로 디자인 결정 예정. 파트너 앱 모든 화면이 동일 info 아이콘 → bottom sheet 패턴을 따른다.</td>
+          <td>📝 화면별 sections 콘텐츠(도움말 Q&amp;A)는 호출 측에서 정의한다. 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 신규·리뉴얼 파트너 화면은 동일 info 아이콘 → bottom sheet 패턴을 채택한다.</td>
         </tr>
       </tbody>
     </table>

--- a/apps/mds/docs/public/specs/partner_home_page/index.md
+++ b/apps/mds/docs/public/specs/partner_home_page/index.md
@@ -55,12 +55,12 @@ AppBar(로고 좌측) + 스크롤 body + 하단 NavigationBar. body는 **오버�
 
 ## AppBar sub-anatomy
 
-파트너 홈 AppBar — 좌측 워드마크 + 우측 actions(info + bug report(dev only) + 알림). info icon은 화면별 컨텍스트 도움말 sheet 트리거 (파트너 앱 일관 패턴).
+파트너 홈 AppBar — 좌측 워드마크 + 우측 actions(info + bug report(dev only) + 알림). info icon은 현재 적용 화면(홈·파티 관리·신청관리·정산)의 컨텍스트 도움말 sheet 트리거.
 
 | Region | Alignment | Notes |
 |---|---|---|
 | ① Brand (leading) | 좌측 정렬 | minglit 로고 + "PARTNER" suffix · 탭 동작 없음 · 홈 식별자 역할. |
-| ② Info action (1st trailing) | 우측 · 40×40 hit-region | info_outline 22×22 · 탭 시 도움말 bottom sheet 진입 (State 8). 파트너 앱 모든 화면에 동일 패턴 적용. |
+| ② Info action (1st trailing) | 우측 · 40×40 hit-region | info_outline 22×22 · 탭 시 도움말 bottom sheet 진입 (State 8). 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 신규·리뉴얼 파트너 화면은 같은 패턴을 채택한다. |
 | ③ Bug report (2nd trailing · dev only) | 우측 · 40×40 hit-region | 개발 빌드 한정 — BugReportAction 컴포넌트. |
 | ④ Notification (3rd trailing) | 우측 · 40×40 hit-region | notifications_outlined 22×22 · 미읽음 배지(뱃지) 오버레이 가능. |
 | — | AppBar bg | --color-surface · surfaceTint transparent · border-bottom 없음. |
@@ -183,11 +183,11 @@ info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 파트너 앱 
 
 | 항목 | 내용 |
 |---|---|
-| 조건 | AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 파트너 앱 전체 일관 패턴. |
+| 조건 | AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 현재 적용 화면(홈·파티 관리·신청관리·정산)의 일관 도움말 패턴. |
 | 사용자 액션 | ① "확인" 버튼 탭 — sheet dismiss (primary).② handle 드래그 / scrim 탭 — dismiss (보조).③ sheet 내부 스크롤 — max-height 초과 시. |
 | 컴포넌트 | · MinglitHelpSheet — props: title: String · sections: List<HelpSection>.· 화면별 도움말 내용은 호출 측에서 정의 — sheet chrome만 책임.· 진입: showModalBottomSheet(isScrollControlled · barrierColor · shape rounded top). |
 | 토큰 | · scrim: rgba(0,0,0,0.45) · sheet bg --color-background · 상단 모서리 radius-card· handle 36×4 · --color-divider · header 16/700 primary· CTA "확인" — height 48 · partner-primary filled · 15/700 white · margin medium· max-height 75vh |
-| 노트 | 📝 화면별 sections 콘텐츠(도움말 Q&A)는 추후 별도 이슈로 디자인 결정 예정. 파트너 앱 모든 화면이 동일 info 아이콘 → bottom sheet 패턴을 따른다. |
+| 노트 | 📝 화면별 sections 콘텐츠(도움말 Q&A)는 호출 측에서 정의한다. 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 신규·리뉴얼 파트너 화면은 동일 info 아이콘 → bottom sheet 패턴을 채택한다. |
 
 ## 카드 노출 순서 (Order priority)
 

--- a/apps/mds/docs/public/specs/partner_home_page/index.md
+++ b/apps/mds/docs/public/specs/partner_home_page/index.md
@@ -67,7 +67,7 @@ AppBar(로고 좌측) + 스크롤 body + 하단 NavigationBar. body는 **오버�
 
 ## Help bottom sheet sub-anatomy _(MinglitHelpSheet 컴포넌트 후보)_
 
-info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 파트너 앱 모든 주요 화면에서 같은 chrome 재사용 — 화면별 sections 콘텐츠만 다름.
+info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 현재 적용 화면(홈·파티 관리·신청관리·정산)은 같은 chrome을 재사용하며, 화면별 sections 콘텐츠만 다름.
 
 | Region | Alignment | Notes |
 |---|---|---|

--- a/apps/mds/docs/public/specs/party_list_page/index.html
+++ b/apps/mds/docs/public/specs/party_list_page/index.html
@@ -911,7 +911,7 @@ body.dark-mode .viewport {
   <section class="doc">
     <h2>Help bottom sheet sub-anatomy <em style="color: var(--color-text-secondary); font-size: 13px;">(MinglitHelpSheet 컴포넌트 후보)</em></h2>
     <p class="intro">
-      info 아이콘 또는 Empty의 help 버튼 탭 시 노출되는 컨텍스트 도움말 sheet. 첫 사용자가 가질 만한 Q&amp;A 4개 시퀀스 (개념 → 용어 → 상태 → 핵심 규칙). 파트너 앱 모든 주요 화면에서 같은 chrome 재사용 — 화면별 sections 콘텐츠만 다름.
+      info 아이콘 또는 Empty의 help 버튼 탭 시 노출되는 컨텍스트 도움말 sheet. 첫 사용자가 가질 만한 Q&amp;A 4개 시퀀스 (개념 → 용어 → 상태 → 핵심 규칙). 현재 적용 화면(홈·파티 관리·신청관리·정산)은 같은 chrome을 재사용하며, 화면별 sections 콘텐츠만 다름.
     </p>
     <table class="ref">
       <thead>
@@ -1493,7 +1493,7 @@ body.dark-mode .viewport {
             </div>
           </td>
           <td class="state-mini__aspect">조건</td>
-          <td>AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 파트너 앱 전체 일관 패턴 (모든 주요 화면에서 info → 컨텍스트 도움말).</td>
+          <td>AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 현재 적용 화면(홈·파티 관리·신청관리·정산)의 일관 패턴 (info → 컨텍스트 도움말).</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>

--- a/apps/mds/docs/public/specs/party_list_page/index.html
+++ b/apps/mds/docs/public/specs/party_list_page/index.html
@@ -870,7 +870,7 @@ body.dark-mode .viewport {
   <section class="doc">
     <h2>AppBar sub-anatomy</h2>
     <p class="intro">
-      파트너 앱 simpleAppBar — back leading + centered title + 우측 actions(info + add). 글로벌 일관 패턴이라 모든 파트너 화면이 동일 구조를 따른다 (info icon은 화면별 컨텍스트 도움말 sheet 트리거).
+      현재 적용 화면(홈·파티 관리·신청관리·정산)의 simpleAppBar 도움말 패턴 — back leading + centered title + 우측 actions(info + add). 이 화면들은 같은 AppBar info 도움말 구조를 사용한다.
     </p>
     <table class="ref">
       <thead>
@@ -879,7 +879,7 @@ body.dark-mode .viewport {
       <tbody>
         <tr><td>① Back (leading)</td><td>좌측 · 40×40 hit-region · auto pop</td><td>back arrow 22×22 · color <code>--color-text-primary</code> · push 진입 시 자동 노출. 진입 경로(MorePage / Onboarding 등)로 복귀.</td></tr>
         <tr><td>② Title (centered)</td><td>중앙 정렬 · 1줄</td><td>"파티 관리" · <code>--typography-font-size-app-bar-title</code> 18 · w600 · <code>color-text-primary</code>. 절대 변경되지 않는 페이지 식별자.</td></tr>
-        <tr><td>③ Info action (1st trailing)</td><td>우측 · 40×40 hit-region</td><td>info_outline 22×22 · 탭 시 <strong>도움말 bottom sheet</strong> 진입 (State 5). 파트너 앱 모든 화면에 동일 패턴 적용 — 각 화면별 컨텍스트 도움말 콘텐츠는 호출 측에서 정의.</td></tr>
+        <tr><td>③ Info action (1st trailing)</td><td>우측 · 40×40 hit-region</td><td>info_outline 22×22 · 탭 시 <strong>도움말 bottom sheet</strong> 진입 (State 5). 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 각 화면별 컨텍스트 도움말 콘텐츠는 호출 측에서 정의한다.</td></tr>
         <tr><td>④ Add action (2nd trailing)</td><td>우측 · 40×40 hit-region · 가장 우측</td><td>add 아이콘 22×22 · 탭 시 <a href="/specs/party_create_wizard_page/index.html"><code>PartyCreateRoute</code></a> push (새 파티 만들기). info 다음 위치라 "도움말 → 액션" 순서가 자연스러움.</td></tr>
         <tr><td>—</td><td>AppBar bg</td><td>scaffold gray와 동일</td><td><code>--color-surface</code> · surfaceTint transparent · border-bottom 없음. 본문 카드와 시각적 분리는 색 대비로만.</td></tr>
       </tbody>
@@ -1537,7 +1537,7 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td class="state-mini__aspect">노트</td>
-          <td>📝 모든 파트너 앱 화면이 동일 info 아이콘 → bottom sheet 패턴을 따른다 — 학습 비용 최소화. 화면별 sections 콘텐츠만 다름. <strong>MinglitHelpSheet 컴포넌트 신설 issue 별도 파일링 필요.</strong></td>
+          <td>📝 현재 적용 화면은 홈·파티 관리·신청관리·정산이다. 신규·리뉴얼 파트너 화면은 동일 info 아이콘 → bottom sheet 패턴을 채택하고, 화면별 sections 콘텐츠만 다르게 정의한다.</td>
         </tr>
       </tbody>
     </table>

--- a/apps/mds/docs/public/specs/party_list_page/index.md
+++ b/apps/mds/docs/public/specs/party_list_page/index.md
@@ -81,17 +81,17 @@ D-day chip tier (MinglitDDayChip 컴포넌트)
 
 ## AppBar sub-anatomy
 
-파트너 앱 simpleAppBar — back leading + centered title + 우측 actions(info + add). 글로벌 일관 패턴이라 모든 파트너 화면이 동일 구조를 따른다 (info icon은 화면별 컨텍스트 도움말 sheet 트리거).
+현재 적용 화면(홈·파티 관리·신청관리·정산)의 simpleAppBar 도움말 패턴 — back leading + centered title + 우측 actions(info + add). 이 화면들은 같은 AppBar info 도움말 구조를 사용한다.
 
 | Region | Alignment | Notes |
 |---|---|---|
 | ① Back (leading) | 좌측 · 40×40 hit-region · auto pop | back arrow 22×22 · color --color-text-primary · push 진입 시 자동 노출. 진입 경로(MorePage / Onboarding 등)로 복귀. |
 | ② Title (centered) | 중앙 정렬 · 1줄 | "파티 관리" · --typography-font-size-app-bar-title 18 · w600 · color-text-primary. 절대 변경되지 않는 페이지 식별자. |
-| ③ Info action (1st trailing) | 우측 · 40×40 hit-region | info_outline 22×22 · 탭 시 도움말 bottom sheet 진입 (State 5). 파트너 앱 모든 화면에 동일 패턴 적용 — 각 화면별 컨텍스트 도움말 콘텐츠는 호출 측에서 정의. |
+| ③ Info action (1st trailing) | 우측 · 40×40 hit-region | info_outline 22×22 · 탭 시 도움말 bottom sheet 진입 (State 5). 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 각 화면별 컨텍스트 도움말 콘텐츠는 호출 측에서 정의한다. |
 | ④ Add action (2nd trailing) | 우측 · 40×40 hit-region · 가장 우측 | add 아이콘 22×22 · 탭 시 PartyCreateRoute push (새 파티 만들기). info 다음 위치라 "도움말 → 액션" 순서가 자연스러움. |
 | — | AppBar bg | scaffold gray와 동일 | --color-surface · surfaceTint transparent · border-bottom 없음. 본문 카드와 시각적 분리는 색 대비로만. |
 
-**QR 액션 제거 — 도움말 패턴으로 대체:** 이전 버전(v1)의 QR 스캔 아이콘은 글로벌 체크인 진입점이었으나 list view 컨텍스트에서 부적절(어느 파티의 체크인인지 불명) → 제거. 그 자리에 info 아이콘을 두어 파트너 앱 전체 도움말 패턴의 진입점으로 활용.
+**QR 액션 제거 — 도움말 패턴으로 대체:** 이전 버전(v1)의 QR 스캔 아이콘은 글로벌 체크인 진입점이었으나 list view 컨텍스트에서 부적절(어느 파티의 체크인인지 불명) → 제거. 그 자리에 info 아이콘을 두어 현재 적용 화면 도움말 패턴의 진입점으로 활용.
 
 ## Empty state sub-anatomy
 
@@ -195,12 +195,12 @@ Sections 콘텐츠 구성 원칙 (첫 사용자 mental flow)
 
 | 항목 | 내용 |
 |---|---|
-| 조건 | AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 파트너 앱 전체 일관 패턴 (모든 주요 화면에서 info → 컨텍스트 도움말). |
+| 조건 | AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 현재 적용 화면(홈·파티 관리·신청관리·정산)의 일관 패턴 (info → 컨텍스트 도움말). |
 | 사용자 액션 | ① "확인" 버튼 탭 — sheet dismiss, 원래 화면으로 복귀 (primary path).② handle 드래그 다운 / scrim 탭 — 동일하게 dismiss (gesture path · 보조).③ sheet 내부 스크롤 — 도움말 항목이 많을 때 세로 스크롤 (max-height 75% · scrollable body · CTA는 sheet 하단 고정).④ "파티 등록하기" 같은 인라인 링크 (선택) — 도움말 안에서 관련 화면으로 직접 이동 (구현 단계 선택). |
 | 에지케이스 | · 도움말 항목이 길어 max-height 초과 시 sheet 내부 스크롤 (scaffold body는 잠금).· keyboard가 올라오는 입력 시나리오는 본 sheet에 없음 — 입력 도구 X.· 다중 sheet 진입 (info 안에서 또 info 등) 금지 — sheet 위 sheet stacking 안 함. |
 | 컴포넌트 (제안) | · MinglitHelpSheet (mds_core 신규 컴포넌트 후보) — 파트너 앱 일관 패턴화.· props: title: String · sections: List<HelpSection> (각 section: icon + title + body).· 화면별 도움말 내용은 호출 측에서 정의 — sheet 컴포넌트는 chrome만 책임.· 진입: showModalBottomSheet(isScrollControlled · barrierColor · shape rounded top). |
 | 토큰 | · scrim: rgba(0,0,0,0.45) — Material default barrier· sheet bg --color-background · 상단 모서리 radius-card· handle 36×4 · radius 2 · --color-divider· header 16/700 primary (close icon 없음 — CTA + handle drag로 dismiss)· CTA "확인" — bottom sticky · height 48 · partner-primary filled · 15/700 white · margin medium 좌우/하단· section title 14/700 primary · icon 18×18 partner-primary· section body 13 secondary · line-height 1.55· section 사이 1px --color-divider top border (첫 항목 제외)· max-height 75vh — 이상 시 내부 스크롤 |
-| 노트 | 📝 모든 파트너 앱 화면이 동일 info 아이콘 → bottom sheet 패턴을 따른다 — 학습 비용 최소화. 화면별 sections 콘텐츠만 다름. MinglitHelpSheet 컴포넌트 신설 issue 별도 파일링 필요. |
+| 노트 | 📝 현재 적용 화면은 홈·파티 관리·신청관리·정산이다. 신규·리뉴얼 파트너 화면은 동일 info 아이콘 → bottom sheet 패턴을 채택하고, 화면별 sections 콘텐츠만 다르게 정의한다. |
 
 🔄
 

--- a/apps/mds/docs/public/specs/party_list_page/index.md
+++ b/apps/mds/docs/public/specs/party_list_page/index.md
@@ -107,7 +107,7 @@ D-day chip tier (MinglitDDayChip 컴포넌트)
 
 ## Help bottom sheet sub-anatomy _(MinglitHelpSheet 컴포넌트 후보)_
 
-info 아이콘 또는 Empty의 help 버튼 탭 시 노출되는 컨텍스트 도움말 sheet. 첫 사용자가 가질 만한 Q&A 4개 시퀀스 (개념 → 용어 → 상태 → 핵심 규칙). 파트너 앱 모든 주요 화면에서 같은 chrome 재사용 — 화면별 sections 콘텐츠만 다름.
+info 아이콘 또는 Empty의 help 버튼 탭 시 노출되는 컨텍스트 도움말 sheet. 첫 사용자가 가질 만한 Q&A 4개 시퀀스 (개념 → 용어 → 상태 → 핵심 규칙). 현재 적용 화면(홈·파티 관리·신청관리·정산)은 같은 chrome을 재사용하며, 화면별 sections 콘텐츠만 다름.
 
 | Region | Alignment | Notes |
 |---|---|---|

--- a/apps/mds/docs/public/specs/settlement_page/index.html
+++ b/apps/mds/docs/public/specs/settlement_page/index.html
@@ -624,7 +624,7 @@ body.dark-mode .sp-month-card { background: var(--color-dark-surface); }
       </thead>
       <tbody>
         <tr><td>① Title (leading)</td><td>좌측 정렬 · 1줄</td><td>"정산" · <code>--typography-font-size-app-bar-title</code> 18 · w600 · <code>color-text-primary</code>. padding-left medium.</td></tr>
-        <tr><td>② Info action (1st trailing)</td><td>우측 · 40×40 hit-region</td><td>info_outline 22×22 · 탭 시 <strong>도움말 bottom sheet</strong> 진입 (State 5). 파트너 앱 모든 화면에 동일 패턴 적용.</td></tr>
+        <tr><td>② Info action (1st trailing)</td><td>우측 · 40×40 hit-region</td><td>info_outline 22×22 · 탭 시 <strong>도움말 bottom sheet</strong> 진입 (State 5). 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 신규·리뉴얼 파트너 화면은 같은 패턴을 채택한다.</td></tr>
         <tr><td>③ Wallet action (2nd trailing)</td><td>우측 · 40×40 hit-region · SETTLEMENT_EDIT 권한 보유 시만</td><td>account_balance_wallet_outlined 22×22 · 탭 시 정산 계좌 화면 push.</td></tr>
         <tr><td>—</td><td>AppBar bg</td><td><code>--color-surface</code> · surfaceTint transparent · border-bottom 없음.</td></tr>
       </tbody>

--- a/apps/mds/docs/public/specs/settlement_page/index.html
+++ b/apps/mds/docs/public/specs/settlement_page/index.html
@@ -634,7 +634,7 @@ body.dark-mode .sp-month-card { background: var(--color-dark-surface); }
   <section class="doc">
     <h2>Help bottom sheet sub-anatomy <em style="color: var(--color-text-secondary); font-size: 13px;">(MinglitHelpSheet 컴포넌트 후보)</em></h2>
     <p class="intro">
-      info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 파트너 앱 모든 주요 화면에서 같은 chrome 재사용 — 화면별 sections 콘텐츠만 다름.
+      info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 현재 적용 화면(홈·파티 관리·신청관리·정산)은 같은 chrome을 재사용하며, 화면별 sections 콘텐츠만 다름.
     </p>
     <table class="ref">
       <thead>
@@ -1060,7 +1060,7 @@ body.dark-mode .sp-month-card { background: var(--color-dark-surface); }
             </div>
           </td>
           <td class="state-mini__aspect">조건</td>
-          <td>AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 파트너 앱 전체 일관 패턴.</td>
+          <td>AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 현재 적용 화면(홈·파티 관리·신청관리·정산)의 일관 도움말 패턴.</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>

--- a/apps/mds/docs/public/specs/settlement_page/index.md
+++ b/apps/mds/docs/public/specs/settlement_page/index.md
@@ -65,7 +65,7 @@ Scaffold + AppBar(title:"정산", actions: 지갑 IconButton, bottom: 2-tab TabB
 
 ## Help bottom sheet sub-anatomy _(MinglitHelpSheet 컴포넌트 후보)_
 
-info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 파트너 앱 모든 주요 화면에서 같은 chrome 재사용 — 화면별 sections 콘텐츠만 다름.
+info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 현재 적용 화면(홈·파티 관리·신청관리·정산)은 같은 chrome을 재사용하며, 화면별 sections 콘텐츠만 다름.
 
 | Region | Alignment | Notes |
 |---|---|---|
@@ -168,7 +168,7 @@ info 아이콘 탭 시 노출되는 컨텍스트 도움말 sheet. 파트너 앱 
 
 | 항목 | 내용 |
 |---|---|
-| 조건 | AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 파트너 앱 전체 일관 패턴. |
+| 조건 | AppBar의 info 아이콘 탭 → 화면 위 bottom sheet 슬라이드 업. 현재 적용 화면(홈·파티 관리·신청관리·정산)의 일관 도움말 패턴. |
 | 사용자 액션 | ① "확인" 버튼 탭 — sheet dismiss (primary).② handle 드래그 / scrim 탭 — dismiss (보조).③ sheet 내부 스크롤 — max-height 초과 시. |
 | 컴포넌트 | · MinglitHelpSheet — props: title: String · sections: List<HelpSection>.· 화면별 도움말 내용은 호출 측에서 정의 — sheet chrome만 책임.· 진입: showModalBottomSheet(isScrollControlled · barrierColor · shape rounded top). |
 | 토큰 | · scrim: rgba(0,0,0,0.45) · sheet bg --color-background · 상단 모서리 radius-card· handle 36×4 · --color-divider · header 16/700 primary· CTA "확인" — height 48 · partner-primary filled · 15/700 white · margin medium· max-height 75vh |

--- a/apps/mds/docs/public/specs/settlement_page/index.md
+++ b/apps/mds/docs/public/specs/settlement_page/index.md
@@ -59,7 +59,7 @@ Scaffold + AppBar(title:"정산", actions: 지갑 IconButton, bottom: 2-tab TabB
 | Region | Alignment | Notes |
 |---|---|---|
 | ① Title (leading) | 좌측 정렬 · 1줄 | "정산" · --typography-font-size-app-bar-title 18 · w600 · color-text-primary. padding-left medium. |
-| ② Info action (1st trailing) | 우측 · 40×40 hit-region | info_outline 22×22 · 탭 시 도움말 bottom sheet 진입 (State 7). 파트너 앱 모든 화면에 동일 패턴 적용. |
+| ② Info action (1st trailing) | 우측 · 40×40 hit-region | info_outline 22×22 · 탭 시 도움말 bottom sheet 진입 (State 7). 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 신규·리뉴얼 파트너 화면은 같은 패턴을 채택한다. |
 | ③ Wallet action (2nd trailing) | 우측 · 40×40 hit-region · SETTLEMENT_EDIT 권한 보유 시만 | account_balance_wallet_outlined 22×22 · 탭 시 정산 계좌 화면 push. |
 | — | AppBar bg | --color-surface · surfaceTint transparent · border-bottom 없음. |
 

--- a/apps/mds/docs/src/lib/components.ts
+++ b/apps/mds/docs/src/lib/components.ts
@@ -2235,7 +2235,7 @@ await showMinglitBottomSheet(
       'confirmLabel ElevatedButton — partner-primary 색상 명시 (테마 상속 아님, 유저/파트너 앱 모두 동일 렌더링 보장)',
     ],
     guidelines: [
-      { kind: 'do',   text: '파트너 앱 화면 AppBar 우측 info 아이콘 탭 → showMinglitHelpSheet 패턴으로 일관 적용.',    recipeKey: 'do-info-icon-pattern' },
+      { kind: 'do',   text: '현재 적용 화면(홈·파티 관리·신청관리·정산)의 AppBar 우측 info 아이콘 탭 → showMinglitHelpSheet 패턴으로 일관 적용. 신규·리뉴얼 화면은 같은 패턴을 채택.', recipeKey: 'do-info-icon-pattern' },
       { kind: 'dont', text: 'HelpSheet 안에 버튼/폼/액션 삽입 금지 — 정보 전달 전용. 액션이 필요하면 별도 Route 사용.', recipeKey: 'dont-action-in-help' },
       { kind: 'do',   text: '섹션 제목은 "질문 형태" — 사용자 mental model에 맞춰 Q&A 구성.',                          recipeKey: 'do-qa-format' },
       { kind: 'dont', text: '단일 섹션만 있을 때 MinglitHelpSheet 사용 금지 — MinglitBottomSheet + Text 사용.',         recipeKey: 'dont-single-section' },
@@ -2262,8 +2262,8 @@ await showMinglitHelpSheet(
 );`,
     placement: {
       where: [
-        '파트너 앱 모든 화면 AppBar 우측 info(help) 아이콘 탭 시 표시.',
-        '어느 화면에서든 showMinglitHelpSheet() 호출로 표시. scaffold 종속 없음.',
+        '현재 적용 화면(홈·파티 관리·신청관리·정산)의 AppBar 우측 info(help) 아이콘 탭 시 표시.',
+        '신규·리뉴얼 파트너 화면은 showMinglitHelpSheet() 호출 패턴으로 확장. scaffold 종속 없음.',
       ],
       spacing: [
         { neighbor: '핸들 바',         gap: 'spacing-xxsmall (2px) 최상단 · spacing-xsmall (4px) 상하 · spacing-small (8px) 아래' },


### PR DESCRIPTION
## Summary
- Replace the over-broad partner AppBar info help-sheet claim with the explicit current scope: home, party management, application management, and settlement.
- Keep the forward policy for new or redesigned partner screens to adopt the same info icon -> MinglitHelpSheet pattern.
- Add MDS docs local run commands to apps/mds/docs/BLUEDOC.md while keeping it at 50 lines.

Fixes #2421

## Verification
- rg check: no remaining over-broad claim in the touched MDS help-sheet docs
- npm run lint --workspace=apps/mds/docs
- npm run build --workspace=apps/mds/docs
- Local server: http://localhost:3003/specs/partner_home_page/index.html