### PR TITLE
feat(app_partner): add partner guide hub

### DIFF
--- a/apps/app_partner/BLUEDOC.md
+++ b/apps/app_partner/BLUEDOC.md
@@ -43,9 +43,8 @@ Minglit 의 **파트너 사장님 Flutter 앱**. 매장 관리·멤버 초대·�
 
 ## 관련
 
-- [architecture.md](./architecture.md) — 파트너 앱 라우팅·권한 redirect 상세
-- [minglit_kit/BLUEDOC.md](../../shared/packages/minglit_kit/BLUEDOC.md) — 공용 패키지
+- [architecture.md](./architecture.md) — 라우팅·권한 / [minglit_kit](../../shared/packages/minglit_kit/BLUEDOC.md) — 공용 패키지
 - [README.md](./README.md) — 빌드·실행 / [integration_test/cuj](./integration_test/cuj/BLUEDOC.md) — CUJ
 
 ---
-_Reviewed: 2026-05-28 19:40_
+_Reviewed: 2026-06-03 13:01_

--- a/apps/app_partner/integration_test/mds-emulator-render/more_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/more_page/builder.dart
@@ -36,6 +36,9 @@ class _NoOpMoreCoordinator implements MoreCoordinator {
   void pushNotificationSettings() {}
 
   @override
+  void pushPartnerGuide() {}
+
+  @override
   void pushPartyList() {}
 
   @override

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_guide/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_guide/builder.dart
@@ -1,29 +1,51 @@
+import 'package:app_partner/src/features/home/guide/partner_guide_page.dart';
 import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
 
 import '../_engine/builder.dart';
 
-class _PartnerGuideRenderPage extends StatelessWidget {
-  const _PartnerGuideRenderPage();
+class PartnerGuideBuilder extends MdsScreenBuilder<PartnerGuidePage> {
+  PartnerGuideBuilder() : super(page: const PartnerGuidePage());
 
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text('partner_guide'),
-      ),
-    );
-  }
-}
-
-class PartnerGuideBuilder extends MdsScreenBuilder<_PartnerGuideRenderPage> {
-  PartnerGuideBuilder() : super(page: const _PartnerGuideRenderPage());
+  bool _showTopicSheet = false;
+  Brightness _brightness = Brightness.light;
 
   PartnerGuideBuilder defaultState() {
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  PartnerGuideBuilder withTopicSheet() {
+    _showTopicSheet = true;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
     return this;
   }
 
   PartnerGuideBuilder dark() {
-    useDarkTheme();
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
     return this;
+  }
+
+  @override
+  Widget build() {
+    final home = _showTopicSheet
+        ? const PartnerGuidePage(initialTopicSlug: 'dashboard-overview')
+        : const PartnerGuidePage();
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: home,
+      ),
+    );
   }
 }

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_guide/partner_guide_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_guide/partner_guide_test.dart
@@ -14,7 +14,7 @@ final catalog = MdsCatalog<PartnerGuideBuilder>(
   builder: PartnerGuideBuilder.new,
   states: [
     MdsState('state-default', (b) => b.defaultState(), mdsIndex: 1),
-    MdsState('state-default-2', (b) => b.defaultState(), mdsIndex: 2),
+    MdsState('state-topic-sheet', (b) => b.withTopicSheet(), mdsIndex: 2),
   ],
 );
 

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_home_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_home_page/builder.dart
@@ -73,6 +73,9 @@ class _NoOpPartnerHomeCoordinator implements PartnerHomeCoordinator {
   void pushLocationGuide() {}
 
   @override
+  void pushPartnerGuide() {}
+
+  @override
   void pushNotificationCenter() {}
 
   @override

--- a/apps/app_partner/lib/src/features/home/guide/partner_guide_page.dart
+++ b/apps/app_partner/lib/src/features/home/guide/partner_guide_page.dart
@@ -1,0 +1,235 @@
+import 'dart:async' show unawaited;
+
+import 'package:app_partner/src/features/home/guide/partner_guide_topic.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+const double _kGuideIntroIconBoxSize =
+    MinglitIconSize.large + MinglitSpacing.medium;
+const double _kGuideTopicIconBoxSize =
+    MinglitIconSize.medium + MinglitSpacing.sm;
+
+class PartnerGuidePage extends StatefulWidget {
+  const PartnerGuidePage({
+    super.key,
+    this.initialTopicSlug,
+  });
+
+  final String? initialTopicSlug;
+
+  @override
+  State<PartnerGuidePage> createState() => _PartnerGuidePageState();
+}
+
+class _PartnerGuidePageState extends State<PartnerGuidePage> {
+  bool _didOpenInitialTopic = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _openInitialTopicOnce();
+  }
+
+  void _openInitialTopicOnce() {
+    if (_didOpenInitialTopic || widget.initialTopicSlug == null) {
+      return;
+    }
+
+    final topic = partnerGuideTopicBySlug(widget.initialTopicSlug!);
+    if (topic == null) {
+      return;
+    }
+
+    _didOpenInitialTopic = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      unawaited(showPartnerGuideTopicSheet(context, topic));
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      appBar: MinglitTheme.simpleAppBar(title: '도움말'),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.only(
+            top: MinglitSpacing.medium,
+            bottom: MinglitSpacing.xxxlarge,
+          ),
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: MinglitSpacing.medium,
+              ),
+              child: _GuideIntro(colorScheme: colorScheme, theme: theme),
+            ),
+            const SizedBox(height: MinglitSpacing.large),
+            MinglitSettingsGroup(
+              header: '토픽',
+              children: [
+                for (final topic in partnerGuideTopics)
+                  _GuideTopicTile(
+                    key: ValueKey(topic.routePath),
+                    topic: topic,
+                    onTap: () {
+                      unawaited(showPartnerGuideTopicSheet(context, topic));
+                    },
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GuideIntro extends StatelessWidget {
+  const _GuideIntro({
+    required this.colorScheme,
+    required this.theme,
+  });
+
+  final ColorScheme colorScheme;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colorScheme.primary.withValues(alpha: MinglitOpacity.tintFill),
+        borderRadius: BorderRadius.circular(MinglitRadius.card),
+        border: Border.all(
+          color: colorScheme.primary.withValues(alpha: MinglitOpacity.subtle),
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(MinglitSpacing.large),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: _kGuideIntroIconBoxSize,
+              height: _kGuideIntroIconBoxSize,
+              decoration: BoxDecoration(
+                color: colorScheme.primary.withValues(
+                  alpha: MinglitOpacity.highlight,
+                ),
+                borderRadius: BorderRadius.circular(MinglitRadius.input),
+              ),
+              child: Icon(
+                Icons.menu_book_outlined,
+                color: colorScheme.primary,
+                size: MinglitIconSize.medium,
+              ),
+            ),
+            const SizedBox(width: MinglitSpacing.medium),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '밍글릿 파트너 가이드',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: MinglitSpacing.xsmall),
+                  Text(
+                    '운영 중 자주 확인하는 항목을 토픽별로 모았어요.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GuideTopicTile extends StatelessWidget {
+  const _GuideTopicTile({
+    required this.topic,
+    required this.onTap,
+    super.key,
+  });
+
+  final PartnerGuideTopic topic;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: MinglitSpacing.medium,
+          vertical: MinglitSpacing.sm,
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: _kGuideTopicIconBoxSize,
+              height: _kGuideTopicIconBoxSize,
+              decoration: BoxDecoration(
+                color: topic.iconColor.withValues(
+                  alpha: MinglitOpacity.tintFill,
+                ),
+                borderRadius: BorderRadius.circular(MinglitRadius.input),
+              ),
+              child: Icon(
+                topic.icon,
+                color: topic.iconColor,
+                size: MinglitIconSize.small,
+              ),
+            ),
+            const SizedBox(width: MinglitSpacing.medium),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    topic.title,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: MinglitSpacing.xxsmall),
+                  Text(
+                    topic.subtitle,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: MinglitSpacing.small),
+            Icon(
+              Icons.chevron_right,
+              size: MinglitIconSize.small,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/lib/src/features/home/guide/partner_guide_topic.dart
+++ b/apps/app_partner/lib/src/features/home/guide/partner_guide_topic.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+class PartnerGuideTopic {
+  const PartnerGuideTopic({
+    required this.slug,
+    required this.routePath,
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    required this.subtitle,
+    required this.sections,
+  });
+
+  final String slug;
+  final String routePath;
+  final IconData icon;
+  final Color iconColor;
+  final String title;
+  final String subtitle;
+  final List<HelpSection> sections;
+}
+
+const partnerGuideTopics = [
+  PartnerGuideTopic(
+    slug: 'dashboard-overview',
+    routePath: '/guide/dashboard/overview',
+    icon: Icons.query_stats_outlined,
+    iconColor: MinglitColors.info,
+    title: '운영 현황',
+    subtitle: '대시보드 숫자와 이동 경로',
+    sections: [
+      HelpSection(
+        title: '이 숫자가 뭔가요?',
+        body:
+            '등록된 파티는 게시 완료된 파티 수예요. '
+            '모집 중인 이벤트는 활성 이벤트 수이고, '
+            '참가예정 고객은 활성 이벤트의 결제 완료 참가자 합계예요.',
+      ),
+      HelpSection(
+        title: '탭하면 어디로 이동하나요?',
+        body: '등록된 파티는 파티 리스트, 모집 중인 이벤트는 이벤트 리스트, 참가예정 고객은 신청관리 탭으로 이동해요.',
+      ),
+    ],
+  ),
+  PartnerGuideTopic(
+    slug: 'operations-live',
+    routePath: '/guide/operations/live',
+    icon: Icons.play_circle_outline,
+    iconColor: MinglitColors.success,
+    title: '진행 중',
+    subtitle: '체크인과 이벤트 운영',
+    sections: [
+      HelpSection(
+        title: '체크인은 언제부터 가능한가요?',
+        body:
+            '이벤트 시작 2시간 전부터 QR 체크인이 활성화돼요. '
+            '그 전에는 QR 체크인 버튼이 비활성 상태로 보여요.',
+      ),
+      HelpSection(
+        title: 'QR 체크인과 수동 체크인은 어떻게 다른가요?',
+        body:
+            'QR 체크인은 사용자가 보여준 QR을 스캔하는 기본 흐름이에요. '
+            'QR을 읽기 어렵거나 휴대폰 분실 같은 예외 상황에서는 '
+            '명단에서 수동 체크인을 사용할 수 있어요.',
+      ),
+      HelpSection(
+        title: '이벤트가 끝나면 어떻게 되나요?',
+        body:
+            '종료 시각 이후 24시간 동안 홈에 남아 운영 상태를 확인할 수 있고, '
+            '이후에는 홈에서 사라져요. 정산 탭에서는 계속 추적할 수 있어요.',
+      ),
+    ],
+  ),
+  PartnerGuideTopic(
+    slug: 'applications-pending',
+    routePath: '/guide/applications/pending',
+    icon: Icons.fact_check_outlined,
+    iconColor: MinglitColors.primary,
+    title: '이벤트 참가 승인 대기',
+    subtitle: '승인, 거절, 결제 전환',
+    sections: [
+      HelpSection(
+        title: '왜 승인이 필요한가요?',
+        body: '파트너가 사용자 프로필, 사진, 자기소개를 확인한 뒤 승인해야 결제 안내가 발송되고 참가가 확정돼요.',
+      ),
+      HelpSection(
+        title: '거절하면 환불이 필요한가요?',
+        body: '거절 단계에서는 결제가 진행되지 않으므로 환불이 필요하지 않아요. 입력한 거절 사유는 사용자에게 안내돼요.',
+      ),
+      HelpSection(
+        title: '승인 후 사용자가 결제하지 않으면요?',
+        body: '승인 후 24시간 안에 결제가 완료되지 않으면 신청이 자동 만료돼요.',
+      ),
+    ],
+  ),
+  PartnerGuideTopic(
+    slug: 'operations-upcoming',
+    routePath: '/guide/operations/upcoming',
+    icon: Icons.event_available_outlined,
+    iconColor: MinglitColors.warning,
+    title: '진행 임박',
+    subtitle: 'T-7 체크리스트와 환불 정책',
+    sections: [
+      HelpSection(
+        title: '진행 임박은 어떤 상태인가요?',
+        body: '시작 7일 이내 이벤트예요. 최종 명단 확인, 워크인 준비, 환불 정책 확인이 필요한 단계예요.',
+      ),
+      HelpSection(
+        title: '환불 정책은 어떻게 적용되나요?',
+        body: 'T-7 이내 사용자 환불 요청은 정책에 따라 부분 환불될 수 있어요. 파트너 사유 취소는 전액 환불로 처리돼요.',
+      ),
+      HelpSection(
+        title: '정산 기준은 무엇인가요?',
+        body: 'QR 체크인 완료 참가자가 정산 기준이에요. 정산 마감일은 이벤트 종료 후 익월 말일이에요.',
+      ),
+    ],
+  ),
+  PartnerGuideTopic(
+    slug: 'events-recruiting',
+    routePath: '/guide/events/recruiting',
+    icon: Icons.campaign_outlined,
+    iconColor: MinglitColors.tertiary,
+    title: '모집 중인 이벤트',
+    subtitle: '공유, 정원, 가격 변경',
+    sections: [
+      HelpSection(
+        title: '이벤트는 어떻게 공유하나요?',
+        body:
+            '이벤트 상세 화면의 공유 버튼을 사용해요. '
+            '앱을 설치하지 않은 사용자도 웹 미리보기로 내용을 확인할 수 있어요.',
+      ),
+      HelpSection(
+        title: '정원이 다 차지 않아도 진행할 수 있나요?',
+        body: '최소 인원을 별도로 설정하지 않았다면 정원 미달이어도 진행할 수 있어요.',
+      ),
+      HelpSection(
+        title: '모집 시작 후 가격 변경이 가능한가요?',
+        body:
+            '이미 결제한 사용자가 있을 수 있어 모집 시작 후 가격 변경은 지원하지 않아요. '
+            '변경이 필요하면 이벤트를 취소하고 다시 생성해야 해요.',
+      ),
+    ],
+  ),
+  PartnerGuideTopic(
+    slug: 'create-party-drafts',
+    routePath: '/guide/create-party/drafts',
+    icon: Icons.edit_calendar_outlined,
+    iconColor: MinglitColors.secondary,
+    title: '작성 중인 파티',
+    subtitle: '임시저장, 게시, 이벤트 연결',
+    sections: [
+      HelpSection(
+        title: '임시저장과 게시는 어떻게 다른가요?',
+        body: '임시저장은 사용자에게 노출되지 않아요. 게시하면 검색에 노출되지만, 사용자가 신청하려면 이벤트를 만들어야 해요.',
+      ),
+      HelpSection(
+        title: '파티와 이벤트는 무엇이 다른가요?',
+        body: '파티는 모임의 브랜드이고 이벤트는 회차예요. 하나의 파티 안에서 여러 이벤트를 반복 운영할 수 있어요.',
+      ),
+      HelpSection(
+        title: '이미지는 어떤 규격이 좋나요?',
+        body: '16:9 비율, 최소 1080x608, JPG 또는 PNG를 권장해요. 사용자 앱의 대표 영역에 노출돼요.',
+      ),
+    ],
+  ),
+];
+
+PartnerGuideTopic? partnerGuideTopicBySlug(String slug) {
+  for (final topic in partnerGuideTopics) {
+    if (topic.slug == slug) {
+      return topic;
+    }
+  }
+  return null;
+}
+
+Future<void> showPartnerGuideTopicSheet(
+  BuildContext context,
+  PartnerGuideTopic topic,
+) {
+  return showMinglitHelpSheet(
+    context: context,
+    title: topic.title,
+    sections: topic.sections,
+  );
+}

--- a/apps/app_partner/lib/src/features/home/partner_home_coordinator.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_coordinator.dart
@@ -27,6 +27,10 @@ class PartnerHomeCoordinator {
     unawaited(_router.push(const LocationGuideRoute().location));
   }
 
+  void pushPartnerGuide() {
+    unawaited(_router.push(const PartnerGuideRoute().location));
+  }
+
   // Fix #635: settlement 탭 전환을 home coordinator를 통해 위임 (feature 격리)
   void goToSettlement() {
     _router.go(const SettlementRoute().location);

--- a/apps/app_partner/lib/src/features/home/partner_home_page.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_page.dart
@@ -149,6 +149,7 @@ class PartnerHomePage extends ConsumerWidget {
                           coordinator.pushEventCreate(selected.id);
                         }
                       },
+                      onOpenGuide: coordinator.pushPartnerGuide,
                     ),
                   ] else ...[
                     HomeOverviewBlock(

--- a/apps/app_partner/lib/src/features/home/widgets/onboarding_step_guide.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/onboarding_step_guide.dart
@@ -9,6 +9,7 @@ class OnboardingStepGuide extends StatelessWidget {
     required this.partyName,
     required this.onCreateParty,
     required this.onCreateEvent,
+    this.onOpenGuide,
     super.key,
   });
 
@@ -16,6 +17,7 @@ class OnboardingStepGuide extends StatelessWidget {
   final String? partyName;
   final VoidCallback onCreateParty;
   final VoidCallback onCreateEvent;
+  final VoidCallback? onOpenGuide;
 
   @override
   Widget build(BuildContext context) {
@@ -216,6 +218,20 @@ class OnboardingStepGuide extends StatelessWidget {
         // How it works (only before party creation)
         if (!hasParty) ...[
           const SizedBox(height: MinglitSpacing.large),
+          if (onOpenGuide != null) ...[
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: onOpenGuide,
+                icon: const Icon(
+                  Icons.help_outline,
+                  size: MinglitIconSize.small,
+                ),
+                label: const Text('도움말 보기'),
+              ),
+            ),
+            const SizedBox(height: MinglitSpacing.medium),
+          ],
           Container(
             padding: const EdgeInsets.all(MinglitSpacing.medium),
             decoration: BoxDecoration(

--- a/apps/app_partner/lib/src/features/more/more_coordinator.dart
+++ b/apps/app_partner/lib/src/features/more/more_coordinator.dart
@@ -19,7 +19,7 @@ class MoreCoordinator {
   }
 
   void pushPartnerGuide() {
-    unawaited(_router.push(const PartnerGuideRoute().location));
+    _router.go(const PartnerGuideRoute().location);
   }
 
   void pushMemberList(String partnerId) {
@@ -38,7 +38,7 @@ class MoreCoordinator {
   // Fix #1568: 정산 계좌 관리 진입점
   // Fix #1834: push() cross-branch (/more → /settlement) fails silently in
   // StatefulShellRoute (same class of bug as #1680). Use go() to switch branch
-  // directly — matching the pattern of goToSettlement() in SettlementCoordinator.
+  // directly, matching goToSettlement() in SettlementCoordinator.
   void pushBankAccountManagement() {
     _router.go(const BankAccountRoute().location);
   }

--- a/apps/app_partner/lib/src/features/more/more_coordinator.dart
+++ b/apps/app_partner/lib/src/features/more/more_coordinator.dart
@@ -18,6 +18,10 @@ class MoreCoordinator {
     unawaited(_router.push(const NotificationSettingsRoute().location));
   }
 
+  void pushPartnerGuide() {
+    unawaited(_router.push(const PartnerGuideRoute().location));
+  }
+
   void pushMemberList(String partnerId) {
     unawaited(_router.push(MemberListRoute(partnerId: partnerId).location));
   }

--- a/apps/app_partner/lib/src/features/more/more_page.dart
+++ b/apps/app_partner/lib/src/features/more/more_page.dart
@@ -159,6 +159,11 @@ class MorePage extends ConsumerWidget {
               header: '약관 및 정보',
               children: [
                 MinglitSettingsTile(
+                  leading: Icons.help_outline,
+                  title: '도움말',
+                  onTap: moreCoordinator.pushPartnerGuide,
+                ),
+                MinglitSettingsTile(
                   leading: Icons.privacy_tip_outlined,
                   title: '개인정보처리방침',
                   onTap: () {

--- a/apps/app_partner/lib/src/routing/app_routes.dart
+++ b/apps/app_partner/lib/src/routing/app_routes.dart
@@ -10,6 +10,7 @@ import 'package:app_partner/src/features/application/event_application_manage_pa
 import 'package:app_partner/src/features/auth/partner_login_page.dart';
 import 'package:app_partner/src/features/checkin/checkin_placeholder_page.dart';
 import 'package:app_partner/src/features/home/guide/location_guide_page.dart';
+import 'package:app_partner/src/features/home/guide/partner_guide_page.dart';
 import 'package:app_partner/src/features/home/partner_home_page.dart';
 import 'package:app_partner/src/features/member/partner_member_list_page.dart';
 import 'package:app_partner/src/features/member/partner_member_permission_page.dart';
@@ -113,7 +114,10 @@ class NotificationCenterRoute extends GoRouteData
       routes: [
         TypedGoRoute<HomeRoute>(
           path: '/',
-          routes: [TypedGoRoute<LocationGuideRoute>(path: 'guide/location')],
+          routes: [
+            TypedGoRoute<LocationGuideRoute>(path: 'guide/location'),
+            TypedGoRoute<PartnerGuideRoute>(path: 'guide'),
+          ],
         ),
       ],
     ),
@@ -270,6 +274,13 @@ class HomeRoute extends GoRouteData with $HomeRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const PartnerHomePage();
+}
+
+class PartnerGuideRoute extends GoRouteData with $PartnerGuideRoute {
+  const PartnerGuideRoute();
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const PartnerGuidePage();
 }
 
 class ApplicationListRoute extends GoRouteData with $ApplicationListRoute {

--- a/apps/app_partner/lib/src/routing/app_routes.g.dart
+++ b/apps/app_partner/lib/src/routing/app_routes.g.dart
@@ -180,6 +180,10 @@ RouteBase get $partnerShellRoute => StatefulShellRouteData.$route(
               path: 'guide/location',
               factory: $LocationGuideRoute._fromState,
             ),
+            GoRouteData.$route(
+              path: 'guide',
+              factory: $PartnerGuideRoute._fromState,
+            ),
           ],
         ),
       ],
@@ -383,6 +387,27 @@ mixin $LocationGuideRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/guide/location');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $PartnerGuideRoute on GoRouteData {
+  static PartnerGuideRoute _fromState(GoRouterState state) =>
+      const PartnerGuideRoute();
+
+  @override
+  String get location => GoRouteData.$location('/guide');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/apps/app_partner/test/BLUEDOC.md
+++ b/apps/app_partner/test/BLUEDOC.md
@@ -38,4 +38,4 @@ CI 자동 실행: `pr-gate.test-flutter-apps` matrix. 커버리지 dev 자동 �
 - [tests/_coverage/BLUEDOC](../../../tests/_coverage/BLUEDOC.md)
 
 ---
-_Reviewed: 2026-05-30 23:22_
+_Reviewed: 2026-06-03 13:01_

--- a/apps/app_partner/test/src/features/home/guide/partner_guide_page_test.dart
+++ b/apps/app_partner/test/src/features/home/guide/partner_guide_page_test.dart
@@ -1,0 +1,53 @@
+import 'package:app_partner/src/features/home/guide/partner_guide_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  group('PartnerGuidePage', () {
+    testWidgets('renders guide topics', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: const PartnerGuidePage(),
+        ),
+      );
+
+      expect(find.text('도움말'), findsOneWidget);
+      expect(find.text('밍글릿 파트너 가이드'), findsOneWidget);
+      expect(find.text('운영 현황'), findsOneWidget);
+      expect(find.text('진행 중'), findsOneWidget);
+      expect(find.text('이벤트 참가 승인 대기'), findsOneWidget);
+      expect(find.text('진행 임박'), findsOneWidget);
+      expect(find.text('모집 중인 이벤트'), findsOneWidget);
+      expect(find.text('작성 중인 파티'), findsOneWidget);
+    });
+
+    testWidgets('opens topic sheet from row tap', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: const PartnerGuidePage(),
+        ),
+      );
+
+      await tester.tap(find.text('운영 현황'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('이 숫자가 뭔가요?'), findsOneWidget);
+      expect(find.text('확인'), findsOneWidget);
+    });
+
+    testWidgets('opens initial topic sheet from slug', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: const PartnerGuidePage(initialTopicSlug: 'dashboard-overview'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('이 숫자가 뭔가요?'), findsOneWidget);
+    });
+  });
+}

