### PR TITLE
fix(ci): clean MDS render artifacts before capture

### DIFF
--- a/.github/workflows/monitor-mds-render-coverage.yml
+++ b/.github/workflows/monitor-mds-render-coverage.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           rm -rf docs/infra/mds-emulator-render
           mkdir -p docs/infra/mds-emulator-render
-          touch docs/infra/mds-emulator-render/.artifact-root
+          touch docs/infra/mds-emulator-render/artifact-root.txt
 
       - name: Run render shard on Android emulator
         uses: reactivecircus/android-emulator-runner@v2
@@ -102,7 +102,7 @@ jobs:
 
             rm -rf "$OUTPUT_ROOT"
             mkdir -p "$OUTPUT_ROOT"
-            touch "$OUTPUT_ROOT/.artifact-root"
+            touch "$OUTPUT_ROOT/artifact-root.txt"
 
             cd "$APP_DIR"
 

--- a/.github/workflows/monitor-mds-render-coverage.yml
+++ b/.github/workflows/monitor-mds-render-coverage.yml
@@ -80,6 +80,12 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules && sudo udevadm trigger --name-match=kvm
 
+      - name: Prepare empty render artifact directory
+        run: |
+          rm -rf docs/infra/mds-emulator-render
+          mkdir -p docs/infra/mds-emulator-render
+          touch docs/infra/mds-emulator-render/.artifact-root
+
       - name: Run render shard on Android emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -96,6 +102,7 @@ jobs:
 
             rm -rf "$OUTPUT_ROOT"
             mkdir -p "$OUTPUT_ROOT"
+            touch "$OUTPUT_ROOT/.artifact-root"
 
             cd "$APP_DIR"
 


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## What changed
- Adds a pre-emulator cleanup step for `docs/infra/mds-emulator-render` in `monitor-mds-render-coverage`.
- Leaves a `.artifact-root` marker before the emulator action and after the in-script cleanup so failed/zero-capture shards still produce an artifact payload without stale PNGs.

## Why
Refs #2913.

Partial work; this PR does not close #2913 because it fixes monitor artifact accuracy, not the full MDS state coverage gap.

The latest monitor run uploaded the checked-in `home_page` PNGs from every failed shard, so the coverage issue reported 4 captured states even though render capture had failed. This PR prevents stale repository PNGs from contaminating failed shard artifacts.

## Verification
- `git diff --check`
- `dart run scripts/mds_render_coverage.dart --json` (expected exit 1 with current checked-in 4/369 state coverage; confirms coverage script behavior is unchanged)

## Residual risk
- This does not fix the underlying Android emulator/render-capture failure or increase state coverage by itself. It makes the next monitor result accurately report zero newly captured PNGs when render capture fails before producing screenshots.