### PR TITLE
chore(workflow): route MDS change issues to architecture

### DIFF
--- a/.github/workflows/triage-mds-issue.yml
+++ b/.github/workflows/triage-mds-issue.yml
@@ -92,12 +92,6 @@ jobs:
               | head -n 200
             echo '```'
             echo ""
-            echo "## tpm 트리아지 가이드"
-            echo ""
-            echo "- spec 변경이 **코드 반영을 요구**하면 → \`needs-swe\` 부여 (본문에 관련 Flutter 위젯 경로 명시)"
-            echo "- spec 변경이 **단순 정리/리팩터링**이면 → close"
-            echo "- 판단 애매하면 → \`needs-uiux\` 부여 (ux-designer 워커가 drift 분석)"
-            echo ""
             echo "## 관련 Flutter 코드 검색 힌트"
             echo ""
             echo '```bash'
@@ -124,5 +118,6 @@ jobs:
 
           gh issue create \
             --repo "$REPO" \
-            --title "[mds-change] ${FILE_COUNT}개 spec 변경 — 코드 반영 검토 필요 (${COMMIT_SHA:0:7})" \
-            --body "$BODY"
+            --title "[mds-change] ${FILE_COUNT}개 spec 변경 — 구현·문서·CUJ 영향 검토 필요 (${COMMIT_SHA:0:7})" \
+            --body "$BODY" \
+            --label needs-arch


### PR DESCRIPTION
## Summary
- `triage-mds-issue`에서 TPM 라벨 판단 가이드를 제거했습니다.
- 자동 생성되는 MDS 변경 이슈 제목을 `구현·문서·CUJ 영향 검토 필요`로 바꿨습니다.
- MDS 변경 이슈 생성 시 기본 라벨로 `needs-arch`를 붙이도록 했습니다.

## Why
- #2952 후속: MDS 변경이 구현만 유도되지 않고 feature doc/CUJ 영향까지 먼저 검토되도록 라우팅을 조정합니다.

## Verification
- `git diff --check -- .github/workflows/triage-mds-issue.yml`

Refs #2952