--- a/apps/app_partner/test/src/features/home/partner_home_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/home/partner_home_coordinator_test.dart
@@ -58,6 +58,16 @@ void main() {
       ).called(1);
     });
 
+    test('pushPartnerGuide calls router.push with guide hub route', () {
+      final container = createContainer(
+        overrides: [goRouterProvider.overrideWithValue(mockRouter)],
+      );
+
+      container.read(partnerHomeCoordinatorProvider).pushPartnerGuide();
+
+      verify(() => mockRouter.push(any(that: equals('/guide')))).called(1);
+    });
+
     test('goToSettlement calls router.go with settlement route', () {
       final container = createContainer(
         overrides: [goRouterProvider.overrideWithValue(mockRouter)],

--- a/apps/app_partner/test/src/features/home/widgets/onboarding_step_guide_test.dart
+++ b/apps/app_partner/test/src/features/home/widgets/onboarding_step_guide_test.dart
@@ -110,5 +110,31 @@ void main() {
         expect(callCount, 1);
       },
     );
+
+    testWidgets('calls onOpenGuide callback when guide button tapped', (
+      tester,
+    ) async {
+      var callCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: OnboardingStepGuide(
+                hasParty: false,
+                partyName: null,
+                onCreateParty: () {},
+                onCreateEvent: () {},
+                onOpenGuide: () => callCount++,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('도움말 보기'));
+      expect(callCount, 1);
+    });
   });
 }

