### PR TITLE
test(user): restore trust renewal pending review text

### DIFF
--- a/apps/app_user/lib/src/features/discovery/trust_badge/ui/trust_badge_contract_harness.dart
+++ b/apps/app_user/lib/src/features/discovery/trust_badge/ui/trust_badge_contract_harness.dart
@@ -381,6 +381,7 @@ class _TrustLifecycleHarnessState extends State<TrustLifecycleHarness> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text('현재 등급: ${trustLevelLabel(level)}'),
+          if (_snapshot.pendingReview) const Text('심사 중'),
           if (_showRenewalGuide) const Text('인증 갱신 안내'),
           ElevatedButton(
             onPressed: () {


### PR DESCRIPTION
## Summary
- render `심사 중` when the trust lifecycle harness enters `pendingReview`
- unblock the deterministic `trust_badge_test.dart` CUJ failure found by promotion PR #2978

## Verification
- `dart format apps/app_user/lib/src/features/discovery/trust_badge/ui/trust_badge_contract_harness.dart` (warning: existing `very_good_analysis` package resolution warning)
- `git diff --check`

Closes #2985