### PR TITLE
fix(supabase): support sb_secret system auth

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -212,7 +212,7 @@ jobs:
             fi
           }
 
-          sync_secret "service_role_key" "${SERVICE_ROLE_KEY}" "Service role JWT for pg_cron -> EF auth (CI auto-sync)"
+          sync_secret "service_role_key" "${SERVICE_ROLE_KEY}" "Elevated Supabase API key for pg_cron -> EF auth (legacy JWT or sb_secret_ apikey-compatible, CI auto-sync)"
           sync_secret "supabase_url"     "${SUPABASE_URL_VALUE}" "Supabase project URL for pg_cron -> EF calls (CI auto-sync)"
 
           echo "Vault sync complete (${ENV_NAME})"
@@ -242,6 +242,7 @@ jobs:
         run: |
           RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST \
             "${SUPABASE_URL}/functions/v1/dev-seed?mode=images-only" \
+            -H "apikey: ${SUPABASE_KEY}" \
             -H "Authorization: Bearer ${SUPABASE_KEY}" \
             --max-time 30)
           CURL_EXIT=$?
@@ -295,12 +296,13 @@ jobs:
       - name: Verify Edge Function env vars
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Fix #1944: ?env=true now requires service_role — anon key would return 401.
+          # Fix #1944/#2187: ?env=true requires elevated system auth; anon would return 401.
           SERVICE_ROLE_KEY: ${{ steps.env.outputs.SERVICE_ROLE_KEY }}
           PROJECT_ID: ${{ steps.env.outputs.PROJECT_ID }}
           ENV_NAME: ${{ steps.env.outputs.ENV }}
         run: |
           RESPONSE=$(curl -sf "https://${PROJECT_ID}.supabase.co/functions/v1/health?env=true" \
+            -H "apikey: ${SERVICE_ROLE_KEY}" \
             -H "Authorization: Bearer ${SERVICE_ROLE_KEY}" --max-time 15) || {
             echo "::warning::Health endpoint unreachable — skipping EF env check"
             exit 0

--- a/.github/workflows/monitor-event-flow-daily.yml
+++ b/.github/workflows/monitor-event-flow-daily.yml
@@ -58,6 +58,7 @@ jobs:
           # Fix #1635: -s + 수동 status 검사 — error body 로깅 보장
           http_code=$(curl -s -o /tmp/seed_response.json -w "%{http_code}" -X POST \
             "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/dev-seed?mode=images-only" \
+            -H "apikey: ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
             --max-time 60)
           cat /tmp/seed_response.json
@@ -73,6 +74,7 @@ jobs:
           # rate limit 회피하면서 데이터 다양성 ↑. 최대 (3×50 + partners) × 0.4 ≈ 1~2분.
           http_code=$(curl -s -o /tmp/sim_response.json -w "%{http_code}" -X POST \
             "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/event-flow-simulator" \
+            -H "apikey: ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
             -H "Content-Type: application/json" \
             -d '{"ticks": 3, "usersPerTick": 50, "delayBetweenCallsMs": 400}' \

--- a/.github/workflows/monitor-event-flow-hourly.yml
+++ b/.github/workflows/monitor-event-flow-hourly.yml
@@ -41,6 +41,7 @@ jobs:
           # rate limit 회피. hourly 는 smoke 라 daily 보다 작은 payload.
           http_code=$(curl -s -o /tmp/sim_response.json -w "%{http_code}" -X POST \
             "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/event-flow-simulator" \
+            -H "apikey: ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
             -H "Content-Type: application/json" \
             -d '{"ticks": 1, "usersPerTick": 20, "delayBetweenCallsMs": 300}' \

--- a/BLUEDOC.md
+++ b/BLUEDOC.md
@@ -25,9 +25,10 @@ Minglit 모노레포의 **프로젝트 전체 진입점**. 처음 온 에이전�
 ## 관련
 
 - [README.md](./README.md) — 레포 기본 설명
+- [docs/env-reference.md](./docs/env-reference.md) — `env-manifest.json` 기반 자동 생성 env reference
 - [docs/architecture/](./docs/architecture/) — 결제, 검색/추천, 신뢰/인증, 이벤트 파이프라인 등 주요 설계 문서
 - [docs/qa/automation-test-guide.md](./docs/qa/automation-test-guide.md) — 변경 유형별 테스트 기준
 - [docs/operations/edge-functions.md](./docs/operations/edge-functions.md) — Edge Function 디버깅/운영
 
 ---
-_Reviewed: 2026-05-23 10:47_
+_Reviewed: 2026-06-03 12:58_

--- a/docs/architecture/edge-function-auth.md
+++ b/docs/architecture/edge-function-auth.md
@@ -31,7 +31,7 @@ Minglit의 모든 Edge Function (EF) 인증/인가 모델을 기술한다.
 | 영역 | Supabase 제공 | 우리가 커버해야 |
 |---|---|---|
 | Gateway JWT 검증 (`verify_jwt = true`) | ✅ 프레임워크 레벨, 기본값 | 옵트아웃 시 보호 책임 이동 |
-| EF env 자동 주입 (`SUPABASE_SERVICE_ROLE_KEY` 등) | ✅ 단 형식 (legacy JWT vs 신규 sb_secret_) 은 프로젝트 설정 의존 | Vault 와의 형식 일치 보장 (CI sync) |
+| EF env 자동 주입 (`SUPABASE_SECRET_KEYS`, `SUPABASE_SERVICE_ROLE_KEY` 등) | ✅ 신규 secret key JSON + legacy JWT 모두 제공 | Vault/caller 와의 형식 일치 보장 (CI sync) |
 | `verify_jwt = false` 시 내부 보호 강제 | ❌ | ✅ 본 설계 (manifest + wrapper) |
 | EF 별 환경 가드 (dev-only / prod-only) | ❌ | ✅ 본 설계 |
 | Unprotected EF 자동 검출 | ❌ | ✅ CI lint |
@@ -40,14 +40,14 @@ Minglit의 모든 Edge Function (EF) 인증/인가 모델을 기술한다.
 
 `system` caller 검증은 두 경로를 허용한다.
 
-1. legacy: `Authorization: Bearer <token>` 과 EF 내부 `Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")` 의 **exact string match**
-2. 신규 secret key: `apikey: <token>` 과 EF 내부 `Deno.env.get("SUPABASE_SERVICE_ROLE_SECRET")` 의 **exact string match**
+1. legacy JWT: `Authorization: Bearer <token>` 과 EF 내부 `Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")` 의 **exact string match**
+2. 신규 secret key: `apikey: <token>` 과 EF 내부 `JSON.parse(Deno.env.get("SUPABASE_SECRET_KEYS")).default` 또는 같은 JSON dictionary 의 값의 **exact string match**
 
 두 값의 출처:
 
 ```
-GH Secret / Supabase Secret
-  ├─→ EF env (SUPABASE_SERVICE_ROLE_KEY / SUPABASE_SERVICE_ROLE_SECRET)
+GH Secret / Supabase Dashboard API Keys
+  ├─→ EF env (SUPABASE_SERVICE_ROLE_KEY / SUPABASE_SECRET_KEYS)
   └─→ Vault 또는 caller secret
         └─→ cron/service caller 가 Authorization 또는 apikey 헤더에 사용
 ```
@@ -55,9 +55,9 @@ GH Secret / Supabase Secret
 형식별 gateway 호환성:
 
 - legacy JWT (`eyJ...`): verify_jwt=true / false 모두 호환
-- 신규 `sb_secret_...`: verify_jwt=false 전용. JWT가 아니므로 `Authorization: Bearer sb_secret_...` 로 보내면 gateway JWT 검증을 통과하지 못한다.
+- 신규 `sb_secret_...`: verify_jwt=false 전용. JWT가 아니므로 `Authorization: Bearer sb_secret_...` 로 보내면 gateway JWT 검증을 통과하지 못한다. `verify_jwt=false` 함수에서 handler 내부가 `apikey`를 직접 검증해야 한다.
 
-**현재 정책**: legacy JWT bearer 경로는 유지하고, `sb_secret_...` 전환 준비를 위해 `apikey` 경로를 추가한다. `system` caller EF 중 신규 secret key를 받을 수 있어야 하는 함수는 `verify_jwt=false` 로 전환하고 wrapper 내부 인증에 의존한다.
+**현재 정책**: legacy JWT bearer 경로는 유지하되, 신규 Supabase secret key 경로는 `SUPABASE_SECRET_KEYS` + `apikey` 로만 허용한다. `SUPABASE_SERVICE_ROLE_KEY` 에 `sb_secret_...` 값을 넣더라도 bearer credential 로는 인정하지 않는다.
 
 ---
 
@@ -67,7 +67,7 @@ EF 가 받을 수 있는 호출자 분류. manifest 의 `callers` 배열에 명�
 
 | 타입 | 의미 | 검증 방법 |
 |---|---|---|
-| **`system`** | cron, 시스템 우회 | legacy `Authorization: Bearer ${EF_ENV.SUPABASE_SERVICE_ROLE_KEY}` 또는 신규 `apikey: ${EF_ENV.SUPABASE_SERVICE_ROLE_SECRET}` exact match (§1.4) |
+| **`system`** | cron, 시스템 우회 | legacy `Authorization: Bearer ${EF_ENV.SUPABASE_SERVICE_ROLE_KEY}` 또는 신규 `apikey: ${EF_ENV.SUPABASE_SECRET_KEYS[...]}` exact match (§1.4) |
 | **`user`** | 인증된 사용자/파트너 | `supabase.auth.getUser(token)` 으로 decode + claims 추출 → `auth.userId` |
 | **`external`** | 외부 시스템 (webhook 등) | manifest 의 `external_auth` 정책에 따라 IP / HMAC / signature 검증. **Authorization 헤더 무관** |
 | **`public`** | 익명 OK | check 없음. 보통 `envs: ["dev"]` 와 결합하여 prod 노출 차단 |
@@ -90,8 +90,8 @@ EF 가 받을 수 있는 호출자 분류. manifest 의 `callers` 배열에 명�
 0. (선결) Env 가드: ENVIRONMENT ∉ policy.envs → 403 (auth 검증 자체 skip)
 
 1. "system" ∈ callers
-   ├─ Authorization Bearer == EF_ENV.SUPABASE_SERVICE_ROLE_KEY → ✅ pass (keyFormat=legacy)
-   ├─ apikey == EF_ENV.SUPABASE_SERVICE_ROLE_SECRET → ✅ pass (keyFormat=secret)
+   ├─ Authorization Bearer == EF_ENV.SUPABASE_SERVICE_ROLE_KEY(legacy JWT only) → ✅ pass (keyFormat=legacy)
+   ├─ apikey == any EF_ENV.SUPABASE_SECRET_KEYS value → ✅ pass (keyFormat=secret)
    └─ Else → 다음 caller 검증으로 진행
 
 2. Authorization 헤더 있음 + Bearer 형식
@@ -435,7 +435,7 @@ sequenceDiagram
     participant Handler as EF Handler
     participant DB as Postgres
 
-    Caller->>Gateway: POST /functions/v1/<fn-name><br/>Authorization: Bearer <JWT/legacy key><br/>or apikey: sb_secret_...
+    Caller->>Gateway: POST /functions/v1/<fn-name><br/>Authorization: Bearer <user JWT/legacy service_role JWT><br/>or apikey: sb_secret_...
 
     alt verify_jwt = true (config.toml)
         Gateway->>Gateway: JWT 시그니처 검증
@@ -466,7 +466,7 @@ flowchart TD
     Req[Request 도착] --> EnvCheck{ENVIRONMENT<br/>∈ policy.envs?}
     EnvCheck -- No --> E403_env[403 Function disabled]
     EnvCheck -- Yes --> SysAllow{'system'<br/>∈ callers?}
-    SysAllow -- Yes --> SysMatch{Legacy bearer<br/>or secret apikey<br/>matches EF env?}
+    SysAllow -- Yes --> SysMatch{Legacy JWT bearer<br/>or secret apikey<br/>matches EF env?}
     SysMatch -- Yes --> Pass_sys[type=system]
     SysMatch -- No --> AuthHeader{Authorization<br/>Bearer 있음?}
     SysAllow -- No --> AuthHeader
@@ -632,7 +632,7 @@ Phase 1~4 동안 **옛 헬퍼와 새 wrapper 가 공존**. 마이그레이션되
 | TBD-3 | 옛 auth 헬퍼 deprecation timeline + 제거 (Phase 5) | P3 |
 | ~~TBD-4~~ | ~~`external_auth` HMAC / custom 패턴 실제 적용 (PortOne 등)~~ (완료: `checkExternalAuth` — hmac/custom 모두 구현, issue #2186) | ~~P3~~ |
 | TBD-5 | rate limit / deprecation / audit 등 manifest 확장 (`deprecated` 완료 #2188; rate_limit / audit / cors / required_role 후속) | P3 |
-| TBD-6 | 신규 sb_secret_ 형식으로 service_role 마이그레이션 (verify_jwt=true cron-호출 EF 의 verify_jwt=false 전환 검토 포함) | P3 |
+| TBD-6 | 신규 `sb_secret_...` secret key 기반 system caller 마이그레이션 (`SUPABASE_SECRET_KEYS` + `apikey`, legacy `service_role` JWT 제거 시점 포함) | P3 |
 
 ---
 

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -9,7 +9,8 @@
 |-----|-------------|----------|
 | `SUPABASE_URL` | Supabase project URL | Yes |
 | `SUPABASE_PUBLISHABLE_KEY` | Supabase publishable key | Yes |
-| `ENVIRONMENT` | local / development / production | Yes |
+| `ENVIRONMENT` | local / development / dev / production | Yes |
+| `IS_DEMO` | Demo flavor flag — short-circuits all network SDK init when true | No |
 | `SENTRY_DSN` | Sentry error tracking | No |
 | `STATSIG_CLIENT_KEY` | Statsig feature flags | No |
 | `GOOGLE_WEB_CLIENT_ID` | Google OAuth client ID | No |
@@ -24,8 +25,8 @@
 | Key | Description | Required |
 |-----|-------------|----------|
 | `SUPABASE_URL` | Supabase project URL (auto-injected) | Yes |
-| `SUPABASE_SECRET_KEYS` | Supabase `sb_secret_...` JSON dictionary for admin clients and system callers using the `apikey` header | No |
 | `SUPABASE_SERVICE_ROLE_KEY` | Legacy service_role JWT (auto-injected) | Yes |
+| `SUPABASE_SECRET_KEYS` | Supabase sb_secret API key JSON dictionary (auto-injected in hosted Edge Functions) | No |
 | `SENTRY_DSN` | Sentry error tracking | No |
 | `AXIOM_API_TOKEN` | Axiom structured logging | No |
 | `AXIOM_DATASET` | Axiom dataset name | No |
@@ -118,11 +119,8 @@
 
 | Key | Description | Required |
 |-----|-------------|----------|
-| `ENVIRONMENT` | Dev guard (must be development/dev/local) | Yes |
+| `ENVIRONMENT` | Dev guard (dev) | Yes |
 | `GITHUB_ACCESS_TOKEN` | GitHub issue/status reporting for simulator failures | Yes |
-| `SUPABASE_ANON_KEY` | actor sign-in for simulated user/partner JWTs | Yes |
-| `SUPABASE_SERVICE_ROLE_KEY` | simulator service client | Yes |
-| `SIM_USER_PASSWORD` | dev seed actor password | Yes |
 
 ### ai-embed
 
@@ -135,6 +133,18 @@
 | Key | Description | Required |
 |-----|-------------|----------|
 | `OPENAI_API_KEY` | OpenAI API key for tag extraction | Yes |
+
+### user-get-ticket-token
+
+| Key | Description | Required |
+|-----|-------------|----------|
+| `TICKET_SIGNING_PRIVATE_KEY_JWK` | Ed25519 private key (OKP JWK) for signing ticket QR tokens | Yes |
+
+### event-checkin
+
+| Key | Description | Required |
+|-----|-------------|----------|
+| `TICKET_SIGNING_PUBLIC_KEY_JWK` | Ed25519 public key (OKP JWK) for verifying QR token signatures | Yes |
 
 ## Next.js (landing_user)
 
@@ -159,11 +169,8 @@
 | `SUPABASE_ACCESS_TOKEN` | Supabase CLI auth | Yes |
 | `SUPABASE_DEV_DB_PASSWORD` | Dev DB password | Yes |
 | `SUPABASE_DEV_PROJECT_ID` | Dev project ref | Yes |
-| `SUPABASE_DEV_URL` | Dev Supabase URL | Yes |
 | `SUPABASE_DEV_PUBLISHABLE_KEY` | Dev publishable key | Yes |
 | `SUPABASE_DEV_SECRET_KEY` | Dev elevated Supabase API key (legacy service_role JWT or sb_secret_ secret key) | Yes |
-| `SUPABASE_RC_URL` | RC Supabase URL for manual simulator runs | No |
-| `SUPABASE_RC_SECRET_KEY` | RC service role key for manual simulator runs | No |
 | `SUPABASE_MAIN_DB_PASSWORD` | Main DB password | Yes |
 | `SUPABASE_MAIN_PROJECT_ID` | Main project ref | Yes |
 | `SUPABASE_MAIN_PUBLISHABLE_KEY` | Main publishable key | Yes |
@@ -174,7 +181,7 @@
 | `STATSIG_SERVER_KEY` | Statsig server | No |
 | `AXIOM_API_TOKEN` | Axiom logging | No |
 | `CODECOV_TOKEN` | Codecov upload | No |
-| `SIM_USER_PASSWORD` | Dev simulator user password (`event-flow-simulator`) | No |
+| `SIM_USER_PASSWORD` | Dev simulator user password (event-flow-simulator EF 전용) | No |
 
 ## Vault
 

--- a/docs/operations/edge-functions.md
+++ b/docs/operations/edge-functions.md
@@ -77,15 +77,15 @@ supabase functions serve --inspect
 ### 3. 로컬에서 함수 호출
 
 ```bash
-# Service role key로 호출 (인증 우회)
+# Legacy service_role JWT로 호출
 curl -s -X POST "http://localhost:54321/functions/v1/<function-name>" \
   -H "Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>" \
   -H "Content-Type: application/json" \
   -d '{"key": "value"}'
 
-# sb_secret_ 형식 secret key로 system caller 호출
+# sb_secret_ 형식 secret key로 system caller 호출 (SUPABASE_SECRET_KEYS['default'])
 curl -s -X POST "http://localhost:54321/functions/v1/<function-name>" \
-  -H "apikey: <SUPABASE_SERVICE_ROLE_SECRET>" \
+  -H "apikey: <SUPABASE_SECRET_KEY>" \
   -H "Content-Type: application/json" \
   -d '{"key": "value"}'
 
@@ -100,7 +100,7 @@ curl -s ... | python3 -m json.tool
 ### 1. 함수 호출
 
 ```bash
-# Dev 서버 직접 호출
+# Dev 서버 직접 호출 — legacy service_role JWT
 curl -s -X POST "https://<project-ref>.supabase.co/functions/v1/<function-name>" \
   -H "Authorization: Bearer <SERVICE_ROLE_KEY>" \
   -H "Content-Type: application/json" \
@@ -108,12 +108,12 @@ curl -s -X POST "https://<project-ref>.supabase.co/functions/v1/<function-name>"
 
 # sb_secret_ 형식은 Bearer가 아니라 apikey 헤더로 호출
 curl -s -X POST "https://<project-ref>.supabase.co/functions/v1/<function-name>" \
-  -H "apikey: <SERVICE_ROLE_SECRET>" \
+  -H "apikey: <SECRET_API_KEY>" \
   -H "Content-Type: application/json" \
   -d '{"key": "value"}'
 ```
 
-환경 변수는 `minglit_env/dev/supabase.env`에서 확인.
+CI/배포 기준 key 는 GitHub/Supabase secrets 를 기준으로 한다. `minglit_env/dev/supabase.env`는 로컬 실행 보조 파일이며 라이브 secret 과 drift 될 수 있다.
 
 ### 2. 배포된 함수 목록 확인
 
@@ -226,8 +226,8 @@ curl -X POST ".../functions/v1/event-flow-simulator" \
 | `AXIOM_DATASET` | Axiom 데이터셋 | - | `edge-functions` | `edge-functions` |
 | `SENTRY_DSN` | Sentry 에러 트래킹 | 미설정 (비활성) | 설정됨 | 설정됨 |
 | `SUPABASE_URL` | Supabase API URL | `http://localhost:54321` | `https://<ref>.supabase.co` | `https://<ref>.supabase.co` |
-| `SUPABASE_SERVICE_ROLE_KEY` | 관리자 키 | 로컬 키 | 시크릿 | 시크릿 |
-| `SUPABASE_SERVICE_ROLE_SECRET` | `sb_secret_...` system caller 키 | 선택 | 시크릿 | 시크릿 |
+| `SUPABASE_SECRET_KEYS` | `sb_secret_...` JSON dictionary | 선택 | 자동 주입 | 자동 주입 |
+| `SUPABASE_SERVICE_ROLE_KEY` | legacy service_role JWT | 로컬 키 | 자동 주입 | 자동 주입 |
 
 ## 트러블슈팅
 

--- a/env-manifest.json
+++ b/env-manifest.json
@@ -49,10 +49,13 @@
           "desc": "Supabase project URL (auto-injected)"
         },
         "SUPABASE_SERVICE_ROLE_KEY": {
-          "desc": "Service role JWT (auto-injected)"
+          "desc": "Legacy service_role JWT (auto-injected)"
         }
       },
       "optional": {
+        "SUPABASE_SECRET_KEYS": {
+          "desc": "Supabase sb_secret API key JSON dictionary (auto-injected in hosted Edge Functions)"
+        },
         "SENTRY_DSN": {
           "desc": "Sentry error tracking"
         },
@@ -261,7 +264,7 @@
         "desc": "Dev publishable key"
       },
       "SUPABASE_DEV_SECRET_KEY": {
-        "desc": "Dev service role key"
+        "desc": "Dev elevated Supabase API key (legacy service_role JWT or sb_secret_ secret key)"
       },
       "SUPABASE_MAIN_DB_PASSWORD": {
         "desc": "Main DB password"
@@ -271,6 +274,9 @@
       },
       "SUPABASE_MAIN_PUBLISHABLE_KEY": {
         "desc": "Main publishable key"
+      },
+      "SUPABASE_MAIN_SECRET_KEY": {
+        "desc": "Main elevated Supabase API key (legacy service_role JWT or sb_secret_ secret key)"
       },
       "OPENAI_API_KEY": {
         "desc": "OpenAI API"
@@ -300,7 +306,7 @@
   "vault": {
     "required": {
       "service_role_key": {
-        "desc": "Service role JWT for pg_cron -> EF auth (PR #1758: requireServiceRole guard)"
+        "desc": "Elevated Supabase API key for pg_cron -> EF auth (legacy service_role JWT or sb_secret_ secret key)"
       },
       "supabase_url": {
         "desc": "Project URL for pg_cron -> EF calls"

--- a/scripts/generate-env-docs.sh
+++ b/scripts/generate-env-docs.sh
@@ -93,7 +93,7 @@ lines.append('|-----|-------------|----------|')
 lines.extend(table(m['vault']['required'], 'Yes'))
 lines.append('')
 
-print('\n'.join(lines))
+print('\n'.join(lines).rstrip())
 " > "$OUTPUT"
 
 echo "Generated $OUTPUT"

--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -32,4 +32,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-05-25 22:30_
+_Reviewed: 2026-06-03 12:58_

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -715,3 +715,22 @@ enabled = true
 verify_jwt = false  # system caller; wrapper accepts legacy bearer or sb_secret apikey
 import_map = "./deno.json"
 entrypoint = "./functions/ai-extract-tags/index.ts"
+
+# Fix #2187 follow-up: keep all auth-manifest entries explicitly registered.
+[functions.user-mark-match-results-viewed]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/user-mark-match-results-viewed/index.ts"
+
+[functions.partner-review-applications]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/partner-review-applications/index.ts"
+
+[functions.commit-match-likes]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/commit-match-likes/index.ts"

--- a/supabase/functions/_shared/BLUEDOC.md
+++ b/supabase/functions/_shared/BLUEDOC.md
@@ -11,7 +11,7 @@
 | `edge_function_*_test.ts`                                        | wrapper auth/external/deprecation 회귀 테스트                                      |
 | `env_keystore.ts`                                                | env-manifest 기반 환경변수 typed 접근                                             |
 | `request_utils.ts` / `input_validation.ts` / `response_utils.ts` | request parsing, typed input field validation, CORS/success/error response        |
-| `supabase_client.ts`                                             | service/user Supabase client 생성                                                 |
+| `supabase_client.ts`                                             | service/user Supabase client 생성, secret key `apikey`/legacy bearer 헤더 호환    |
 | `logger.ts` / `axiom_logger.ts` / `statsig_utils.ts`             | local/Axiom/Statsig observability                                                 |
 | `iamport_client.ts` / `portone_client.ts`                        | 결제 외부 client                                                                  |
 | `partner_permissions.ts` / `refund_utils.ts` / `worker_utils.ts` | IO 포함 공용 helper                                                               |
@@ -36,4 +36,4 @@
 
 ---
 
-_Reviewed: 2026-05-24 16:45_
+_Reviewed: 2026-06-03 12:58_

--- a/supabase/functions/_shared/edge_function.ts
+++ b/supabase/functions/_shared/edge_function.ts
@@ -13,9 +13,18 @@
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { createServiceClient } from "./supabase_client.ts";
+import {
+  createServiceClient,
+  getLegacyServiceRoleJwt,
+  getSupabaseSecretApiKeys,
+} from "./supabase_client.ts";
 import { corsResponse, errorResponse } from "./response_utils.ts";
-import { initSentry, captureException, log as axiomLog, flush as axiomFlush } from "./logger.ts";
+import {
+  captureException,
+  flush as axiomFlush,
+  initSentry,
+  log as axiomLog,
+} from "./logger.ts";
 import authManifest from "../auth-manifest.json" with { type: "json" };
 
 // --------------------------------------------------------------------------
@@ -44,19 +53,19 @@ export interface EFContext {
 export type ExternalAuth =
   | { type: "ip_allowlist"; ips: string[] }
   | {
-      type: "hmac";
-      /** Deno env var name that holds the HMAC secret */
-      secret_env: string;
-      /** Request header carrying the signature (e.g. "x-portone-signature-v2") */
-      header: string;
-    }
+    type: "hmac";
+    /** Deno env var name that holds the HMAC secret */
+    secret_env: string;
+    /** Request header carrying the signature (e.g. "x-portone-signature-v2") */
+    header: string;
+  }
   | {
-      type: "custom";
-      /** Path to an auth checker module, relative to the EF directory.
-       *  The module must export `check(req: Request): Promise<{ok:true;reason:string}|{ok:false}>`.
-       */
-      module: string;
-    };
+    type: "custom";
+    /** Path to an auth checker module, relative to the EF directory.
+     *  The module must export `check(req: Request): Promise<{ok:true;reason:string}|{ok:false}>`.
+     */
+    module: string;
+  };
 
 /** Interface that a `custom` external_auth module must satisfy. */
 export interface CustomAuthChecker {
@@ -102,7 +111,7 @@ function detectFnName(opts: MinglitEFOptions): string {
   if (m) return m[1];
   throw new Error(
     `[minglitEdgeFunction] Cannot detect EF name from Deno.mainModule=${main}. ` +
-    `Set MINGLIT_EF_TEST_FN_NAME env var or pass opts.fnName.`,
+      `Set MINGLIT_EF_TEST_FN_NAME env var or pass opts.fnName.`,
   );
 }
 
@@ -111,7 +120,7 @@ function loadPolicy(fnName: string): EFPolicy {
   if (!policy) {
     throw new Error(
       `[minglitEdgeFunction] auth-manifest.json missing entry for '${fnName}'. ` +
-      `Add it before deploy.`,
+        `Add it before deploy.`,
     );
   }
   return policy;
@@ -122,7 +131,7 @@ function readEnvironment(): Environment {
   if (!env) {
     throw new Error(
       `[minglitEdgeFunction] ENVIRONMENT env var not set. ` +
-      `Required for env gate. Check supabase secrets set ENVIRONMENT=...`,
+        `Required for env gate. Check supabase secrets set ENVIRONMENT=...`,
     );
   }
   // Normalize 'development' alias of 'dev'
@@ -141,7 +150,10 @@ function readEnvironment(): Environment {
  * @param deprecated ISO date string from the manifest (e.g. "2026-12-01").
  * @returns          New Response with the deprecation headers added.
  */
-export function addDeprecationHeaders(res: Response, deprecated: string): Response {
+export function addDeprecationHeaders(
+  res: Response,
+  deprecated: string,
+): Response {
   const date = new Date(deprecated);
   if (Number.isNaN(date.getTime())) return res;
   const httpDate = date.toUTCString();
@@ -150,7 +162,11 @@ export function addDeprecationHeaders(res: Response, deprecated: string): Respon
   headers.set("Deprecation", `@${httpDate}`);
   // RFC 8594 §3 — Sunset header: the point at which the resource is removed
   headers.set("Sunset", httpDate);
-  return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  });
 }
 
 /**
@@ -172,7 +188,9 @@ export async function checkExternalAuth(
       const realIp = req.headers.get("x-real-ip");
       const cfIp = req.headers.get("cf-connecting-ip");
       const xff = req.headers.get("x-forwarded-for");
-      const xffRightmost = xff ? xff.split(",").map(s => s.trim()).pop() : null;
+      const xffRightmost = xff
+        ? xff.split(",").map((s) => s.trim()).pop()
+        : null;
       const clientIp = realIp || cfIp || xffRightmost;
       if (clientIp && external.ips.includes(clientIp)) {
         return { ok: true, reason: `ip_allowlist:${clientIp}` };
@@ -200,17 +218,26 @@ export async function checkExternalAuth(
       );
 
       // Accept both "<hex>" and "sha256=<hex>" formats (PortOne V2 uses the prefixed form).
-      const sigHex = signature.startsWith("sha256=") ? signature.slice(7) : signature;
+      const sigHex = signature.startsWith("sha256=")
+        ? signature.slice(7)
+        : signature;
       // Reject odd-length or non-hex chars before decoding. parseInt("aZ",16) silently
       // stops at "Z" returning 10, so a regex guard is required to reject malformed input.
-      if (sigHex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(sigHex)) return { ok: false };
+      if (sigHex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(sigHex)) {
+        return { ok: false };
+      }
       const sigBytes = new Uint8Array(sigHex.length / 2);
       for (let i = 0; i < sigHex.length; i += 2) {
         sigBytes[i / 2] = parseInt(sigHex.slice(i, i + 2), 16);
       }
 
       // crypto.subtle.verify performs constant-time HMAC comparison internally.
-      const valid = await crypto.subtle.verify("HMAC", key, sigBytes, new TextEncoder().encode(body));
+      const valid = await crypto.subtle.verify(
+        "HMAC",
+        key,
+        sigBytes,
+        new TextEncoder().encode(body),
+      );
       if (valid) {
         return { ok: true, reason: `hmac:${external.header}` };
       }
@@ -219,7 +246,10 @@ export async function checkExternalAuth(
 
     case "custom": {
       // Resolve path relative to this EF's directory (escape hatch for bespoke auth).
-      const moduleUrl = new URL(external.module, new URL(`../${fnName}/`, import.meta.url));
+      const moduleUrl = new URL(
+        external.module,
+        new URL(`../${fnName}/`, import.meta.url),
+      );
       const mod = await import(moduleUrl.href) as CustomAuthChecker;
       return await mod.check(req);
     }
@@ -229,8 +259,9 @@ export async function checkExternalAuth(
 /**
  * Checks system caller credentials.
  *
- * Legacy service_role stays on `Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>`.
- * New Supabase secret keys (`sb_secret_...`) are not JWTs and must use `apikey`.
+ * Legacy service_role JWT stays on `Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>`.
+ * New Supabase secret keys (`SUPABASE_SECRET_KEYS['default']`, `sb_secret_...`) are
+ * not JWTs and must use `apikey`.
  * Exported for unit testing; not part of the stable public API.
  */
 export function checkSystemAuth(
@@ -239,7 +270,7 @@ export function checkSystemAuth(
   const authHeader = req.headers.get("Authorization") ?? "";
   if (authHeader.startsWith("Bearer ")) {
     const token = authHeader.slice(7);
-    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    const serviceKey = getLegacyServiceRoleJwt();
 
     if (serviceKey && token === serviceKey) {
       return { ok: true, keyFormat: "legacy" };
@@ -247,8 +278,7 @@ export function checkSystemAuth(
   }
 
   const apiKey = req.headers.get("apikey") ?? "";
-  const serviceSecret = Deno.env.get("SUPABASE_SERVICE_ROLE_SECRET");
-  if (serviceSecret && apiKey === serviceSecret) {
+  if (apiKey && getSupabaseSecretApiKeys().includes(apiKey)) {
     return { ok: true, keyFormat: "secret" };
   }
 
@@ -289,7 +319,9 @@ export async function verifyAuth(
   // external (Authorization 헤더 무관 — IP / HMAC 등 다른 신호 사용)
   if (allow("external")) {
     if (!policy.external_auth) {
-      throw new Error(`[minglitEdgeFunction] policy.callers includes 'external' but external_auth missing`);
+      throw new Error(
+        `[minglitEdgeFunction] policy.callers includes 'external' but external_auth missing`,
+      );
     }
     const ext = await checkExternalAuth(req, policy.external_auth, fnName);
     if (ext.ok) return { type: "external", reason: ext.reason };
@@ -324,7 +356,10 @@ function makeContext(opts: {
 // Public API
 // --------------------------------------------------------------------------
 
-export function minglitEdgeFunction(handler: EFHandler, opts: MinglitEFOptions = {}): void {
+export function minglitEdgeFunction(
+  handler: EFHandler,
+  opts: MinglitEFOptions = {},
+): void {
   // Lazy init: try at module load, fall back to first-request retry.
   // Eager init succeeds in production (deploy-time env present).
   // Test env may set required env vars after module import — retry on first request.
@@ -356,7 +391,12 @@ export function minglitEdgeFunction(handler: EFHandler, opts: MinglitEFOptions =
     }
     const { fnName, policy, env } = _ctx;
     const requestId = crypto.randomUUID();
-    axiomLog({ function: fnName, level: "info", message: "invoked", metadata: { method: req.method, requestId } });
+    axiomLog({
+      function: fnName,
+      level: "info",
+      message: "invoked",
+      metadata: { method: req.method, requestId },
+    });
 
     try {
       // CORS preflight
@@ -382,12 +422,24 @@ export function minglitEdgeFunction(handler: EFHandler, opts: MinglitEFOptions =
       // Context + handler 호출
       const ctx = makeContext({ auth, fnName, env, requestId });
       let res = await handler(req, ctx);
-      if (policy.deprecated) res = addDeprecationHeaders(res, policy.deprecated);
-      axiomLog({ function: fnName, level: "info", message: "completed", metadata: { status: res.status, requestId } });
+      if (policy.deprecated) {
+        res = addDeprecationHeaders(res, policy.deprecated);
+      }
+      axiomLog({
+        function: fnName,
+        level: "info",
+        message: "completed",
+        metadata: { status: res.status, requestId },
+      });
       return res;
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      axiomLog({ function: fnName, level: "error", message: msg, metadata: { requestId } });
+      axiomLog({
+        function: fnName,
+        level: "error",
+        message: msg,
+        metadata: { requestId },
+      });
       captureException(e instanceof Error ? e : new Error(msg));
       return errorResponse("Internal error", 500);
     } finally {

--- a/supabase/functions/_shared/edge_function_system_auth_test.ts
+++ b/supabase/functions/_shared/edge_function_system_auth_test.ts
@@ -9,7 +9,10 @@ const SYSTEM_POLICY: EFPolicy = {
 
 const AUTH_ENV = {
   SUPABASE_SERVICE_ROLE_KEY: "legacy-service-role-jwt",
-  SUPABASE_SERVICE_ROLE_SECRET: "sb_secret_test_secret_key",
+  SUPABASE_SECRET_KEYS: JSON.stringify({
+    default: "sb_secret_test_secret_key",
+    backgroundWorker: "sb_secret_background_worker_key",
+  }),
 };
 
 function request(headers: Record<string, string> = {}): Request {
@@ -35,6 +38,15 @@ Deno.test("checkSystemAuth: sb_secret apikey passes as secret", async () => {
   await withEnv(AUTH_ENV, () => {
     const result = checkSystemAuth(request({
       apikey: "sb_secret_test_secret_key",
+    }));
+    assertEquals(result, { ok: true, keyFormat: "secret" });
+  });
+});
+
+Deno.test("checkSystemAuth: non-default sb_secret apikey passes as secret", async () => {
+  await withEnv(AUTH_ENV, () => {
+    const result = checkSystemAuth(request({
+      apikey: "sb_secret_background_worker_key",
     }));
     assertEquals(result, { ok: true, keyFormat: "secret" });
   });
@@ -78,6 +90,39 @@ Deno.test("verifyAuth: Authorization bearer sb_secret is not accepted", async ()
   });
 });
 
+Deno.test("verifyAuth: sb_secret stored in SUPABASE_SERVICE_ROLE_KEY is not accepted as bearer", async () => {
+  await withEnv(
+    {
+      SUPABASE_SERVICE_ROLE_KEY: "sb_secret_test_secret_key",
+      SUPABASE_SECRET_KEYS: JSON.stringify({
+        default: "sb_secret_test_secret_key",
+      }),
+    },
+    async () => {
+      await expectUnauthorized(request({
+        Authorization: "Bearer sb_secret_test_secret_key",
+      }));
+    },
+  );
+});
+
+Deno.test("verifyAuth: sb_secret stored in SUPABASE_SERVICE_ROLE_KEY can pass as apikey", async () => {
+  await withEnv(
+    {
+      SUPABASE_SERVICE_ROLE_KEY: "sb_secret_test_secret_key",
+      SUPABASE_SECRET_KEYS: undefined,
+    },
+    async () => {
+      const result = await verifyAuth(
+        request({ apikey: "sb_secret_test_secret_key" }),
+        SYSTEM_POLICY,
+        "test-system-fn",
+      );
+      assertEquals(result, { type: "system", keyFormat: "secret" });
+    },
+  );
+});
+
 Deno.test("verifyAuth: secret apikey system caller passes without Authorization", async () => {
   await withEnv(AUTH_ENV, async () => {
     const result = await verifyAuth(
@@ -100,9 +145,20 @@ Deno.test("verifyAuth: legacy bearer system caller still passes", async () => {
   });
 });
 
-Deno.test("verifyAuth: missing SUPABASE_SERVICE_ROLE_SECRET fails closed for apikey", async () => {
+Deno.test("verifyAuth: missing SUPABASE_SECRET_KEYS fails closed for apikey", async () => {
   await withEnv(
-    { ...AUTH_ENV, SUPABASE_SERVICE_ROLE_SECRET: undefined },
+    { ...AUTH_ENV, SUPABASE_SECRET_KEYS: undefined },
+    async () => {
+      await expectUnauthorized(request({
+        apikey: "sb_secret_test_secret_key",
+      }));
+    },
+  );
+});
+
+Deno.test("verifyAuth: malformed SUPABASE_SECRET_KEYS fails closed for apikey", async () => {
+  await withEnv(
+    { ...AUTH_ENV, SUPABASE_SECRET_KEYS: "not-json" },
     async () => {
       await expectUnauthorized(request({
         apikey: "sb_secret_test_secret_key",

--- a/supabase/functions/_shared/supabase_client.ts
+++ b/supabase/functions/_shared/supabase_client.ts
@@ -1,22 +1,120 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
+function isSecretApiKey(value: string): boolean {
+  return value.startsWith("sb_secret_");
+}
+
+function parseSecretKeys(raw: string | undefined): string[] {
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const record = parsed as Record<string, unknown>;
+      const values = Object.values(record).filter((value): value is string =>
+        typeof value === "string" && isSecretApiKey(value)
+      );
+      const defaultKey = record.default;
+      if (typeof defaultKey === "string" && isSecretApiKey(defaultKey)) {
+        return [defaultKey, ...values.filter((value) => value !== defaultKey)];
+      }
+      return values;
+    }
+
+    if (Array.isArray(parsed)) {
+      return parsed.filter((value): value is string =>
+        typeof value === "string" && isSecretApiKey(value)
+      );
+    }
+  } catch {
+    // Treat malformed runtime secrets as absent; callers fail closed unless a
+    // legacy service_role JWT fallback is configured.
+  }
+
+  return [];
+}
+
+/**
+ * Supabase's hosted runtime exposes new secret API keys as the
+ * SUPABASE_SECRET_KEYS JSON dictionary. The legacy service_role JWT remains in
+ * SUPABASE_SERVICE_ROLE_KEY.
+ */
+export function getSupabaseSecretApiKeys(): string[] {
+  const keys = parseSecretKeys(Deno.env.get("SUPABASE_SECRET_KEYS"));
+
+  // Local compatibility only: some local env files put sb_secret_ directly in
+  // SUPABASE_SERVICE_ROLE_KEY. Do not accept it as a bearer JWT, but allow it as
+  // an apikey credential.
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (
+    serviceRoleKey && isSecretApiKey(serviceRoleKey) &&
+    !keys.includes(serviceRoleKey)
+  ) {
+    return [...keys, serviceRoleKey];
+  }
+
+  return keys;
+}
+
+export function getLegacyServiceRoleJwt(): string | undefined {
+  const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  return key && !isSecretApiKey(key) ? key : undefined;
+}
+
+export function getSupabaseAdminKey(): string | undefined {
+  return getSupabaseSecretApiKeys()[0] ??
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? undefined;
+}
+
+export function makeSupabaseAdminHeaders(): Record<string, string> {
+  const key = getSupabaseAdminKey();
+  if (!key) {
+    throw new Error(
+      "Missing required environment variables: SUPABASE_URL and either SUPABASE_SECRET_KEYS or SUPABASE_SERVICE_ROLE_KEY",
+    );
+  }
+
+  const headers: Record<string, string> = { apikey: key };
+  if (!isSecretApiKey(key)) {
+    headers.Authorization = `Bearer ${key}`;
+  }
+  return headers;
+}
+
+function makeSupabaseAdminFetch(key: string): typeof fetch | undefined {
+  if (!isSecretApiKey(key)) return undefined;
+
+  return (input, init) => {
+    const requestInit = init as globalThis.RequestInit | undefined;
+    const inputRequest = input instanceof Request ? input : undefined;
+    const headers = new Headers(requestInit?.headers ?? inputRequest?.headers);
+    const defaultSecretBearer = `Bearer ${key}`;
+    if (headers.get("Authorization") === defaultSecretBearer) {
+      headers.delete("Authorization");
+    }
+    return fetch(input, { ...requestInit, headers });
+  };
+}
+
 /**
  * Service-role Supabase client — bypasses RLS.
  * Use only in Edge Functions that need elevated access.
  */
 export function createServiceClient(): SupabaseClient {
   const url = Deno.env.get("SUPABASE_URL");
-  const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  const key = getSupabaseAdminKey();
   if (!url || !key) {
     throw new Error(
-      "Missing required environment variables: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY",
+      "Missing required environment variables: SUPABASE_URL and either SUPABASE_SECRET_KEYS or SUPABASE_SERVICE_ROLE_KEY",
     );
   }
+  const adminFetch = makeSupabaseAdminFetch(key);
   return createClient(url, key, {
     auth: {
       persistSession: false,
       autoRefreshToken: false,
       detectSessionInUrl: false,
     },
+    ...(adminFetch ? { global: { fetch: adminFetch } } : {}),
   });
 }

--- a/supabase/functions/_shared/supabase_client_test.ts
+++ b/supabase/functions/_shared/supabase_client_test.ts
@@ -1,0 +1,114 @@
+import { assertEquals } from "@std/assert";
+import {
+  createFetchMock,
+  withEnv,
+  withMockedFetch,
+} from "../_test_utils/mock_http.ts";
+import { createServiceClient } from "./supabase_client.ts";
+
+const BASE_ENV = {
+  SUPABASE_URL: "https://example.supabase.co",
+};
+
+Deno.test("createServiceClient: sb_secret admin client sends apikey without default bearer", async () => {
+  await withEnv(
+    {
+      ...BASE_ENV,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+      SUPABASE_SECRET_KEYS: JSON.stringify({
+        default: "sb_secret_test_key",
+      }),
+    },
+    async () => {
+      let capturedHeaders = new Headers();
+      const { fetchMock } = createFetchMock([
+        {
+          matcher: "/rest/v1/probe",
+          handler: (req) => {
+            capturedHeaders = req.headers;
+            return new Response("[]", {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          },
+        },
+      ]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await createServiceClient().from("probe").select("*");
+      });
+
+      assertEquals(capturedHeaders.get("apikey"), "sb_secret_test_key");
+      assertEquals(capturedHeaders.get("Authorization"), null);
+    },
+  );
+});
+
+Deno.test("createServiceClient: legacy service_role JWT keeps bearer", async () => {
+  await withEnv(
+    {
+      ...BASE_ENV,
+      SUPABASE_SERVICE_ROLE_KEY: "legacy-service-role-jwt",
+      SUPABASE_SECRET_KEYS: undefined,
+    },
+    async () => {
+      let capturedHeaders = new Headers();
+      const { fetchMock } = createFetchMock([
+        {
+          matcher: "/rest/v1/probe",
+          handler: (req) => {
+            capturedHeaders = req.headers;
+            return new Response("[]", {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          },
+        },
+      ]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await createServiceClient().from("probe").select("*");
+      });
+
+      assertEquals(capturedHeaders.get("apikey"), "legacy-service-role-jwt");
+      assertEquals(
+        capturedHeaders.get("Authorization"),
+        "Bearer legacy-service-role-jwt",
+      );
+    },
+  );
+});
+
+Deno.test("createServiceClient: sb_secret admin client preserves user JWT auth calls", async () => {
+  await withEnv(
+    {
+      ...BASE_ENV,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+      SUPABASE_SECRET_KEYS: JSON.stringify({
+        default: "sb_secret_test_key",
+      }),
+    },
+    async () => {
+      let capturedHeaders = new Headers();
+      const { fetchMock } = createFetchMock([
+        {
+          matcher: "/auth/v1/user",
+          handler: (req) => {
+            capturedHeaders = req.headers;
+            return new Response(JSON.stringify({ user: { id: "user-1" } }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          },
+        },
+      ]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await createServiceClient().auth.getUser("user-jwt");
+      });
+
+      assertEquals(capturedHeaders.get("apikey"), "sb_secret_test_key");
+      assertEquals(capturedHeaders.get("Authorization"), "Bearer user-jwt");
+    },
+  );
+});

--- a/supabase/functions/health/health_test.ts
+++ b/supabase/functions/health/health_test.ts
@@ -11,11 +11,19 @@ import {
 Deno.test({
   name: "health - returns 200 with healthy status when all checks pass",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
 
     const { fetchMock } = createFetchMock([
-      { matcher: "/rest/v1/", handler: () => new Response(null, { status: 200 }) },
-      { matcher: "/auth/v1/health", handler: () => jsonResponse({ status: "ok" }) },
+      {
+        matcher: "/rest/v1/",
+        handler: () => new Response(null, { status: 200 }),
+      },
+      {
+        matcher: "/auth/v1/health",
+        handler: () => jsonResponse({ status: "ok" }),
+      },
       { matcher: "/storage/v1/bucket", handler: () => jsonResponse([]) },
     ]);
 
@@ -27,7 +35,9 @@ Deno.test({
       SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
     }, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(new Request("http://localhost", { method: "GET" }));
+        const response = await handler(
+          new Request("http://localhost", { method: "GET" }),
+        );
         assertEquals(response.status, 200);
 
         const body = await readJson(response);
@@ -41,13 +51,72 @@ Deno.test({
 });
 
 Deno.test({
-  name: "health - returns 503 when database is down",
+  name: "health - uses SUPABASE_SECRET_KEYS with apikey header only",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    const assertSecretApiKey = (req: Request) => {
+      assertEquals(req.headers.get("apikey"), "sb_secret_health_key");
+      assertEquals(req.headers.get("Authorization"), null);
+    };
 
     const { fetchMock } = createFetchMock([
-      { matcher: "/rest/v1/", handler: () => new Response(null, { status: 500 }) },
-      { matcher: "/auth/v1/health", handler: () => jsonResponse({ status: "ok" }) },
+      {
+        matcher: "/rest/v1/",
+        handler: (req) => {
+          assertSecretApiKey(req);
+          return new Response(null, { status: 200 });
+        },
+      },
+      {
+        matcher: "/auth/v1/health",
+        handler: () => jsonResponse({ status: "ok" }),
+      },
+      {
+        matcher: "/storage/v1/bucket",
+        handler: (req) => {
+          assertSecretApiKey(req);
+          return jsonResponse([]);
+        },
+      },
+    ]);
+
+    await withEnv({
+      ENVIRONMENT: "dev",
+      MINGLIT_EF_TEST_FN_NAME: "health",
+      SUPABASE_URL: "http://localhost:54321",
+      SUPABASE_ANON_KEY: "test-anon-key",
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+      SUPABASE_SECRET_KEYS: JSON.stringify({ default: "sb_secret_health_key" }),
+    }, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(
+          new Request("http://localhost", { method: "GET" }),
+        );
+        assertEquals(response.status, 200);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "health - returns 503 when database is down",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "/rest/v1/",
+        handler: () => new Response(null, { status: 500 }),
+      },
+      {
+        matcher: "/auth/v1/health",
+        handler: () => jsonResponse({ status: "ok" }),
+      },
       { matcher: "/storage/v1/bucket", handler: () => jsonResponse([]) },
     ]);
 
@@ -59,7 +128,9 @@ Deno.test({
       SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
     }, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(new Request("http://localhost", { method: "GET" }));
+        const response = await handler(
+          new Request("http://localhost", { method: "GET" }),
+        );
         assertEquals(response.status, 503);
 
         const body = await readJson(response);
@@ -74,11 +145,19 @@ Deno.test({
 Deno.test({
   name: "health - response contains required keys",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
 
     const { fetchMock } = createFetchMock([
-      { matcher: "/rest/v1/", handler: () => new Response(null, { status: 200 }) },
-      { matcher: "/auth/v1/health", handler: () => jsonResponse({ status: "ok" }) },
+      {
+        matcher: "/rest/v1/",
+        handler: () => new Response(null, { status: 200 }),
+      },
+      {
+        matcher: "/auth/v1/health",
+        handler: () => jsonResponse({ status: "ok" }),
+      },
       { matcher: "/storage/v1/bucket", handler: () => jsonResponse([]) },
     ]);
 
@@ -90,7 +169,9 @@ Deno.test({
       SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
     }, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(new Request("http://localhost", { method: "GET" }));
+        const response = await handler(
+          new Request("http://localhost", { method: "GET" }),
+        );
         const body = await readJson(response);
 
         assertEquals(typeof body.status, "string");
@@ -107,11 +188,19 @@ Deno.test({
 Deno.test({
   name: "health - returns Content-Type application/json",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
 
     const { fetchMock } = createFetchMock([
-      { matcher: "/rest/v1/", handler: () => new Response(null, { status: 200 }) },
-      { matcher: "/auth/v1/health", handler: () => jsonResponse({ status: "ok" }) },
+      {
+        matcher: "/rest/v1/",
+        handler: () => new Response(null, { status: 200 }),
+      },
+      {
+        matcher: "/auth/v1/health",
+        handler: () => jsonResponse({ status: "ok" }),
+      },
       { matcher: "/storage/v1/bucket", handler: () => jsonResponse([]) },
     ]);
 
@@ -123,7 +212,9 @@ Deno.test({
       SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
     }, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(new Request("http://localhost", { method: "GET" }));
+        const response = await handler(
+          new Request("http://localhost", { method: "GET" }),
+        );
         assertEquals(response.headers.get("Content-Type"), "application/json");
       });
     });
@@ -133,7 +224,9 @@ Deno.test({
 Deno.test({
   name: "health - rejects non-GET with 405",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
 
     await withEnv({
       ENVIRONMENT: "dev",
@@ -142,7 +235,9 @@ Deno.test({
       SUPABASE_ANON_KEY: "test-anon-key",
       SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
     }, async () => {
-      const response = await handler(new Request("http://localhost", { method: "POST" }));
+      const response = await handler(
+        new Request("http://localhost", { method: "POST" }),
+      );
       assertEquals(response.status, 405);
     });
   },
@@ -152,11 +247,19 @@ Deno.test({
 Deno.test({
   name: "health - ?env=true without auth returns 401",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
 
     const { fetchMock } = createFetchMock([
-      { matcher: "/rest/v1/", handler: () => new Response(null, { status: 200 }) },
-      { matcher: "/auth/v1/health", handler: () => jsonResponse({ status: "ok" }) },
+      {
+        matcher: "/rest/v1/",
+        handler: () => new Response(null, { status: 200 }),
+      },
+      {
+        matcher: "/auth/v1/health",
+        handler: () => jsonResponse({ status: "ok" }),
+      },
       { matcher: "/storage/v1/bucket", handler: () => jsonResponse([]) },
     ]);
 
@@ -180,11 +283,19 @@ Deno.test({
 Deno.test({
   name: "health - ?env=true with wrong bearer returns 401",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
 
     const { fetchMock } = createFetchMock([
-      { matcher: "/rest/v1/", handler: () => new Response(null, { status: 200 }) },
-      { matcher: "/auth/v1/health", handler: () => jsonResponse({ status: "ok" }) },
+      {
+        matcher: "/rest/v1/",
+        handler: () => new Response(null, { status: 200 }),
+      },
+      {
+        matcher: "/auth/v1/health",
+        handler: () => jsonResponse({ status: "ok" }),
+      },
       { matcher: "/storage/v1/bucket", handler: () => jsonResponse([]) },
     ]);
 
@@ -211,11 +322,19 @@ Deno.test({
 Deno.test({
   name: "health - ?env=true with correct service role returns env_check",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
 
     const { fetchMock } = createFetchMock([
-      { matcher: "/rest/v1/", handler: () => new Response(null, { status: 200 }) },
-      { matcher: "/auth/v1/health", handler: () => jsonResponse({ status: "ok" }) },
+      {
+        matcher: "/rest/v1/",
+        handler: () => new Response(null, { status: 200 }),
+      },
+      {
+        matcher: "/auth/v1/health",
+        handler: () => jsonResponse({ status: "ok" }),
+      },
       { matcher: "/storage/v1/bucket", handler: () => jsonResponse([]) },
     ]);
 
@@ -231,6 +350,48 @@ Deno.test({
           new Request("http://localhost?env=true", {
             method: "GET",
             headers: { Authorization: "Bearer test-service-key" },
+          }),
+        );
+        const body = await readJson(response);
+        assertEquals(typeof body.env_check, "object");
+        assertEquals(typeof body.env_check.status, "string");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "health - ?env=true with secret apikey returns env_check",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "/rest/v1/",
+        handler: () => new Response(null, { status: 200 }),
+      },
+      {
+        matcher: "/auth/v1/health",
+        handler: () => jsonResponse({ status: "ok" }),
+      },
+      { matcher: "/storage/v1/bucket", handler: () => jsonResponse([]) },
+    ]);
+
+    await withEnv({
+      ENVIRONMENT: "dev",
+      MINGLIT_EF_TEST_FN_NAME: "health",
+      SUPABASE_URL: "http://localhost:54321",
+      SUPABASE_ANON_KEY: "test-anon-key",
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+      SUPABASE_SECRET_KEYS: JSON.stringify({ default: "sb_secret_health_key" }),
+    }, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(
+          new Request("http://localhost?env=true", {
+            method: "GET",
+            headers: { apikey: "sb_secret_health_key" },
           }),
         );
         const body = await readJson(response);

--- a/supabase/functions/health/index.ts
+++ b/supabase/functions/health/index.ts
@@ -1,8 +1,12 @@
 // Fix #2185 (Batch 10): migrate to minglitEdgeFunction wrapper — auth via manifest (system + public)
-import { successResponse, errorResponse } from "../_shared/response_utils.ts";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import { checkAllFunctions } from "../_shared/env_keystore.ts";
 import { nowISO } from "../_shared/temporal_utils.ts";
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
+import {
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
+import { makeSupabaseAdminHeaders } from "../_shared/supabase_client.ts";
 
 interface CheckResult {
   status: "up" | "down";
@@ -29,16 +33,12 @@ async function checkDatabase(): Promise<CheckResult> {
   const start = performance.now();
   try {
     const url = Deno.env.get("SUPABASE_URL") ?? "";
-    const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 
     const res = await withTimeout(
       () =>
         fetch(`${url}/rest/v1/`, {
           method: "HEAD",
-          headers: {
-            apikey: key,
-            Authorization: `Bearer ${key}`,
-          },
+          headers: makeSupabaseAdminHeaders(),
         }),
       TIMEOUT_MS,
     );
@@ -63,9 +63,10 @@ async function checkAuth(): Promise<CheckResult> {
     const key = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
 
     const res = await withTimeout(
-      () => fetch(`${url}/auth/v1/health`, {
-        headers: { apikey: key },
-      }),
+      () =>
+        fetch(`${url}/auth/v1/health`, {
+          headers: { apikey: key },
+        }),
       TIMEOUT_MS,
     );
 
@@ -86,15 +87,11 @@ async function checkStorage(): Promise<CheckResult> {
   const start = performance.now();
   try {
     const url = Deno.env.get("SUPABASE_URL") ?? "";
-    const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 
     const res = await withTimeout(
       () =>
         fetch(`${url}/storage/v1/bucket`, {
-          headers: {
-            apikey: key,
-            Authorization: `Bearer ${key}`,
-          },
+          headers: makeSupabaseAdminHeaders(),
         }),
       TIMEOUT_MS,
     );
@@ -112,7 +109,10 @@ async function checkStorage(): Promise<CheckResult> {
   }
 }
 
-export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
   if (req.method !== "GET") {
     return errorResponse("Method not allowed", 405);
   }
@@ -126,8 +126,7 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
     checkStorage(),
   ]);
 
-  const allUp =
-    database.status === "up" &&
+  const allUp = database.status === "up" &&
     auth.status === "up" &&
     storage.status === "up";
 
@@ -135,9 +134,21 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
     status: allUp ? "healthy" : "unhealthy",
     timestamp: nowISO(),
     checks: {
-      database: { status: database.status, latency_ms: database.latency_ms, ...(database.error && { error: database.error }) },
-      auth: { status: auth.status, latency_ms: auth.latency_ms, ...(auth.error && { error: auth.error }) },
-      storage: { status: storage.status, latency_ms: storage.latency_ms, ...(storage.error && { error: storage.error }) },
+      database: {
+        status: database.status,
+        latency_ms: database.latency_ms,
+        ...(database.error && { error: database.error }),
+      },
+      auth: {
+        status: auth.status,
+        latency_ms: auth.latency_ms,
+        ...(auth.error && { error: auth.error }),
+      },
+      storage: {
+        status: storage.status,
+        latency_ms: storage.latency_ms,
+        ...(storage.error && { error: storage.error }),
+      },
     },
   };
 

--- a/supabase/migrations/20260603033250_cron_service_role_key_apikey_header.sql
+++ b/supabase/migrations/20260603033250_cron_service_role_key_apikey_header.sql
@@ -1,0 +1,126 @@
+-- Fix #2187: pg_cron -> Edge Function system auth must be compatible with
+-- both legacy service_role JWT and new sb_secret_ secret API keys.
+--
+-- Legacy JWT path:
+--   Authorization: Bearer <service_role_key>
+--
+-- New secret key path:
+--   apikey: <service_role_key>
+--
+-- The Vault secret name remains service_role_key so existing deploy sync and
+-- tests keep one source of truth. If the value is legacy JWT, bearer auth wins.
+-- If the value is sb_secret_..., the wrapper rejects bearer and accepts apikey.
+
+DO $$
+DECLARE
+  cron_target record;
+  command_sql text;
+BEGIN
+  FOR cron_target IN
+    SELECT *
+    FROM (VALUES
+      ('process-notifications', 'notification-worker', '* * * * *'),
+      ('settlement-reconciliation-daily', 'reconciliation-daily', '0 13 * * *'),
+      ('settlement-register-transfers', 'settlement-register-transfers', '*/15 * * * *'),
+      ('settlement-payout-sync', 'payout-sync', '0 2,5,8 * * *'),
+      ('settlement-alarm-check', 'metrics-alert', '*/30 * * * *'),
+      ('sync_github_stats', 'github-stats-sync', '30 20 * * *'),
+      ('ai-extract-tags', 'ai-extract-tags', '* * * * *'),
+      ('process-pending-deletions', 'process-pending-deletions', '0 0 * * *'),
+      ('cleanup-blocked-dis', 'cleanup-blocked-dis', '0 1 * * *'),
+      ('cleanup-retention', 'cleanup-retention', '0 3 * * *'),
+      ('recurrence-cron-daily', 'recurrence-cron', '0 0 * * *')
+    ) AS jobs(jobname, function_name, cron_expr)
+  LOOP
+    IF EXISTS (
+      SELECT 1 FROM cron.job AS cj WHERE cj.jobname = cron_target.jobname
+    ) THEN
+      PERFORM cron.unschedule(cron_target.jobname);
+    END IF;
+
+    command_sql := format(
+      $command$
+        SELECT net.http_post(
+          url := (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'supabase_url' LIMIT 1
+          ) || '/functions/v1/%s',
+          headers := jsonb_build_object(
+            'Content-Type', 'application/json',
+            'apikey', (
+              SELECT decrypted_secret FROM vault.decrypted_secrets
+              WHERE name = 'service_role_key' LIMIT 1
+            ),
+            'Authorization', 'Bearer ' || (
+              SELECT decrypted_secret FROM vault.decrypted_secrets
+              WHERE name = 'service_role_key' LIMIT 1
+            )
+          ),
+          body := '{}'::jsonb
+        ) AS request_id;
+      $command$,
+      cron_target.function_name
+    );
+
+    PERFORM cron.schedule(
+      cron_target.jobname,
+      cron_target.cron_expr,
+      command_sql
+    );
+  END LOOP;
+END $$;
+
+-- analytics.call_metrics_alert is not stored in cron.job.command; it is called
+-- by analytics cron functions and then invokes the system-only metrics-alert EF.
+-- Keep it compatible with both legacy service_role JWT and sb_secret_ keys too.
+CREATE OR REPLACE FUNCTION analytics.call_metrics_alert(
+  p_type TEXT,
+  p_title TEXT,
+  p_body TEXT
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  v_service_role_key TEXT;
+  v_supabase_url TEXT;
+BEGIN
+  SELECT decrypted_secret INTO v_service_role_key
+  FROM vault.decrypted_secrets
+  WHERE name = 'service_role_key'
+  LIMIT 1;
+
+  SELECT decrypted_secret INTO v_supabase_url
+  FROM vault.decrypted_secrets
+  WHERE name = 'supabase_url'
+  LIMIT 1;
+
+  IF v_supabase_url IS NULL OR v_service_role_key IS NULL THEN
+    RAISE WARNING 'call_metrics_alert: vault secret missing (supabase_url=%, service_role_key=%)',
+      v_supabase_url IS NOT NULL, v_service_role_key IS NOT NULL;
+    RETURN;
+  END IF;
+
+  PERFORM net.http_post(
+    url := v_supabase_url || '/functions/v1/metrics-alert',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'apikey', v_service_role_key,
+      'Authorization', 'Bearer ' || v_service_role_key
+    ),
+    body := jsonb_build_object(
+      'type', p_type,
+      'title', p_title,
+      'body', p_body
+    )
+  );
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'analytics.call_metrics_alert failed: [%] %', SQLSTATE, SQLERRM;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION analytics.call_metrics_alert(TEXT, TEXT, TEXT)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION analytics.call_metrics_alert(TEXT, TEXT, TEXT)
+  TO service_role;

--- a/supabase/tests/database/94_cron_service_role_key_test.sql
+++ b/supabase/tests/database/94_cron_service_role_key_test.sql
@@ -1,12 +1,14 @@
--- Fix #1758: pg_cron 모든 HTTP EF 호출이 service_role_key를 사용하는지 검증
+-- Fix #1758/#2187: pg_cron 모든 HTTP EF 호출이 service_role_key를 사용하고,
+-- legacy JWT / sb_secret_ 모두 호환되도록 Authorization + apikey 헤더를 함께 보내는지 검증
 -- publishable_key(anon JWT) 사용 시 requireServiceRole() 가드에서 401 반환
 
 BEGIN;
 -- Fix #2647: plan(8) → plan(7) — backend-simulation cron 제거됨
 -- (20260517000002_rename_backend_simulator_to_event_flow_simulator.sql)
-SELECT plan(7);
+-- Fix #2187: plan(7) → plan(8) — analytics.call_metrics_alert도 sb_secret 호환 검증
+SELECT plan(8);
 
--- Helper: 특정 cron job의 Authorization 헤더가 service_role_key를 참조하는지 확인
+-- Helper: 특정 cron job의 headers가 service_role_key를 apikey + Authorization 양쪽에 참조하는지 확인
 CREATE OR REPLACE FUNCTION _check_cron_uses_service_role(p_jobname text)
 RETURNS boolean
 LANGUAGE plpgsql AS $$
@@ -17,50 +19,75 @@ BEGIN
   IF v_command IS NULL THEN
     RETURN false;
   END IF;
-  RETURN v_command LIKE '%service_role_key%' AND v_command NOT LIKE '%publishable_key%';
+  RETURN v_command LIKE '%service_role_key%'
+    AND v_command NOT LIKE '%publishable_key%'
+    AND v_command LIKE '%''apikey''%'
+    AND v_command LIKE '%''Authorization''%';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION _check_metrics_alert_helper_uses_service_role()
+RETURNS boolean
+LANGUAGE plpgsql AS $$
+DECLARE
+  v_definition text;
+BEGIN
+  SELECT pg_get_functiondef('analytics.call_metrics_alert(text,text,text)'::regprocedure)
+    INTO v_definition;
+
+  RETURN v_definition LIKE '%service_role_key%'
+    AND v_definition NOT LIKE '%publishable_key%'
+    AND v_definition LIKE '%''apikey''%'
+    AND v_definition LIKE '%''Authorization''%';
 END;
 $$;
 
 -- 1. process-notifications: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('process-notifications'),
-  'process-notifications cron uses service_role_key (not publishable_key)'
+  'process-notifications cron uses service_role_key with apikey + Authorization'
 );
 
 -- 2. settlement-reconciliation-daily: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('settlement-reconciliation-daily'),
-  'settlement-reconciliation-daily cron uses service_role_key (not publishable_key)'
+  'settlement-reconciliation-daily cron uses service_role_key with apikey + Authorization'
 );
 
 -- 3. settlement-register-transfers: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('settlement-register-transfers'),
-  'settlement-register-transfers cron uses service_role_key (not publishable_key)'
+  'settlement-register-transfers cron uses service_role_key with apikey + Authorization'
 );
 
 -- 4. settlement-payout-sync: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('settlement-payout-sync'),
-  'settlement-payout-sync cron uses service_role_key (not publishable_key)'
+  'settlement-payout-sync cron uses service_role_key with apikey + Authorization'
 );
 
 -- 5. settlement-alarm-check: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('settlement-alarm-check'),
-  'settlement-alarm-check cron uses service_role_key (not publishable_key)'
+  'settlement-alarm-check cron uses service_role_key with apikey + Authorization'
 );
 
 -- 6. ai-extract-tags: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('ai-extract-tags'),
-  'ai-extract-tags cron uses service_role_key (not publishable_key)'
+  'ai-extract-tags cron uses service_role_key with apikey + Authorization'
 );
 
 -- 7. sync_github_stats: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('sync_github_stats'),
-  'sync_github_stats cron uses service_role_key (not publishable_key)'
+  'sync_github_stats cron uses service_role_key with apikey + Authorization'
+);
+
+-- 8. analytics.call_metrics_alert helper: service_role_key 사용
+SELECT ok(
+  _check_metrics_alert_helper_uses_service_role(),
+  'analytics.call_metrics_alert uses service_role_key with apikey + Authorization'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/database/95_ef_auth_manifest_cron_consistency_test.sql
+++ b/supabase/tests/database/95_ef_auth_manifest_cron_consistency_test.sql
@@ -7,7 +7,35 @@
 --            6일간 401 무음 실패. 이 테스트가 PR 차단으로 즉시 감지한다.
 
 BEGIN;
-SELECT plan(2);
+SELECT plan(4);
+
+CREATE OR REPLACE FUNCTION _extract_cron_authorization_vault_key(p_command text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $fn$
+  SELECT (
+    regexp_match(
+      p_command,
+      $re$'Authorization'\s*,\s*'Bearer '\s*\|\|\s*\(\s*SELECT\s+decrypted_secret\s+FROM\s+vault\.decrypted_secrets\s+WHERE\s+name\s*=\s*'([a-z_]+)'\s+LIMIT$re$,
+      'is'
+    )
+  )[1];
+$fn$;
+
+CREATE OR REPLACE FUNCTION _extract_cron_apikey_vault_key(p_command text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $fn$
+  SELECT (
+    regexp_match(
+      p_command,
+      $re$'apikey'\s*,\s*\(\s*SELECT\s+decrypted_secret\s+FROM\s+vault\.decrypted_secrets\s+WHERE\s+name\s*=\s*'([a-z_]+)'\s+LIMIT$re$,
+      'is'
+    )
+  )[1];
+$fn$;
 
 -- ── 헬퍼: cron.job에서 EF 이름과 Authorization vault key 추출
 -- regexp_match (scalar, Pg10+) 사용 — regexp_matches with 'g' is set-returning and
@@ -17,25 +45,61 @@ CREATE TEMP TABLE _cron_ef_calls AS
 SELECT
   jobname,
   (regexp_match(command, '/functions/v1/([a-z][a-z0-9-]+)'))[1]      AS ef_name,
-  (regexp_match(command, 'Authorization.+WHERE name\s*=\s*''([a-z_]+)''\s+LIMIT', 's'))[1] AS vault_key
+  _extract_cron_authorization_vault_key(command) AS auth_vault_key,
+  _extract_cron_apikey_vault_key(command) AS apikey_vault_key
 FROM cron.job
 WHERE command LIKE '%net.http_post%'
   AND command LIKE '%/functions/v1/%';
 
--- ── 1. manifest에 등록된 EF는 반드시 service_role_key vault secret 사용
+-- ── 1. apikey extractor는 Authorization lookup으로 넘어가지 않아야 함
+SELECT is(
+  _extract_cron_apikey_vault_key($fixture$
+    SELECT net.http_post(
+      url := 'https://example.supabase.co/functions/v1/notification-worker',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'apikey', (
+          SELECT decrypted_secret FROM vault.decrypted_secrets
+          WHERE name = 'publishable_key' LIMIT 1
+        ),
+        'Authorization', 'Bearer ' || (
+          SELECT decrypted_secret FROM vault.decrypted_secrets
+          WHERE name = 'service_role_key' LIMIT 1
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $fixture$),
+  'publishable_key',
+  'apikey vault-key extractor must not fall through to Authorization lookup'
+);
+
+-- ── 2. manifest에 등록된 EF는 반드시 service_role_key vault secret 사용
 --    (publishable_key 또는 다른 key → 401 발생)
 SELECT is(
   (
     SELECT count(*)::int
     FROM _cron_ef_calls c
     JOIN public.ef_auth_manifest m ON m.ef_name = c.ef_name
-    WHERE (c.vault_key IS NULL OR c.vault_key != 'service_role_key')
+    WHERE (c.auth_vault_key IS NULL OR c.auth_vault_key != 'service_role_key')
   ),
   0,
-  'All pg_cron EFs in manifest must use service_role_key vault secret'
+  'All pg_cron EFs in manifest must use service_role_key vault secret for Authorization'
 );
 
--- ── 2. pg_cron에서 HTTP 호출하는 EF는 반드시 manifest에 등록되어 있어야 함
+-- ── 3. manifest에 등록된 EF는 sb_secret_ 호환을 위해 apikey 헤더도 service_role_key 사용
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM _cron_ef_calls c
+    JOIN public.ef_auth_manifest m ON m.ef_name = c.ef_name
+    WHERE (c.apikey_vault_key IS NULL OR c.apikey_vault_key != 'service_role_key')
+  ),
+  0,
+  'All pg_cron EFs in manifest must use service_role_key vault secret for apikey'
+);
+
+-- ── 4. pg_cron에서 HTTP 호출하는 EF는 반드시 manifest에 등록되어 있어야 함
 --    (신규 EF를 pg_cron에 추가할 때 manifest 업데이트를 강제)
 SELECT is(
   (


### PR DESCRIPTION
## Summary

- align Edge Function system auth with Supabase `sb_secret_...` secret keys using `apikey` while keeping legacy `service_role` JWT bearer compatibility
- make admin Supabase client/header generation avoid `Authorization: Bearer sb_secret...` and add regression tests
- update cron/workflow calls, env docs, BLUEDOC pointers, and add a migration for pg_cron + `analytics.call_metrics_alert`
- explicitly register missing manifest-backed EF config sections with `verify_jwt=false`

## Verification

- `deno test --allow-all --config supabase/deno.json supabase/functions/_shared/supabase_client_test.ts supabase/functions/_shared/edge_function_system_auth_test.ts supabase/functions/health/health_test.ts`
- `deno test --allow-all --config supabase/deno.json supabase/functions/notification-worker/notification_worker_test.ts supabase/functions/ai-embed/ai_embed_test.ts supabase/functions/ai-extract-tags/ai_extract_tags_test.ts`
- manifest/config consistency script: 54 manifest functions, 54 config sections, no missing, all `verify_jwt=false`
- `git diff --check HEAD~1..HEAD`
- `bash scripts/generate-env-docs.sh && git diff --exit-code -- docs/env-reference.md`

Closes #2187

Follow-up audit issues opened separately:
- #2979
- #2981