--- a/apps/app_partner/test/src/features/more/more_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/more/more_coordinator_test.dart
@@ -35,14 +35,15 @@ void main() {
       verify(() => mockRouter.push(any())).called(1);
     });
 
-    test('pushPartnerGuide calls router.push with guide hub route', () {
+    test('pushPartnerGuide calls router.go with guide hub route', () {
       final container = createContainer(
         overrides: [goRouterProvider.overrideWithValue(mockRouter)],
       );
 
       container.read(moreCoordinatorProvider).pushPartnerGuide();
 
-      verify(() => mockRouter.push(any(that: equals('/guide')))).called(1);
+      verifyNever(() => mockRouter.push(any()));
+      verify(() => mockRouter.go(any(that: equals('/guide')))).called(1);
     });
 
     test('pushMemberList calls router.push with partnerId in route', () {
@@ -80,7 +81,7 @@ void main() {
       ).called(1);
     });
 
-    // Fix #1834: push() cross-branch (more → settlement) fails in StatefulShellRoute.
+    // Fix #1834: push() cross-branch (more -> settlement) fails in shell route.
     // Must use go() — not push() — so this test guards against regression.
     test(
       'pushBankAccountManagement calls router.go with /settlement/bank-account',

--- a/apps/app_partner/test/src/features/more/more_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/more/more_coordinator_test.dart
@@ -35,6 +35,16 @@ void main() {
       verify(() => mockRouter.push(any())).called(1);
     });
 
+    test('pushPartnerGuide calls router.push with guide hub route', () {
+      final container = createContainer(
+        overrides: [goRouterProvider.overrideWithValue(mockRouter)],
+      );
+
+      container.read(moreCoordinatorProvider).pushPartnerGuide();
+
+      verify(() => mockRouter.push(any(that: equals('/guide')))).called(1);
+    });
+
     test('pushMemberList calls router.push with partnerId in route', () {
       final container = createContainer(
         overrides: [goRouterProvider.overrideWithValue(mockRouter)],

--- a/apps/app_partner/test/src/features/more/more_page_test.dart
+++ b/apps/app_partner/test/src/features/more/more_page_test.dart
@@ -112,6 +112,8 @@ void main() {
       // Fix #1213: 로그아웃/회원탈퇴/파트너프로필이 계정 관리 서브페이지로 이동 —
       // MorePage에서는 '계정 관리' 항목만 표시됨
       expect(find.text('계정 관리'), findsOneWidget);
+      await tester.scrollUntilVisible(find.text('도움말'), 100);
+      expect(find.text('도움말'), findsOneWidget);
       await tester.scrollUntilVisible(find.text('개인정보처리방침'), 100);
       expect(find.text('개인정보처리방침'), findsOneWidget);
       await tester.scrollUntilVisible(find.text('이용약관'), 100);
@@ -142,6 +144,21 @@ void main() {
       await tester.pumpAndSettle();
 
       verify(() => mockCoordinator.pushPartyList()).called(1);
+    });
+
+    testWidgets('tapping 도움말 forwards to coordinator', (tester) async {
+      when(() => mockCoordinator.pushPartnerGuide()).thenReturn(null);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(find.text('도움말'), 100);
+      await tester.ensureVisible(find.text('도움말'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('도움말'));
+      await tester.pumpAndSettle();
+
+      verify(() => mockCoordinator.pushPartnerGuide()).called(1);
     });
 
     testWidgets('계정 관리 is visible on MorePage', (tester) async {

--- a/apps/app_partner/test/src/routing/app_routes_test.dart
+++ b/apps/app_partner/test/src/routing/app_routes_test.dart
@@ -61,7 +61,7 @@ void main() {
       );
     });
 
-    test('home branch has location guide sub-route', () {
+    test('home branch has guide sub-routes', () {
       final shellRoute = routes.whereType<StatefulShellRoute>().first;
       final homeBranch = shellRoute.branches[0];
       final homeRoute = homeBranch.routes.first as GoRoute;
@@ -70,7 +70,7 @@ void main() {
           .whereType<GoRoute>()
           .map((r) => r.path)
           .toSet();
-      expect(subPaths, contains('guide/location'));
+      expect(subPaths, containsAll(['guide', 'guide/location']));
     });
 
     test('settlement branch has bank-account and detail sub-routes', () {

--- a/apps/mds/docs/public/specs/partner_guide/index.html
+++ b/apps/mds/docs/public/specs/partner_guide/index.html
@@ -201,28 +201,28 @@ body.dark-mode .viewport {
   <h2>Overview</h2>
   <table class="ref">
     <tbody>
-      <tr><th style="width: 140px;">Status</th><td><strong>🚧 작성 중 (v0.1 초안)</strong></td></tr>
+      <tr><th style="width: 140px;">Status</th><td><strong>✅ 구현 반영 (v1.0)</strong></td></tr>
       <tr><th>App</th><td><code>app_partner</code></td></tr>
       <tr><th>Route / Surface</th><td><code>PartnerGuideRoute</code> · widget: <code>PartnerGuidePage</code></td></tr>
       <tr><th>Path</th><td><code>/guide</code></td></tr>
       <tr>
         <th>Purpose</th>
         <td>
-          파트너 도움말의 진입점 페이지. 6개 토픽 리스트로 구성되며, 각 토픽은 <strong>바텀시트</strong>로 열림 (route 변경 없이 한 페이지 안에서).<br>
-          홈의 각 섹션 ⓘ 버튼은 이 페이지를 거치지 않고 해당 토픽 시트로 직접 진입한다.
+          파트너 도움말의 진입점 페이지. 6개 토픽 리스트로 구성되며, 각 토픽은 <strong>바텀시트</strong>로 열린다.<br>
+          이 HTML은 개별 도움말 페이지가 아니라 재사용 가능한 허브/시트 템플릿이며, 실제 토픽 콘텐츠는 Flutter의 <code>PartnerGuideTopic</code> 데이터로 관리한다.
         </td>
       </tr>
       <tr>
         <th>진입점</th>
         <td>
           ① 파트너 홈 onboarding의 welcome 카드 "도움말 보기" CTA<br>
-          ② 더보기 → 마이페이지 → 도움말 메뉴<br>
-          (각 섹션의 ⓘ 버튼은 메인을 거치지 않고 시트 직접 진입)
+          ② 더보기 → 약관 및 정보 → 도움말 메뉴<br>
+          ③ 향후 홈/카드별 ⓘ 버튼은 <code>initialTopicSlug</code>로 해당 토픽 시트를 직접 열 수 있음
         </td>
       </tr>
       <tr>
         <th>설계 패턴</th>
-        <td>토픽 리스트 (메인) + showModalBottomSheet (Flutter) — 단일 route, 시트 stacking으로 sub-page처럼 노출.</td>
+        <td>단일 HTML spec + 데이터 기반 토픽 모델. 현재는 <code>/guide</code> 허브 + <code>showMinglitHelpSheet</code>, 향후 <code>/guide/create-party/location</code> 같은 deep route로 승격 가능.</td>
       </tr>
     </tbody>
   </table>
@@ -242,17 +242,17 @@ body.dark-mode .viewport {
   <div class="perspective__header">
     <span class="glyph">🧱</span>
     <h2>Layout</h2>
-    <span class="lede">메인 토픽 리스트 + 바텀시트 stacking 구조.</span>
+    <span class="lede">데이터 기반 메인 토픽 리스트 + 바텀시트 템플릿 구조.</span>
   </div>
   <section class="doc">
     <h2>Tree</h2>
-    <p class="intro">단일 route로 동작 — 토픽 탭 시 시트만 stack됨. 시트 dismiss → 메인 리스트로 복귀 (back stack 없음).</p>
+    <p class="intro">현재는 단일 route로 동작 — 토픽 탭 시 시트만 stack됨. 토픽마다 별도 HTML을 만들지 않고 slug/path를 가진 데이터로 확장한다.</p>
     <pre><b>Scaffold</b>
 ├─ <b>AppBar</b>: 좌측 ← back · 타이틀 "도움말"
 ├─ <b>body</b>:
 │   ├─ Intro hero (밍글릿 파트너 가이드 + sub)
 │   ├─ "토픽" 섹션 라벨
-│   └─ <b>토픽 리스트 카드</b> (6 rows)
+│   └─ <b>토픽 리스트 카드</b> (data-driven · 6 rows)
 │       ├─ 운영 현황 — 대시보드 안내
 │       ├─ 진행 중 — 운영 가이드
 │       ├─ 이벤트 참가 승인 대기 — 승인 가이드
@@ -369,15 +369,15 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>
-          <td>① 토픽 row 탭 → 해당 토픽 바텀시트 push (modal).<br>② AppBar ← back → 이전 화면 (홈 또는 마이페이지).</td>
+          <td>① 토픽 row 탭 → 해당 토픽 바텀시트 push (modal).<br>② AppBar ← back → 이전 화면 (홈 또는 더보기).</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">컴포넌트</td>
-          <td>· AppBar (back + "도움말")<br>· Intro hero (gradient 카드 + 환영 카피)<br>· "토픽" 섹션 라벨<br>· 토픽 리스트 카드 (6 row · iOS Settings 스타일 · 컬러 아이콘 박스)</td>
+          <td>· AppBar (back + "도움말")<br>· Intro hero (Minglit token 기반 안내 카드)<br>· "토픽" 섹션 라벨<br>· 토픽 리스트 카드 (6 row · 토큰 컬러 아이콘 박스)</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">노트</td>
-          <td>📝 단일 route. 시트 dismiss 시 이 화면으로 자연 복귀. 홈 ⓘ 버튼은 이 메인 안 거치고 시트 직접 push.</td>
+          <td>📝 단일 route. 시트 dismiss 시 이 화면으로 자연 복귀. 토픽 데이터는 slug/routePath를 보유해 deep route 확장 가능.</td>
         </tr>
       </tbody>
     </table>
@@ -427,7 +427,7 @@ body.dark-mode .viewport {
             </div>
           </td>
           <td class="state-mini__aspect">조건</td>
-          <td>메인에서 토픽 row 탭 또는 홈의 ⓘ 버튼 직접 진입.</td>
+          <td>메인에서 토픽 row 탭 또는 slug 기반 초기 토픽 진입.</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>
@@ -453,7 +453,7 @@ body.dark-mode .viewport {
   <div class="perspective__header">
     <span class="glyph">📋</span>
     <h2>Sheet 콘텐츠</h2>
-    <span class="lede">6개 토픽별 시트 본문. 시스템 동작 / 기능 위치 / 정책 룰 중심.</span>
+    <span class="lede">6개 토픽별 시트 본문. 콘텐츠 SSOT는 Flutter PartnerGuideTopic 데이터이며, 이 섹션은 MDS 검토용 요약.</span>
   </div>
 
   <section class="doc">
@@ -628,11 +628,11 @@ body.dark-mode .viewport {
       <tbody>
         <tr>
           <td><a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a></td>
-          <td>parent — onboarding welcome 카드 "도움말 보기" CTA + 각 섹션 ⓘ 버튼이 진입점.</td>
+          <td>parent — onboarding welcome 카드 "도움말 보기" CTA.</td>
         </tr>
         <tr>
-          <td>마이페이지 (TBD)</td>
-          <td>더보기 → 마이페이지 → 도움말 메뉴 (welcome 카드 dismiss 후에도 항상 접근 가능)</td>
+          <td><code>MorePage</code></td>
+          <td>더보기 → 약관 및 정보 → 도움말 메뉴 (welcome 카드 이후에도 항상 접근 가능)</td>
         </tr>
       </tbody>
     </table>

--- a/apps/mds/docs/public/specs/partner_guide/index.md
+++ b/apps/mds/docs/public/specs/partner_guide/index.md
@@ -4,14 +4,14 @@
 
 ## Overview
 
-| Status | 🚧 작성 중 (v0.1 초안) |
+| Status | ✅ 구현 반영 (v1.0) |
 |---|---|
 | App | app_partner |
 | Route / Surface | PartnerGuideRoute · widget: PartnerGuidePage |
 | Path | /guide |
-| Purpose | 파트너 도움말의 진입점 페이지. 6개 토픽 리스트로 구성되며, 각 토픽은 바텀시트로 열림 (route 변경 없이 한 페이지 안에서).홈의 각 섹션 ⓘ 버튼은 이 페이지를 거치지 않고 해당 토픽 시트로 직접 진입한다. |
-| 진입점 | ① 파트너 홈 onboarding의 welcome 카드 "도움말 보기" CTA② 더보기 → 마이페이지 → 도움말 메뉴(각 섹션의 ⓘ 버튼은 메인을 거치지 않고 시트 직접 진입) |
-| 설계 패턴 | 토픽 리스트 (메인) + showModalBottomSheet (Flutter) — 단일 route, 시트 stacking으로 sub-page처럼 노출. |
+| Purpose | 파트너 도움말의 진입점 페이지. 6개 토픽 리스트로 구성되며, 각 토픽은 바텀시트로 열린다. 이 HTML은 개별 도움말 페이지가 아니라 재사용 가능한 허브/시트 템플릿이며, 실제 토픽 콘텐츠는 Flutter의 PartnerGuideTopic 데이터로 관리한다. |
+| 진입점 | ① 파트너 홈 onboarding의 welcome 카드 "도움말 보기" CTA② 더보기 → 약관 및 정보 → 도움말 메뉴③ 향후 홈/카드별 ⓘ 버튼은 initialTopicSlug로 해당 토픽 시트를 직접 열 수 있음 |
+| 설계 패턴 | 단일 HTML spec + 데이터 기반 토픽 모델. 현재는 /guide 허브 + showMinglitHelpSheet, 향후 /guide/create-party/location 같은 deep route로 승격 가능. |
 
 [🧱 Layout](#layout) [🎨 States](#states) [📋 Sheet 콘텐츠](#sheets) [📖 Reference](#reference)
 
@@ -19,18 +19,18 @@
 
 ## Layout
 
-메인 토픽 리스트 + 바텀시트 stacking 구조.
+데이터 기반 메인 토픽 리스트 + 바텀시트 템플릿 구조.
 
 ## Tree
 
-단일 route로 동작 — 토픽 탭 시 시트만 stack됨. 시트 dismiss → 메인 리스트로 복귀 (back stack 없음).
+현재는 단일 route로 동작 — 토픽 탭 시 시트만 stack됨. 토픽마다 별도 HTML을 만들지 않고 slug/path를 가진 데이터로 확장한다.
 
 **Scaffold**
 ├─ **AppBar**: 좌측 ← back · 타이틀 "도움말"
 ├─ **body**:
 │   ├─ Intro hero (밍글릿 파트너 가이드 + sub)
 │   ├─ "토픽" 섹션 라벨
-│   └─ **토픽 리스트 카드** (6 rows)
+│   └─ **토픽 리스트 카드** (data-driven · 6 rows)
 │       ├─ 운영 현황 — 대시보드 안내
 │       ├─ 진행 중 — 운영 가이드
 │       ├─ 이벤트 참가 승인 대기 — 승인 가이드
@@ -57,9 +57,9 @@
 | 항목 | 내용 |
 |---|---|
 | 조건 | 도움말 진입 — 메인 토픽 리스트. |
-| 사용자 액션 | ① 토픽 row 탭 → 해당 토픽 바텀시트 push (modal).② AppBar ← back → 이전 화면 (홈 또는 마이페이지). |
-| 컴포넌트 | · AppBar (back + "도움말")· Intro hero (gradient 카드 + 환영 카피)· "토픽" 섹션 라벨· 토픽 리스트 카드 (6 row · iOS Settings 스타일 · 컬러 아이콘 박스) |
-| 노트 | 📝 단일 route. 시트 dismiss 시 이 화면으로 자연 복귀. 홈 ⓘ 버튼은 이 메인 안 거치고 시트 직접 push. |
+| 사용자 액션 | ① 토픽 row 탭 → 해당 토픽 바텀시트 push (modal).② AppBar ← back → 이전 화면 (홈 또는 더보기). |
+| 컴포넌트 | · AppBar (back + "도움말")· Intro hero (Minglit token 기반 안내 카드)· "토픽" 섹션 라벨· 토픽 리스트 카드 (6 row · 토큰 컬러 아이콘 박스) |
+| 노트 | 📝 단일 route. 시트 dismiss 시 이 화면으로 자연 복귀. 토픽 데이터는 slug/routePath를 보유해 deep route 확장 가능. |
 
 ### 시트 열림 — "운영 현황" 예시 토픽 탭 시 push되는 modal sheet
 
@@ -67,7 +67,7 @@
 
 | 항목 | 내용 |
 |---|---|
-| 조건 | 메인에서 토픽 row 탭 또는 홈의 ⓘ 버튼 직접 진입. |
+| 조건 | 메인에서 토픽 row 탭 또는 slug 기반 초기 토픽 진입. |
 | 사용자 액션 | ① 시트 body 스크롤 → 콘텐츠 탐색.② "확인" CTA 또는 시트 외부(overlay) 탭 / swipe down → dismiss.③ Dismiss 후 메인 리스트로 자연 복귀. |
 | 컴포넌트 | · Modal overlay (rgba 0.4)· 시트 (bottom-anchored · max-height 80% · top-radius 20px)· 핸들 + 헤더(타이틀 + 구분선) + 스크롤 body + 풀폭 "확인" CTA· body 안 섹션: 타이틀(14/700) + 본문(13 secondary line-height 1.6) |
 | 노트 | 📝 콘텐츠는 토픽별로 다름 (아래 "Sheet 콘텐츠" 섹션 참고). 닫기 X 없음 — "확인" 또는 swipe. |
@@ -76,7 +76,7 @@
 
 ## Sheet 콘텐츠
 
-6개 토픽별 시트 본문. 시스템 동작 / 기능 위치 / 정책 룰 중심.
+6개 토픽별 시트 본문. 콘텐츠 SSOT는 Flutter PartnerGuideTopic 데이터이며, 이 섹션은 MDS 검토용 요약.
 
 ## 1\. 운영 현황
 
@@ -141,5 +141,5 @@ T-7 이내 이벤트 — 환불 정책과 정산 규칙이 적용되기 시작�
 
 | Spec | Relation |
 |---|---|
-| PartnerHomePage | parent — onboarding welcome 카드 "도움말 보기" CTA + 각 섹션 ⓘ 버튼이 진입점. |
-| 마이페이지 (TBD) | 더보기 → 마이페이지 → 도움말 메뉴 (welcome 카드 dismiss 후에도 항상 접근 가능) |
+| PartnerHomePage | parent — onboarding welcome 카드 "도움말 보기" CTA. |
+| MorePage | 더보기 → 약관 및 정보 → 도움말 메뉴 (welcome 카드 이후에도 항상 접근 가능) |

--- a/apps/mds/docs/src/lib/flow-data.ts
+++ b/apps/mds/docs/src/lib/flow-data.ts
@@ -114,6 +114,7 @@ const APP_PARTNER_ONBOARDING_FLOW = `flowchart LR
 
 const APP_PARTNER_MAIN_FLOW = `flowchart TB
   Start([Start]) --> HomeRoute
+  HomeRoute -->|"view guide hub"| PartnerGuideRoute
   HomeRoute -->|"view location guide"| LocationGuideRoute
   HomeRoute -->|"tap notifications"| NotificationCenterRoute
   HomeRoute -->|"bottom nav"| ApplicationListRoute
@@ -124,6 +125,7 @@ const APP_PARTNER_MAIN_FLOW = `flowchart TB
   SettlementRoute -->|"tap settlement item"| SettlementDetailRoute
   SettlementRoute -->|"manage bank account"| BankAccountRoute
   HomeRoute -->|"bottom nav"| MoreRoute
+  MoreRoute -->|"help"| PartnerGuideRoute
   MoreRoute -->|"manage parties (/more/parties)"| PartyListRoute
   PartyListRoute -->|"create party"| PartyCreateRoute
   PartyListRoute -->|"tap party"| PartyDetailRoute
@@ -320,6 +322,7 @@ const KNOWN_SPEC_FILES: { user: ReadonlySet<string>; partner: ReadonlySet<string
     'partner_application_detail_page',
     'partner_apply_page',
     'partner_apply_status_page',
+    'partner_guide',
     'partner_event_detail_page',
     'partner_home_page',
     'partner_login_page',
@@ -396,6 +399,9 @@ const ROUTE_DESIGN_OVERRIDES: Record<string, string> = {
   // rule yields 'login_page', which would point to the user spec — override to
   // the partner-specific spec.
   'partner-LoginRoute':              '/specs/partner_login_page/index.html',
+  // PartnerGuideRoute → template-driven guide hub. Default rule yields
+  // 'partner_guide_page', but the single reusable spec is partner_guide.
+  'partner-PartnerGuideRoute':        '/specs/partner_guide/index.html',
   // CheckinRoute → CheckinPlaceholderPage. Default rule yields 'checkin_page'.
   'partner-CheckinRoute':            '/specs/checkin_placeholder_page/index.html',
   // ApplicationDetailRoute (partner) → PartnerApplicationDetailPage (admin-side
@@ -474,13 +480,7 @@ const STANDALONE_SPECS: { user: StandaloneSpec[]; partner: StandaloneSpec[] } = 
       specBasename: 'event_matching_results_screen',
     },
   ],
-  partner: [
-    {
-      widget: 'PartnerGuide',
-      note: 'spec-only · route TBD',
-      specBasename: 'partner_guide',
-    },
-  ],
+  partner: [],
 };
 
 /** Sub-component specs for an app. Used by /screens to render nested rows. */

--- a/apps/mds/docs/src/lib/route-pages.json
+++ b/apps/mds/docs/src/lib/route-pages.json
@@ -190,6 +190,10 @@
       "widget": "LocationGuidePage",
       "file": "apps/app_partner/lib/src/features/home/guide/location_guide_page.dart"
     },
+    "PartnerGuideRoute": {
+      "widget": "PartnerGuidePage",
+      "file": "apps/app_partner/lib/src/features/home/guide/partner_guide_page.dart"
+    },
     "CheckinRoute": {
       "widget": "CheckinPlaceholderPage",
       "file": "apps/app_partner/lib/src/features/checkin/checkin_placeholder_page.dart"


### PR DESCRIPTION
## Summary
- Add `PartnerGuideRoute` at `/guide` and implement `PartnerGuidePage` as a data-driven guide hub.
- Store guide content in `PartnerGuideTopic` with `slug` and future-ready `routePath` values, while current topics open `showMinglitHelpSheet`.
- Wire entry points from home onboarding (`도움말 보기`) and More > 약관 및 정보 > 도움말.
- Update MDS partner guide spec/flows/route page mapping and render catalog to use the real Flutter screen.

## Verification
- `flutter pub run build_runner build --delete-conflicting-outputs` (build_runner warns the flag is ignored, route file generated)
- `dart analyze apps/app_partner/lib/src/features/home/guide/partner_guide_page.dart apps/app_partner/lib/src/features/home/guide/partner_guide_topic.dart apps/app_partner/lib/src/routing/app_routes.dart apps/app_partner/integration_test/mds-emulator-render/partner_guide/builder.dart apps/app_partner/integration_test/mds-emulator-render/more_page/builder.dart apps/app_partner/integration_test/mds-emulator-render/partner_home_page/builder.dart`
- `flutter test test/src/features/home/guide/partner_guide_page_test.dart test/src/features/home/partner_home_coordinator_test.dart test/src/features/home/widgets/onboarding_step_guide_test.dart test/src/features/more/more_coordinator_test.dart test/src/features/more/more_page_test.dart test/src/routing/app_routes_test.dart`
- `npm run lint --workspace=apps/mds/docs`
- `npm run build --workspace=apps/mds/docs`
- `git diff --check`

Note: full `flutter analyze` still exits non-zero because the app currently has existing repo-wide info-level diagnostics; the two new coordinator mock errors introduced by this change were fixed and changed-file analysis is clean.

Closes #2221