### PR TITLE
ci: move CUJ to dev health promotion contract

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -7,13 +7,13 @@
 | Script | 역할 | 호출자 |
 |---|---|---|
 | [`create-dev-flutter-env.sh`](./create-dev-flutter-env.sh) | Actions secrets → `minglit_env/dev/flutter.env` 재생성 (CI 가 private submodule `minglit_env/` 를 받지 못해서 필요, Fix #1169) | `shared-cuj-integration`, `monitor-patrol-e2e` |
-| [`run-user-cuj.sh`](./run-user-cuj.sh) | `apps/app_user/integration_test/cuj/` 의 CUJ 테스트 실행 (emulator) | `shared-cuj-integration` (app-name=user 일 때) |
-| [`run-partner-cuj.sh`](./run-partner-cuj.sh) | `apps/app_partner/integration_test/cuj/` CUJ 실행 | `shared-cuj-integration` (app-name=partner 일 때) |
+| [`run-user-cuj.sh`](./run-user-cuj.sh) | `apps/app_user/integration_test/cuj/` 의 CUJ 테스트 실행. 모든 CUJ 파일을 실행한 뒤 실패 목록 aggregate | `shared-cuj-integration` (app-name=user 일 때), `monitor-dev-cuj` |
+| [`run-partner-cuj.sh`](./run-partner-cuj.sh) | `apps/app_partner/integration_test/cuj/` CUJ 실행. 모든 CUJ 파일을 실행한 뒤 실패 목록 aggregate | `shared-cuj-integration` (app-name=partner 일 때), `monitor-dev-cuj` |
 | [`check-bluedoc-freshness.sh`](./check-bluedoc-freshness.sh) | PR 에서 새/삭제 파일에 대해 가장 가까운 ancestor BLUEDOC.md 갱신 강제. 통과: 이정표 표 갱신 또는 BLUEDOC 의 `_Reviewed_` 날짜 bump. + 모든 BLUEDOC.md 의 Reviewed 형식 검증 | `pr-gate.check-bluedoc-freshness` (required check) |
 | [`check-pr-issue-reference.sh`](./check-pr-issue-reference.sh) | dev-staging PR 본문에 이슈 종료 의도(`Closes/Fixes/Resolves`) 또는 명시적 비종료 사유(`Refs` + 이유 / `No linked issue`)가 있는지 검사 | `pr-gate.static-checks` |
 | [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | `ios-deploy` action 의 브랜치 분기(`main` vs `non-main`) 회귀 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
 | [`check-android-deploy-workflow-contract.py`](./check-android-deploy-workflow-contract.py) | Android deploy release archive token 계약 + merge promotion 뒤 snapshot metadata 탐색 회귀 검증 | `pr-gate.static-checks` |
-| [`check-dev-soak-workflow-contract.py`](./check-dev-soak-workflow-contract.py) | dev event-flow cron install + `dev-rc-cut-gate` + `shared-soak-gate` 판정 계약 검증 | `pr-gate.static-checks` |
+| [`check-dev-soak-workflow-contract.py`](./check-dev-soak-workflow-contract.py) | dev event-flow cron install + `monitor-dev-cuj` + `dev-rc-cut-gate` + `shared-soak-gate` 판정 계약 검증 | `pr-gate.static-checks` |
 | [`check-dev-cut-workflow-contract.py`](./check-dev-cut-workflow-contract.py) | promotion cut workflow 의 full-history checkout, merge auto-merge mode, `shared-notify` repo 컨텍스트 계약 검증 | `pr-gate.static-checks` |
 | [`check-ios-connectivity-plus-cap.sh`](./check-ios-connectivity-plus-cap.sh) | iOS deploy runner 가 지원할 때까지 `connectivity_plus <7.1.0` resolution 강제 | `pr-gate.guard-ios-connectivity-plus-cap` |
 | [`scan-build-artifact-secrets.py`](./scan-build-artifact-secrets.py) | APK/AAB/`.next` 등 빌드 산출물에서 Supabase service-role secret 패턴을 redacted summary 로 검사 | `pr-gate.scan-build-artifact-secrets` |
@@ -25,6 +25,7 @@
 - **필수 env 는 시작부에 `: "${VAR:?msg}"` 로 검증** — secret 누락 시 즉시 명확히 fail.
 - **secrets 는 환경변수로 받기만** — script 안에 secret 값·경로 하드코드 금지.
 - **`cd apps/<app>` 같은 작업 디렉토리 전제는 명시** — 호출 워크플로우의 `working-directory:` 와 일치.
+- **CUJ env 파일은 기본 `minglit_env/dev/flutter.env`** — 로컬/CI override 는 `MINGLIT_CUJ_DART_DEFINE_FILE` 로만 한다.
 - **무거워지면 composite action 으로 승격** — script 가 외부 액션 chain 을 만들기 시작하면 [`actions/`](../actions/BLUEDOC.md) 로.
 
 ## 관련
@@ -34,4 +35,4 @@
 - [.github/BLUEDOC.md](../BLUEDOC.md) — 상위 진입점
 
 ---
-_Reviewed: 2026-06-03 12:18_
+_Reviewed: 2026-06-03 15:15_

--- a/.github/scripts/check-dev-soak-workflow-contract.py
+++ b/.github/scripts/check-dev-soak-workflow-contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate dev soak monitor and RC cut gate workflow contracts."""
+"""Validate dev health monitor and RC cut gate workflow contracts."""
 
 from __future__ import annotations
 
@@ -13,9 +13,18 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 MONITOR_DISTRIBUTED = ROOT / ".github/workflows/monitor-event-flow-distributed.yml"
+MONITOR_DEV_STAGING_HEALTH = ROOT / ".github/workflows/monitor-dev-staging-health.yml"
+MONITOR_DEV_CUJ = ROOT / ".github/workflows/monitor-dev-cuj.yml"
 DEPLOY_DEV_EVENT_FLOW_CRON = ROOT / ".github/workflows/deploy-dev-event-flow-cron.yml"
+SET_DEV_SOAK_STATUS = ROOT / ".github/workflows/set-dev-soak-status.yml"
 DEV_RC_CUT_GATE = ROOT / ".github/workflows/dev-rc-cut-gate.yml"
 SHARED_SOAK_GATE = ROOT / ".github/workflows/shared-soak-gate.yml"
+PR_GATE = ROOT / ".github/workflows/pr-gate.yml"
+DEV_PR_GATE = ROOT / ".github/workflows/dev-pr-gate.yml"
+RC_PR_GATE = ROOT / ".github/workflows/rc-pr-gate.yml"
+MAIN_PR_GATE = ROOT / ".github/workflows/main-pr-gate.yml"
+RUN_USER_CUJ = ROOT / ".github/scripts/run-user-cuj.sh"
+RUN_PARTNER_CUJ = ROOT / ".github/scripts/run-partner-cuj.sh"
 
 
 def fail(message: str) -> None:
@@ -134,6 +143,131 @@ def assert_dev_cron_deploy_contract() -> None:
             fail(f"install-dev-event-flow-cron.sh missing contract fragment: {fragment}")
 
 
+def assert_set_dev_soak_status_contract() -> None:
+    workflow = load_workflow(SET_DEV_SOAK_STATUS)
+    config = on_config(workflow)
+    dispatch = config.get("workflow_dispatch", {})
+    inputs = dispatch.get("inputs", {}) if isinstance(dispatch, dict) else {}
+    signal = inputs.get("signal", {}) if isinstance(inputs, dict) else {}
+    options = signal.get("options", []) if isinstance(signal, dict) else []
+    required_signals = [
+        "backend-simulator",
+        "cuj-user",
+        "cuj-partner",
+        "real-device",
+        "app-ai-review",
+    ]
+    for item in required_signals:
+        if item not in options:
+            fail(f"set-dev-soak-status workflow_dispatch signal options missing {item}")
+
+    jobs = jobs_config(workflow, SET_DEV_SOAK_STATUS)
+    mapper = jobs.get("map-dev-soak-status", {})
+    if not isinstance(mapper, dict):
+        fail("set-dev-soak-status must define map-dev-soak-status job")
+    script = run_block(mapper, "Map dev soak signal to status context")
+    required_fragments = [
+        "backend-simulator) CONTEXT=\"dev-soak/backend-simulator\"",
+        "cuj-user) CONTEXT=\"dev-soak/cuj-user\"",
+        "cuj-partner) CONTEXT=\"dev-soak/cuj-partner\"",
+        "real-device) CONTEXT=\"dev-soak/real-device\"",
+        "app-ai-review) CONTEXT=\"dev-soak/app-ai-review\"",
+    ]
+    for fragment in required_fragments:
+        if fragment not in script:
+            fail(f"set-dev-soak-status mapping missing fragment: {fragment}")
+
+
+def assert_dev_staging_health_contract() -> None:
+    workflow = load_workflow(MONITOR_DEV_STAGING_HEALTH)
+    jobs = jobs_config(workflow, MONITOR_DEV_STAGING_HEALTH)
+    forbidden_jobs = {
+        "cuj-user",
+        "cuj-partner",
+        "status-cuj-user",
+        "status-cuj-partner",
+    }
+    for job in forbidden_jobs:
+        if job in jobs:
+            fail(f"monitor-dev-staging-health must not define {job}; CUJ belongs to monitor-dev-cuj")
+    text = MONITOR_DEV_STAGING_HEALTH.read_text(encoding="utf-8")
+    if "dev-staging-health/cuj-" in text or "shared-cuj-integration.yml" in text:
+        fail("monitor-dev-staging-health must not run or write CUJ health statuses")
+
+
+def assert_monitor_dev_cuj_contract() -> None:
+    workflow = load_workflow(MONITOR_DEV_CUJ)
+    config = on_config(workflow)
+    push = config.get("push", {})
+    branches = push.get("branches", []) if isinstance(push, dict) else []
+    if branches != ["dev"]:
+        fail("monitor-dev-cuj must run only on push to dev")
+
+    jobs = jobs_config(workflow, MONITOR_DEV_CUJ)
+    plan = jobs.get("plan", {})
+    if not isinstance(plan, dict):
+        fail("monitor-dev-cuj must define plan job")
+    plan_script = run_block(plan, "Resolve dev CUJ candidate")
+    required_plan_fragments = [
+        "git fetch origin dev",
+        "EVENT_NAME",
+        "PUSH_SHA",
+        "INPUT_CANDIDATE_SHA",
+        "candidate_sha must be a full 40-character commit SHA",
+        "git merge-base --is-ancestor",
+        "candidate_sha must be reachable from origin/dev",
+    ]
+    for fragment in required_plan_fragments:
+        if fragment not in plan_script:
+            fail(f"monitor-dev-cuj plan step missing fragment: {fragment}")
+
+    expected_cuj_jobs = {
+        "cuj-user": ("user", "cuj-user", "status-cuj-user", "notify-cuj-user-failure"),
+        "cuj-partner": ("partner", "cuj-partner", "status-cuj-partner", "notify-cuj-partner-failure"),
+    }
+    for job_name, (app_name, signal, status_job, notify_job) in expected_cuj_jobs.items():
+        job = jobs.get(job_name, {})
+        if not isinstance(job, dict) or job.get("uses") != "./.github/workflows/shared-cuj-integration.yml":
+            fail(f"monitor-dev-cuj {job_name} must call shared-cuj-integration")
+        with_config = job.get("with", {})
+        if not isinstance(with_config, dict) or with_config.get("app-name") != app_name:
+            fail(f"monitor-dev-cuj {job_name} must use app-name={app_name}")
+
+        status = jobs.get(status_job, {})
+        if not isinstance(status, dict) or status.get("uses") != "./.github/workflows/set-dev-soak-status.yml":
+            fail(f"monitor-dev-cuj {status_job} must call set-dev-soak-status")
+        status_with = status.get("with", {})
+        if not isinstance(status_with, dict) or status_with.get("signal") != signal:
+            fail(f"monitor-dev-cuj {status_job} must write signal={signal}")
+
+        notify = jobs.get(notify_job, {})
+        if not isinstance(notify, dict) or notify.get("uses") != "./.github/workflows/shared-notify.yml":
+            fail(f"monitor-dev-cuj {notify_job} must call shared-notify")
+        notify_with = notify.get("with", {})
+        if not isinstance(notify_with, dict):
+            fail(f"monitor-dev-cuj {notify_job} with block did not parse as a mapping")
+        if notify_with.get("stage") != "dev-soak" or notify_with.get("signal") != signal:
+            fail(f"monitor-dev-cuj {notify_job} must notify stage=dev-soak signal={signal}")
+        if "blocks_rc_cut" not in notify_with:
+            fail(f"monitor-dev-cuj {notify_job} must set blocks_rc_cut")
+
+
+def assert_cuj_runner_contract() -> None:
+    for path in [RUN_USER_CUJ, RUN_PARTNER_CUJ]:
+        script = path.read_text(encoding="utf-8")
+        required_fragments = [
+            "DART_DEFINE_FILE=\"${MINGLIT_CUJ_DART_DEFINE_FILE:-",
+            "failed=0",
+            "failures=()",
+            "if ! flutter test",
+            "failures+=(\"$f\")",
+            "printf ' - %s\\n' \"${failures[@]}\"",
+        ]
+        for fragment in required_fragments:
+            if fragment not in script:
+                fail(f"{path.name} must aggregate CUJ failures; missing fragment: {fragment}")
+
+
 def assert_dev_rc_cut_gate_contract() -> None:
     workflow = load_workflow(DEV_RC_CUT_GATE)
     jobs = jobs_config(workflow, DEV_RC_CUT_GATE)
@@ -149,31 +283,79 @@ def assert_dev_rc_cut_gate_contract() -> None:
     if with_config.get("candidate_ref") != "dev":
         fail("dev-rc-cut-gate must evaluate origin/dev")
     min_soak_hours = str(with_config.get("min_soak_hours", ""))
-    if "24" not in min_soak_hours:
-        fail("dev-rc-cut-gate minimum soak must default to 24 hours")
+    if "0" not in min_soak_hours or "24" in min_soak_hours:
+        fail("dev-rc-cut-gate minimum dev soak must default to 0 hours")
 
     raw_required_runs = str(with_config.get("required_runs_json", "")).strip()
     try:
         required_runs = json.loads(raw_required_runs)
     except Exception as exc:  # noqa: BLE001 - contract failure should show parse detail.
         fail(f"dev-rc-cut-gate required_runs_json is invalid JSON: {exc}")
-    if not isinstance(required_runs, list) or len(required_runs) != 1:
-        fail("dev-rc-cut-gate must define exactly one required run contract")
-    run = required_runs[0]
-    if not isinstance(run, dict):
-        fail("dev-rc-cut-gate required run contract must be an object")
-
-    expected = {
-        "workflow": "deploy-dev-event-flow-cron.yml",
-        "branch": "dev",
-        "min_success": 1,
-        "match_head_sha": True,
+    if not isinstance(required_runs, list) or len(required_runs) != 2:
+        fail("dev-rc-cut-gate must define deploy-dev-event-flow-cron and monitor-dev-cuj required run contracts")
+    runs_by_workflow = {
+        item.get("workflow"): item
+        for item in required_runs
+        if isinstance(item, dict)
     }
-    for key, value in expected.items():
-        if run.get(key) != value:
-            fail(f"dev-rc-cut-gate required run {key} must be {value!r}")
-    if int(run.get("run_limit", 0)) < int(run["min_success"]):
-        fail("dev-rc-cut-gate run_limit must be >= min_success")
+
+    expected_runs = {
+        "deploy-dev-event-flow-cron.yml": {
+            "branch": "dev",
+            "min_success": 1,
+            "match_head_sha": True,
+        },
+        "monitor-dev-cuj.yml": {
+            "branch": "dev",
+            "min_success": 1,
+            "match_head_sha": True,
+        },
+    }
+    for workflow_name, expected in expected_runs.items():
+        run = runs_by_workflow.get(workflow_name)
+        if not isinstance(run, dict):
+            fail(f"dev-rc-cut-gate missing required run contract for {workflow_name}")
+        for key, value in expected.items():
+            if run.get(key) != value:
+                fail(f"dev-rc-cut-gate {workflow_name} required run {key} must be {value!r}")
+        if int(run.get("run_limit", 0)) < int(run["min_success"]):
+            fail(f"dev-rc-cut-gate {workflow_name} run_limit must be >= min_success")
+
+    failure_contexts = str(with_config.get("failure_contexts", ""))
+    success_contexts = str(with_config.get("success_contexts", ""))
+    required_contexts = [
+        "dev-soak/backend-simulator",
+        "dev-soak/cuj-user",
+        "dev-soak/cuj-partner",
+    ]
+    for context in required_contexts:
+        if context not in failure_contexts:
+            fail(f"dev-rc-cut-gate failure_contexts missing {context}")
+        if context not in success_contexts:
+            fail(f"dev-rc-cut-gate success_contexts missing {context}")
+
+    if with_config.get("pass_context") != "dev-rc-cut-pass":
+        fail("dev-rc-cut-gate pass_context must be dev-rc-cut-pass")
+
+
+def assert_pr_gate_cuj_contract() -> None:
+    pr_gate = load_workflow(PR_GATE)
+    config = on_config(pr_gate)
+    workflow_call = config.get("workflow_call", {})
+    inputs = workflow_call.get("inputs", {}) if isinstance(workflow_call, dict) else {}
+    run_cuj = inputs.get("run_cuj_integration", {}) if isinstance(inputs, dict) else {}
+    if not isinstance(run_cuj, dict) or run_cuj.get("default") is not False:
+        fail("pr-gate run_cuj_integration must default to false")
+
+    for path in [DEV_PR_GATE, RC_PR_GATE, MAIN_PR_GATE]:
+        workflow = load_workflow(path)
+        jobs = jobs_config(workflow, path)
+        core = jobs.get("pr-gate-core", {})
+        if not isinstance(core, dict):
+            fail(f"{path.name} must define pr-gate-core")
+        with_config = core.get("with", {})
+        if not isinstance(with_config, dict) or with_config.get("run_cuj_integration") is not False:
+            fail(f"{path.name} must pass run_cuj_integration=false")
 
 
 def assert_shared_soak_gate_contract() -> None:
@@ -192,9 +374,14 @@ def assert_shared_soak_gate_contract() -> None:
 def main() -> None:
     assert_distributed_monitor_contract()
     assert_dev_cron_deploy_contract()
+    assert_set_dev_soak_status_contract()
+    assert_dev_staging_health_contract()
+    assert_monitor_dev_cuj_contract()
+    assert_cuj_runner_contract()
     assert_dev_rc_cut_gate_contract()
+    assert_pr_gate_cuj_contract()
     assert_shared_soak_gate_contract()
-    print("Dev soak workflow contract OK")
+    print("Dev health workflow contract OK")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run-partner-cuj.sh
+++ b/.github/scripts/run-partner-cuj.sh
@@ -5,6 +5,7 @@ cd apps/app_partner
 # CUJ tests — emulator 기반 행위 검증.
 # 대응 BLUEDOC: apps/app_partner/integration_test/cuj/BLUEDOC.md
 CUJ_DIR="integration_test/cuj"
+DART_DEFINE_FILE="${MINGLIT_CUJ_DART_DEFINE_FILE:-../../minglit_env/dev/flutter.env}"
 
 if [ ! -d "$CUJ_DIR" ]; then
   echo "⏭ $CUJ_DIR not found, skipping."
@@ -12,15 +13,27 @@ if [ ! -d "$CUJ_DIR" ]; then
 fi
 
 found=0
+failed=0
+failures=()
 while IFS= read -r f; do
   [ -f "$f" ] || continue
   found=1
   echo "▶ Running: $f"
-  flutter test "$f" \
+  if ! flutter test "$f" \
     --flavor dev \
-    --dart-define-from-file=../../minglit_env/dev/flutter.env
+    --dart-define-from-file="$DART_DEFINE_FILE"; then
+    failed=1
+    failures+=("$f")
+    echo "❌ Failed: $f"
+  fi
 done < <(find "$CUJ_DIR" -name "*_test.dart" -not -path "*/_engine/*" | sort)
 
 if [ "$found" -eq 0 ]; then
   echo "⏭ No CUJ tests found in $CUJ_DIR, skipping."
+fi
+
+if [ "$failed" -ne 0 ]; then
+  echo "❌ CUJ failures:"
+  printf ' - %s\n' "${failures[@]}"
+  exit 1
 fi

--- a/.github/scripts/run-user-cuj.sh
+++ b/.github/scripts/run-user-cuj.sh
@@ -5,6 +5,7 @@ cd apps/app_user
 # CUJ tests — emulator 기반 행위 검증.
 # 대응 BLUEDOC: apps/app_user/integration_test/cuj/BLUEDOC.md
 CUJ_DIR="integration_test/cuj"
+DART_DEFINE_FILE="${MINGLIT_CUJ_DART_DEFINE_FILE:-../../minglit_env/dev/flutter.env}"
 
 if [ ! -d "$CUJ_DIR" ]; then
   echo "⏭ $CUJ_DIR not found, skipping."
@@ -12,15 +13,27 @@ if [ ! -d "$CUJ_DIR" ]; then
 fi
 
 found=0
+failed=0
+failures=()
 while IFS= read -r f; do
   [ -f "$f" ] || continue
   found=1
   echo "▶ Running: $f"
-  flutter test "$f" \
+  if ! flutter test "$f" \
     --flavor dev \
-    --dart-define-from-file=../../minglit_env/dev/flutter.env
+    --dart-define-from-file="$DART_DEFINE_FILE"; then
+    failed=1
+    failures+=("$f")
+    echo "❌ Failed: $f"
+  fi
 done < <(find "$CUJ_DIR" -name "*_test.dart" -not -path "*/_engine/*" | sort)
 
 if [ "$found" -eq 0 ]; then
   echo "⏭ No CUJ tests found in $CUJ_DIR, skipping."
+fi
+
+if [ "$failed" -ne 0 ]; then
+  echo "❌ CUJ failures:"
+  printf ' - %s\n' "${failures[@]}"
+  exit 1
 fi

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -14,7 +14,7 @@
 | `pr-setup-` | PR push 마다 PR 브랜치를 mutate 하는 자동화 (포맷 등) | (현재 없음 — `pr-setup-format` 은 #2627 에서 `pr-gate-format-check` 잡으로 대체) |
 | `pr-review-setup-` | PR 의 "리뷰 준비" 자동화 — auto-merge enable + 조건 충족 시 `needs-review` 라벨 부여 | `pr-review-setup` |
 | `deploy-` | 사용자·dev 환경에 코드·스키마·시드가 안 갔음 | `dev-deploy`, `main-deploy`, `deploy-vercel`, `deploy-supabase`, `deploy-dev-event-flow-cron`, `deploy-android-user`, `deploy-ios-user`, `deploy-dev-seed` |
-| `monitor-` | 운영·테스트 시스템 헬스 이상 / 스케줄 유지보수 | `monitor-dev-staging-health`, `monitor-db-invariants`, `monitor-event-flow-distributed`, `monitor-event-flow-hourly`, `monitor-event-flow-daily`, `monitor-mds-render-coverage`, `monitor-patrol-e2e`, `monitor-allure`, `monitor-build-retention`, `monitor-security-advisor`, `monitor-doc-freshness` |
+| `monitor-` | 운영·테스트 시스템 헬스 이상 / 스케줄 유지보수 | `monitor-dev-staging-health`, `monitor-dev-cuj`, `monitor-db-invariants`, `monitor-event-flow-distributed`, `monitor-event-flow-hourly`, `monitor-event-flow-daily`, `monitor-mds-render-coverage`, `monitor-patrol-e2e`, `monitor-allure`, `monitor-build-retention`, `monitor-security-advisor`, `monitor-doc-freshness` |
 | `sync-` | repo 에 자동 commit/push 가 실패함 (dev-staging push 또는 merge 기반) | `sync-graphify`, `sync-mds-mockups`, `sync-pr-branches`, `sync-test-coverage` |
 | `set-` | GitHub status/metadata 를 쓰는 수동·자동 API entrypoint 실패 | `set-dev-soak-status`, `set-rc-soak-status` |
 | `triage-` | 이슈 생성·슬래시 명령 (commit 없음) | `triage-mds-issue`, `triage-slash` |
@@ -33,10 +33,11 @@
 - Branch ruleset 의 required check 는 `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 같은 branch별 wrapper job 이름을 사용한다. `ci-result` summary job 은 폐기한다.
 - `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 얇은 wrapper 로 시작한다. 내부에서는 `pr-gate.yml` reusable core 를 호출하고, wrapper job 이 최종 required check context 를 제공한다.
 - `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 `shared-pr-source-guard` 로 직접 PR 을 차단한다. 정상 진입점은 `dev-staging` 이고, 예외는 branch별 approved hotfix 뿐이다.
-- `monitor-dev-staging-health` 는 required check 가 아니다. 6시간마다 `dev-staging` HEAD 에서 EF unit/integration + user/partner CUJ 를 돌려 nightly 전에 회귀를 발견하고, 결과를 `dev-staging-health/*` commit status 로 남긴다.
+- `monitor-dev-staging-health` 는 required check 가 아니다. 6시간마다 `dev-staging` HEAD 에서 EF unit/integration 중심으로 nightly 전 회귀를 발견하고, 결과를 `dev-staging-health/*` commit status 로 남긴다.
+- `monitor-dev-cuj` 는 `dev` push 마다 user/partner CUJ 를 실행하고 `dev-soak/cuj-user`, `dev-soak/cuj-partner` status 와 실패 이슈를 남긴다. CUJ 는 PR gate 가 아니라 새 dev commit 의 health signal 이다.
 - `dev-staging-dev-cut-gate` 는 수동 candidate inspect 전용이며 per-merge mutation 을 하지 않는다. 날짜 기반 dev-staging version bump/tag 는 하루 1회 `dev-staging-dev-cut` 이 직접 수행한다.
 - `dev-staging-dev-cut` 은 release bot 으로 protected `dev-staging` 에 version bump commit 을 fast-forward push 하고 `vYY.MM.DD+YYMMDDNN-dev-staging` tag 를 만든 뒤, 해당 tag SHA 를 `dev` 로 promote 한다. `dev`/`rc`/`main` promotion 은 source-controlled version 변경 없이 처리한다.
-- `dev-rc-cut-gate` 는 cut 직전 evaluator 다. 내부에서 `shared-soak-gate` 를 호출해 `dev-soak/*` status 와 `deploy-dev-event-flow-cron` candidate install run 을 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
+- `dev-rc-cut-gate` 는 cut 직전 evaluator 다. 내부에서 `shared-soak-gate` 를 호출해 legacy `dev-soak/*` health status, `deploy-dev-event-flow-cron`, `monitor-dev-cuj` same-SHA run evidence 를 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
 - Release gate 는 true evidence 기반이다. required success status/run history/git lineage 가 없으면 `unknown` 이며, failure issue 가 없다는 이유만으로 `dev-rc-cut-pass` 또는 `rc-main-cut-pass` 를 쓰지 않는다.
 - `dev-rc-cut` 은 latest `dev-rc-cut-pass` dev commit 에서 `rc/YYYY-Wxx` branch 를 만들고 `promo/rc-*` tag 를 생성한다. RC branch 에 version bump commit 을 만들지 않는다.
 - `dev-rc-cut` 은 active RC 가 있으면 기본 skip 한다. active RC 는 1개만 유지하고, 예외는 release-manager override 로만 허용한다.
@@ -52,7 +53,7 @@
 - 실제 build/upload/notify 로직은 각각 `shared-android-deploy`, `shared-ios-deploy`, `shared-vercel-deploy` 에 둔다.
 - 모바일 배포 산출물(APK/AAB/IPA)은 GitHub Release asset 으로 보관한다. Actions artifact 는 테스트/디버깅 산출물용이며, deploy archive 의 source-of-truth 로 쓰지 않는다.
 - deploy entry 는 후속 단계에서 `[branch]-deploy` 로 통일한다 (`dev-deploy`, `rc-deploy`, `main-deploy`). `monitor-event-flow-*` 는 deploy 가 아니라 지속 batch signal 이다.
-- `set-dev-soak-status` / `set-rc-soak-status` 는 workflow 와 AI agent 가 사용하는 공개 status write API 다. 내부에서는 `shared-set-commit-status` 를 호출한다.
+- `set-dev-soak-status` / `set-rc-soak-status` 는 workflow 와 AI agent 가 사용하는 공개 status write API 다. `dev-soak/*` prefix 는 dev health 의 legacy compatibility context 이며, 내부에서는 `shared-set-commit-status` 를 호출한다.
 - protected branch/tag 에 직접 push 하는 workflow 는 `minglit-release-bot` GitHub App token 을 사용한다. App credential 은 `minglit_env/{stage}/github.env` 파일에서 먼저 읽고, 공통 token mint 는 `.github/actions/release-bot-token` 에서 처리한다.
 - `version-bump` 는 source-controlled version file 변경용 reusable/legacy building block 이다. active dev-staging daily cut 은 `dev-staging-dev-cut` 안에서 `scripts/bump-version.sh` 를 직접 실행한다.
 - 앱 deploy version 은 `shared-version-metadata` 가 latest dev-staging snapshot build number 를 찾아 Android/iOS build command 에 주입한다.
@@ -76,4 +77,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — branch별 required check / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-25 12:00_
+_Reviewed: 2026-06-03 15:15_

--- a/.github/workflows/dev-pr-gate.yml
+++ b/.github/workflows/dev-pr-gate.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       stage: dev
       base_ref: dev
-      run_cuj_integration: true
+      run_cuj_integration: false
     secrets: inherit
 
   dev-pr-gate:

--- a/.github/workflows/dev-rc-cut-gate.yml
+++ b/.github/workflows/dev-rc-cut-gate.yml
@@ -14,9 +14,9 @@ on:
         description: Minimum candidate age in hours.
         required: false
         type: string
-        default: '24'
+        default: '0'
       dry_run:
-        description: Evaluate only; do not write dev soak/pass commit statuses.
+        description: Evaluate only; do not write dev health/pass commit statuses.
         required: false
         type: boolean
         default: false
@@ -33,22 +33,27 @@ permissions:
 
 jobs:
   evaluate-dev-soak:
-    name: evaluate-dev-soak
+    name: evaluate-dev-health
     uses: ./.github/workflows/shared-soak-gate.yml
     with:
       candidate_ref: dev
       candidate_sha: ${{ inputs.candidate_sha || '' }}
-      min_soak_hours: ${{ inputs.min_soak_hours || '24' }}
+      min_soak_hours: ${{ inputs.min_soak_hours || '0' }}
       required_runs_json: >-
         [
-          {"workflow":"deploy-dev-event-flow-cron.yml","branch":"dev","min_success":1,"run_limit":20,"match_head_sha":true}
+          {"workflow":"deploy-dev-event-flow-cron.yml","branch":"dev","min_success":1,"run_limit":20,"match_head_sha":true},
+          {"workflow":"monitor-dev-cuj.yml","branch":"dev","min_success":1,"run_limit":20,"match_head_sha":true}
         ]
       failure_contexts: |
         dev-soak/backend-simulator
+        dev-soak/cuj-user
+        dev-soak/cuj-partner
       success_contexts: |
         dev-soak/backend-simulator
+        dev-soak/cuj-user
+        dev-soak/cuj-partner
       pass_context: dev-rc-cut-pass
-      pass_description: 'dev-rc-cut-gate passed; this dev commit can be cut to RC'
+      pass_description: 'dev-rc-cut-gate passed; this dev commit has required dev health evidence'
       dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit
 

--- a/.github/workflows/main-pr-gate.yml
+++ b/.github/workflows/main-pr-gate.yml
@@ -31,7 +31,7 @@ jobs:
     with:
       stage: main
       base_ref: main
-      run_cuj_integration: true
+      run_cuj_integration: false
     secrets: inherit
 
   validate-rc-promotion:

--- a/.github/workflows/monitor-dev-cuj.yml
+++ b/.github/workflows/monitor-dev-cuj.yml
@@ -1,0 +1,167 @@
+name: monitor-dev-cuj
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Optional full dev commit SHA. Defaults to latest origin/dev.
+        required: false
+        type: string
+
+concurrency:
+  group: monitor-dev-cuj-${{ github.event_name == 'push' && github.sha || inputs.candidate_sha || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  statuses: write
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      candidate_sha: ${{ steps.plan.outputs.candidate_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve dev CUJ candidate
+        id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_SHA: ${{ github.sha }}
+          INPUT_CANDIDATE_SHA: ${{ inputs.candidate_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin dev --depth=200
+
+          CANDIDATE_SHA="${INPUT_CANDIDATE_SHA}"
+          if [ "${EVENT_NAME}" = "push" ]; then
+            CANDIDATE_SHA="${PUSH_SHA}"
+          fi
+          if [ -z "${CANDIDATE_SHA}" ]; then
+            CANDIDATE_SHA="$(git rev-parse FETCH_HEAD)"
+          fi
+          if ! [[ "${CANDIDATE_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::candidate_sha must be a full 40-character commit SHA."
+            exit 1
+          fi
+          if ! git cat-file -e "${CANDIDATE_SHA}^{commit}" 2>/dev/null; then
+            git fetch origin '+refs/heads/dev:refs/remotes/origin/dev' --depth=200
+          fi
+          if ! git cat-file -e "${CANDIDATE_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::candidate_sha is not reachable from fetched dev history: ${CANDIDATE_SHA}"
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${CANDIDATE_SHA}" FETCH_HEAD; then
+            echo "::error::candidate_sha must be reachable from origin/dev: ${CANDIDATE_SHA}"
+            exit 1
+          fi
+
+          echo "candidate_sha=${CANDIDATE_SHA}" >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "## monitor-dev-cuj"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| target_ref | dev |"
+            echo "| candidate_sha | ${CANDIDATE_SHA} |"
+            echo "| trigger | ${EVENT_NAME} |"
+            echo "| checks | user CUJ, partner CUJ |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  cuj-user:
+    needs: [plan]
+    uses: ./.github/workflows/shared-cuj-integration.yml
+    with:
+      app-name: user
+      target-ref: ${{ needs.plan.outputs.candidate_sha }}
+    secrets: inherit
+
+  cuj-partner:
+    needs: [plan]
+    uses: ./.github/workflows/shared-cuj-integration.yml
+    with:
+      app-name: partner
+      target-ref: ${{ needs.plan.outputs.candidate_sha }}
+    secrets: inherit
+
+  status-cuj-user:
+    needs: [plan, cuj-user]
+    if: always() && needs.plan.result == 'success'
+    permissions:
+      contents: read
+      statuses: write
+    uses: ./.github/workflows/set-dev-soak-status.yml
+    with:
+      signal: cuj-user
+      state: ${{ needs['cuj-user'].result == 'success' && 'success' || 'failure' }}
+      sha: ${{ needs.plan.outputs.candidate_sha }}
+      target_url: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+      description: ${{ needs['cuj-user'].result == 'success' && 'User CUJ health passed' || 'User CUJ health failed' }}
+    secrets: inherit
+
+  status-cuj-partner:
+    needs: [plan, cuj-partner]
+    if: always() && needs.plan.result == 'success'
+    permissions:
+      contents: read
+      statuses: write
+    uses: ./.github/workflows/set-dev-soak-status.yml
+    with:
+      signal: cuj-partner
+      state: ${{ needs['cuj-partner'].result == 'success' && 'success' || 'failure' }}
+      sha: ${{ needs.plan.outputs.candidate_sha }}
+      target_url: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+      description: ${{ needs['cuj-partner'].result == 'success' && 'Partner CUJ health passed' || 'Partner CUJ health failed' }}
+    secrets: inherit
+
+  notify-cuj-user-failure:
+    needs: [plan, cuj-user, status-cuj-user]
+    if: always()
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      statuses: write
+    uses: ./.github/workflows/shared-notify.yml
+    with:
+      failed: ${{ needs.plan.result != 'success' || needs['cuj-user'].result != 'success' || needs['status-cuj-user'].result != 'success' }}
+      workflow_name: Dev User CUJ Health Monitor
+      severity: P1-high
+      stage: dev-soak
+      signal: cuj-user
+      blocks_rc_cut: ${{ needs.plan.result == 'success' && needs['cuj-user'].result != 'success' }}
+      commit_sha: ${{ needs.plan.outputs.candidate_sha }}
+      target_url: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+      status_description: ${{ needs['cuj-user'].result == 'success' && 'User CUJ status write failed' || 'User CUJ health failed' }}
+      job_results: '{"plan":"${{ needs.plan.result }}","cuj-user":"${{ needs[''cuj-user''].result }}","status-cuj-user":"${{ needs[''status-cuj-user''].result }}"}'
+    secrets: inherit
+
+  notify-cuj-partner-failure:
+    needs: [plan, cuj-partner, status-cuj-partner]
+    if: always()
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      statuses: write
+    uses: ./.github/workflows/shared-notify.yml
+    with:
+      failed: ${{ needs.plan.result != 'success' || needs['cuj-partner'].result != 'success' || needs['status-cuj-partner'].result != 'success' }}
+      workflow_name: Dev Partner CUJ Health Monitor
+      severity: P1-high
+      stage: dev-soak
+      signal: cuj-partner
+      blocks_rc_cut: ${{ needs.plan.result == 'success' && needs['cuj-partner'].result != 'success' }}
+      commit_sha: ${{ needs.plan.outputs.candidate_sha }}
+      target_url: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+      status_description: ${{ needs['cuj-partner'].result == 'success' && 'Partner CUJ status write failed' || 'Partner CUJ health failed' }}
+      job_results: '{"plan":"${{ needs.plan.result }}","cuj-partner":"${{ needs[''cuj-partner''].result }}","status-cuj-partner":"${{ needs[''status-cuj-partner''].result }}"}'
+    secrets: inherit

--- a/.github/workflows/monitor-dev-staging-health.yml
+++ b/.github/workflows/monitor-dev-staging-health.yml
@@ -41,7 +41,7 @@ jobs:
             echo "| target_ref | dev-staging |"
             echo "| candidate_sha | ${CANDIDATE_SHA} |"
             echo "| cadence | every 6 hours |"
-            echo "| checks | EF unit, EF integration, user CUJ, partner CUJ |"
+            echo "| checks | EF unit, EF integration |"
           } >> "$GITHUB_STEP_SUMMARY"
 
   ef-unit:
@@ -153,22 +153,6 @@ jobs:
         if: always()
         run: supabase stop --no-backup || true
 
-  cuj-user:
-    needs: [plan]
-    uses: ./.github/workflows/shared-cuj-integration.yml
-    with:
-      app-name: user
-      target-ref: ${{ needs.plan.outputs.candidate_sha }}
-    secrets: inherit
-
-  cuj-partner:
-    needs: [plan]
-    uses: ./.github/workflows/shared-cuj-integration.yml
-    with:
-      app-name: partner
-      target-ref: ${{ needs.plan.outputs.candidate_sha }}
-    secrets: inherit
-
   status-ef-unit:
     needs: [plan, ef-unit]
     if: always() && needs.plan.result == 'success'
@@ -197,36 +181,8 @@ jobs:
       description: ${{ needs['ef-integration'].result == 'success' && 'EF integration health passed' || 'EF integration health failed' }}
     secrets: inherit
 
-  status-cuj-user:
-    needs: [plan, cuj-user]
-    if: always() && needs.plan.result == 'success'
-    permissions:
-      contents: read
-      statuses: write
-    uses: ./.github/workflows/shared-set-commit-status.yml
-    with:
-      sha: ${{ needs.plan.outputs.candidate_sha }}
-      context: dev-staging-health/cuj-user
-      state: ${{ needs['cuj-user'].result == 'success' && 'success' || 'failure' }}
-      description: ${{ needs['cuj-user'].result == 'success' && 'User CUJ health passed' || 'User CUJ health failed' }}
-    secrets: inherit
-
-  status-cuj-partner:
-    needs: [plan, cuj-partner]
-    if: always() && needs.plan.result == 'success'
-    permissions:
-      contents: read
-      statuses: write
-    uses: ./.github/workflows/shared-set-commit-status.yml
-    with:
-      sha: ${{ needs.plan.outputs.candidate_sha }}
-      context: dev-staging-health/cuj-partner
-      state: ${{ needs['cuj-partner'].result == 'success' && 'success' || 'failure' }}
-      description: ${{ needs['cuj-partner'].result == 'success' && 'Partner CUJ health passed' || 'Partner CUJ health failed' }}
-    secrets: inherit
-
   notify-failure:
-    needs: [plan, ef-unit, ef-integration, cuj-user, cuj-partner]
+    needs: [plan, ef-unit, ef-integration]
     if: always()
     permissions:
       actions: read
@@ -239,4 +195,4 @@ jobs:
       severity: P1-high
       commit_sha: ${{ needs.plan.outputs.candidate_sha }}
       target_url: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
-      job_results: '{"ef-unit":"${{ needs[''ef-unit''].result }}","ef-integration":"${{ needs[''ef-integration''].result }}","cuj-user":"${{ needs[''cuj-user''].result }}","cuj-partner":"${{ needs[''cuj-partner''].result }}"}'
+      job_results: '{"ef-unit":"${{ needs[''ef-unit''].result }}","ef-integration":"${{ needs[''ef-integration''].result }}"}'

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -14,10 +14,10 @@ on:
         type: string
         default: 'dev'
       run_cuj_integration:
-        description: 'Run emulator CUJ integration jobs when app/kit paths changed'
+        description: 'Debug-only CUJ switch. Regular CUJ health runs from monitor-dev-cuj on dev push.'
         required: false
         type: boolean
-        default: true
+        default: false
 
 concurrency:
   # Branch-specific wrappers own the user-facing required check name.
@@ -115,7 +115,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: python3 .github/scripts/check-android-deploy-workflow-contract.py
 
-      - name: Check dev soak workflow contract
+      - name: Check dev health workflow contract
         if: ${{ !cancelled() }}
         run: python3 .github/scripts/check-dev-soak-workflow-contract.py
 

--- a/.github/workflows/rc-pr-gate.yml
+++ b/.github/workflows/rc-pr-gate.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       stage: rc
       base_ref: ${{ github.base_ref }}
-      run_cuj_integration: true
+      run_cuj_integration: false
     secrets: inherit
 
   rc-pr-gate:

--- a/.github/workflows/set-dev-soak-status.yml
+++ b/.github/workflows/set-dev-soak-status.yml
@@ -6,7 +6,7 @@ on:
       signal:
         type: string
         required: true
-        description: 'Dev soak signal. Allowed: backend-simulator, real-device, app-ai-review.'
+        description: 'Dev health signal. Allowed: backend-simulator, cuj-user, cuj-partner, real-device, app-ai-review.'
       state:
         type: string
         required: true
@@ -39,11 +39,13 @@ on:
   workflow_dispatch:
     inputs:
       signal:
-        description: Dev soak signal.
+        description: Dev health signal.
         required: true
         type: choice
         options:
           - backend-simulator
+          - cuj-user
+          - cuj-partner
           - real-device
           - app-ai-review
       state:
@@ -92,10 +94,12 @@ jobs:
 
           case "${INPUT_SIGNAL}" in
             backend-simulator) CONTEXT="dev-soak/backend-simulator" ;;
+            cuj-user) CONTEXT="dev-soak/cuj-user" ;;
+            cuj-partner) CONTEXT="dev-soak/cuj-partner" ;;
             real-device) CONTEXT="dev-soak/real-device" ;;
             app-ai-review) CONTEXT="dev-soak/app-ai-review" ;;
             *)
-              echo "::error::signal must be one of: backend-simulator, real-device, app-ai-review."
+              echo "::error::signal must be one of: backend-simulator, cuj-user, cuj-partner, real-device, app-ai-review."
               exit 1
               ;;
           esac

--- a/.github/workflows/shared-notify.yml
+++ b/.github/workflows/shared-notify.yml
@@ -215,3 +215,6 @@ jobs:
           if [ -n "${INPUT_SIGNAL}" ]; then
             gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --add-label "${INPUT_SIGNAL}" || true
           fi
+          if [ "${INPUT_BLOCKS_RC_CUT}" = "true" ]; then
+            gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --add-label release-blocker || true
+          fi

--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -14,9 +14,11 @@ flowchart LR
   nc --> npg[dev-pr-gate]
   npg --> dev[dev]
 
-  dev -. 24h soak .-> rg[dev-rc-cut-gate]
+  dev --> dh[dev health / CUJ signals]
+  dh --> rg[dev-rc-cut-gate]
   monitor["monitor-event-flow-* batch"] -. dev-soak/backend-simulator .-> dev
-  ai["AI app soak / real-device"] -. dev-soak/app-ai-review .-> dev
+  cuj["monitor-dev-cuj"] -. dev-soak/cuj-* .-> dev
+  ai["AI app review / real-device"] -. dev-soak/app-ai-review .-> dev
   rg -->|pass| rgp["dev-rc-cut-pass status"]
   rg -->|blocked| issue[status failure + issue/audit]
   rgp --> rcut[dev-rc-cut]
@@ -44,10 +46,10 @@ flowchart LR
 | 단계 | Entry workflow | 역할 |
 |------|----------------|------|
 | dev-staging PR | `dev-staging-pr-gate` | feature/agent PR 의 빠른 CI gate |
-| dev-staging 지속 검증 | `monitor-dev-staging-health` | 6시간마다 EF unit/integration + user/partner CUJ 로 nightly 전 회귀 감지 |
+| dev-staging 지속 검증 | `monitor-dev-staging-health` | nightly 전 backend/EF 회귀 조기 감지 |
 | dev-staging → dev cut gate | `dev-staging-dev-cut-gate` | 수동 candidate inspect 전용. per-merge mutation 없음 |
 | dev-staging → dev cut | `dev-staging-dev-cut` + `dev-pr-gate` | daily cut 시점에 coherent snapshot 을 직접 bump/tag 하고 dev PR 로 promote |
-| dev → rc cut gate | `dev-rc-cut-gate` | 24h dev soak status + dev cron install run 확인 후 `dev-rc-cut-pass` status 부여 |
+| dev → rc cut gate | `dev-rc-cut-gate` | dev health/CUJ status + dev cron install run 확인 후 `dev-rc-cut-pass` status 부여 |
 | dev deploy/validation | `dev-deploy` | dev 환경 deploy/validation orchestrator. 이벤트 플로우 시뮬레이터는 dev Supabase pg_cron 으로 별도 운영 |
 | dev → rc cut | `dev-rc-cut` | latest `dev-rc-cut-pass` commit 에서 `rc/YYYY-Wxx` 생성 |
 | rc hotfix | dev-staging fix PR + `rc-pr-gate` | dev-staging 에 먼저 반영된 fix commit 을 active RC 로 cherry-pick/promote |
@@ -61,7 +63,7 @@ flowchart LR
 | 단계 | 역할 | 진입 방식 |
 |------|------|-----------|
 | `dev-staging` | AI agent commit zone | 일반 PR + auto-merge + 가벼운 `pr-gate` |
-| `dev` | soak-validated trunk | daily `dev-staging-dev-cut` → 24h soak → `dev-rc-cut-gate` |
+| `dev` | integration-health trunk | daily `dev-staging-dev-cut` → dev push health/CUJ → `dev-rc-cut-gate` |
 | `rc/YYYY-Wxx` | mobile RC, 5일 soak | weekly cut from latest dev-rc-cut-pass |
 | `main` | mobile-stable snapshot | rc → main 머지 (soak 통과 시) |
 
@@ -77,12 +79,14 @@ flowchart LR
 
 | 문서 | 내용 |
 |------|------|
+| [promotion-contract.md](./promotion-contract.md) | 승격 정책 + concrete workflow/status/tag/failure contract |
 | [branch-flow.md](./branch-flow.md) | flow + protection + tag + hotfix |
 | [test-strategy.md](./test-strategy.md) | per-stage gates |
 | [error-detection.md](./error-detection.md) | detection layers |
 | [dev-staging-pipeline.md](./dev-staging-pipeline.md) | 일반 PR/auto-merge + pr-gate + safety net CI |
 | [dev-pipeline.md](./dev-pipeline.md) | dev-staging-dev-cut + dev-rc-cut-gate + auto-deploy chain |
-| [dev-soak-status-model.md](./dev-soak-status-model.md) | dev soak commit status contexts + run history based `dev-rc-cut-gate` 판정 |
+| [dev-soak-status-model.md](./dev-soak-status-model.md) | legacy `dev-soak/*` status contexts + run history based `dev-rc-cut-gate` 판정 |
+| [rc-eligibility.md](./rc-eligibility.md) | `dev-rc-cut-pass` RC eligibility marker 호환 계약 |
 | [rc-promotion.md](./rc-promotion.md) | dev-rc-cut + soak + dev-staging-first hotfix |
 | [main-promotion.md](./main-promotion.md) | rc → main + main-deploy + min-version |
 | [hotfix-policy.md](./hotfix-policy.md) | dev/rc/main 직접 PR 차단 + branch별 hotfix 승인 규칙 |
@@ -99,7 +103,7 @@ flowchart LR
 - 코드 promotion = 한 방향 PR, 기능 promotion = flag flip
 - `*-cut-gate` = 다음 브랜치로 promote 할 source artifact 선별/마킹, `*-cut` = 그 artifact 로 PR/branch 생성. 검증과 promotion 을 같은 workflow 에 섞지 않는다
 - dev/rc release 판정은 **true evidence 기반**이다. failure issue/status 가 없다는 것은 `unknown` 이며 pass 가 아니다. cut-gate 는 명시적인 success status, required workflow run history, git lineage 같은 positive evidence 만 소비한다
-- dev soak 판정의 source-of-truth 는 GitHub Issue/label 이 아니라 commit status context + workflow run history 다 ([dev-soak-status-model.md](./dev-soak-status-model.md))
+- RC eligibility 판정의 source-of-truth 는 GitHub Issue/label 이 아니라 commit status context + workflow run history 다 ([promotion-contract.md](./promotion-contract.md), [dev-soak-status-model.md](./dev-soak-status-model.md))
 - cut-gate Issue 는 사람이 진행 상태를 추적하기 위한 projection 이다. 생성/갱신/닫기는 `.github/actions/cut-issue` 와 `close-cut-issue-on-pr-merge` 가 담당하며, promotion 판정 SSOT 로 사용하지 않는다
 - 일반 작업 PR 은 dev-staging 에서 squash 로 정리한다. Branch promotion PR 은 source branch ancestry 보존을 위해 merge commit 을 사용하며, dev/rc/main 에 linear history 를 강제하지 않는다
 - Protected branch 직접 push 는 human 금지. dev-staging daily cut version bump, promotion branch/tag, RC cleanup 은 `minglit-release-bot` 전용 token + Ruleset bypass 로만 허용
@@ -125,7 +129,7 @@ Promotion PR 제목은 workflow 이름과 source artifact 를 앞에 둔다. PR 
 
 ### RC Eligibility Marker
 
-RC cut 의 source-of-truth status 이름은 **`dev-rc-cut-pass`** 이다. `rc-eligible` 은 현재 구현된 workflow/status 명칭이 아니며, 새 이름으로 바꾸려면 `dev-rc-cut-gate`, `dev-rc-cut`, `main-pr-gate`, 문서 전체를 같은 PR 에서 일괄 변경한다.
+RC cut 의 source-of-truth status 이름은 **`dev-rc-cut-pass`** 이다. `rc-eligible` 은 workflow/status 명칭으로 쓰지 않으며, 새 이름으로 바꾸려면 `dev-rc-cut-gate`, `dev-rc-cut`, `main-pr-gate`, 문서 전체를 같은 PR 에서 일괄 변경한다.
 
 ---
-_Reviewed: 2026-05-25 16:20_
+_Reviewed: 2026-06-03 15:15_

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -1,6 +1,6 @@
 # Branch Flow
 
-`dev-staging → dev → rc → main` 4-stage 모델의 머지 방향, branch protection, promotion tag, deploy/validation chain.
+`dev-staging → dev → rc → main` 4-stage 모델의 머지 방향, branch protection, promotion tag, deploy/validation chain. Concrete workflow/status/tag/failure contract 는 [promotion-contract.md](./promotion-contract.md) 를 기준으로 한다.
 
 ## 흐름 다이어그램
 
@@ -95,7 +95,12 @@ monitor-event-flow-*:
 monitor-dev-staging-health:
   schedule: every 6 hours
   branch: dev-staging
-  purpose: EF unit/integration + user/partner CUJ early regression signal
+  purpose: EF unit/integration early regression signal
+
+monitor-dev-cuj:
+  trigger: push to dev
+  branch: dev
+  purpose: user/partner CUJ health signal
 ```
 
 ### main push → prod deploy chain
@@ -131,6 +136,10 @@ Mobile APK/AAB/IPA archive 는 GitHub Release asset 이 canonical 이다. Action
 - 주간 dev-rc-cut 요일
 - Fastlane / store upload 설정
 - `RELEASE.md` 작성
+
+## 관련
+
+- [promotion-contract.md](./promotion-contract.md) — 승격 정책 + concrete marker/failure contract
 
 ---
 _Reviewed: 2026-05-24 10:24_

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -1,13 +1,14 @@
 # Dev Pipeline
 
-`dev` 브랜치가 trunk 역할: dev-staging 의 daily snapshot 을 받고, 24h soak 후 `dev-rc-cut-gate` 가 commit status 와 dev cron install signal 을 평가한다. RC 는 `dev-rc-cut-pass` status 를 보고 cut 한다. 이벤트 플로우 시뮬레이터는 dev Supabase pg_cron 으로 계속 돌며, backend prod deploy 는 main 머지 후 `main-deploy` 에서 수행한다.
+`dev` 브랜치가 integration-health trunk 역할: dev-staging 의 daily snapshot 을 받고, 새 dev commit 마다 health/CUJ signal 을 기록한다. `dev-rc-cut-gate` 는 commit status 와 dev cron install signal 을 평가해 `dev-rc-cut-pass` 를 쓰고, RC 는 그 status 를 보고 cut 한다. 이벤트 플로우 시뮬레이터는 dev Supabase pg_cron 으로 계속 돌며, backend prod deploy 는 main 머지 후 `main-deploy` 에서 수행한다.
 
-## 4가지 workflow
+## 주요 workflow
 
 1. **`dev-staging-dev-cut`** — daily cron, dev-staging tip 을 직접 bump/tag 한 뒤 그 snapshot 으로 PR 생성
 2. **`dev-pr-gate`** — snapshot PR 머지 전 검증 (defensive)
-3. **`dev-rc-cut-gate`** — cut 직전 evaluator. 24h soak + commit status + cron install run 확인 후 `dev-rc-cut-pass` set
-4. **`dev-deploy` / cron install** — dev 환경 deploy/smoke 가 필요할 때 수행. 이벤트 플로우 시뮬레이터는 dev pg_cron 으로 별도 운영
+3. **`monitor-dev-cuj`** — dev push 마다 user/partner CUJ 를 끝까지 실행하고 `dev-soak/cuj-*` status 기록
+4. **`dev-rc-cut-gate`** — cut 직전 evaluator. dev health status + cron install run 확인 후 `dev-rc-cut-pass` set
+5. **`dev-deploy` / cron install** — dev 환경 deploy/smoke 가 필요할 때 수행. 이벤트 플로우 시뮬레이터는 dev pg_cron 으로 별도 운영
 
 ## `dev-staging-dev-cut`
 
@@ -36,11 +37,11 @@
 
 (상세는 [dev-staging-pipeline.md](./dev-staging-pipeline.md))
 
-## `dev-rc-cut-gate` — Soak Evaluator
+## `dev-rc-cut-gate` — Health Evaluator
 
 cut 직전 schedule/manual 로 실행된다. 통과 = "이 dev HEAD commit 은 RC cut source 로 사용할 수 있음".
 
-> **정책 변경**: `dev-rc-cut-gate` 는 heavy test runner 가 아니라 evaluator 다. 테스트/모니터는 별도 workflow 또는 AI agent 가 돌고, 실패 즉시 commit status 를 남긴다. `dev-rc-cut-gate` 는 24h soak 가 실제로 돌았는지 확인한 뒤 성공 status 를 확정한다.
+> **정책 변경**: `dev-rc-cut-gate` 는 heavy test runner 가 아니라 evaluator 다. 테스트/모니터는 별도 workflow 또는 AI agent 가 돌고, 실패 즉시 commit status 를 남긴다. Dev 단계의 24h soak 는 폐기하고, RC 단계에서만 5일 soak 를 운영한다.
 
 ### Source of truth
 
@@ -51,20 +52,22 @@ GitHub Issue 는 source-of-truth 가 아니다. Gate 판정은 commit status con
 | Context | failure 작성자 | success 작성자 |
 |---------|---------------|----------------|
 | `dev-soak/backend-simulator` | `event-flow-simulator` reporter 또는 `deploy-dev-event-flow-cron` 실패 path | `dev-rc-cut-gate` |
+| `dev-soak/cuj-user` | `monitor-dev-cuj` | `monitor-dev-cuj` 또는 `dev-rc-cut-gate` |
+| `dev-soak/cuj-partner` | `monitor-dev-cuj` | `monitor-dev-cuj` 또는 `dev-rc-cut-gate` |
 | `dev-soak/real-device` | real-device/Test Lab workflow 또는 AI agent | `dev-rc-cut-gate` |
 | `dev-soak/app-ai-review` | AI agent | `dev-rc-cut-gate` |
 | `dev-rc-cut-pass` | 없음 | `dev-rc-cut-gate` |
 
-상세 status model 은 [dev-soak-status-model.md](./dev-soak-status-model.md) 를 따른다.
+`dev-soak/*` 는 legacy context prefix 다. 정책상 dev soak 는 없지만 existing consumer 호환을 위해 status prefix 를 유지한다. 상세 승격 계약은 [promotion-contract.md](./promotion-contract.md), status model 은 [dev-soak-status-model.md](./dev-soak-status-model.md) 를 따른다.
 
 ### 무엇을 확인하는가
 
-`dev-rc-cut-gate` 는 latest `origin/dev` HEAD 만 평가한다. dev 에 새 commit 이 들어오면 candidate 와 24h soak clock 은 reset 된다.
+`dev-rc-cut-gate` 는 latest `origin/dev` HEAD 만 평가한다. dev 에 새 commit 이 들어오면 candidate 는 새 HEAD 로 교체된다.
 
 | 검증 | 조건 |
 |------|------|
-| Soak duration | candidate age >= 24h |
 | Event-flow distributed simulator | candidate SHA 에서 `deploy-dev-event-flow-cron` success >= 1 + `dev-soak/backend-simulator` failure 없음 |
+| CUJ | candidate SHA 에서 `monitor-dev-cuj` success >= 1 + `dev-soak/cuj-user` / `dev-soak/cuj-partner` failure 없음 |
 | Legacy hourly/daily simulator | 수동 smoke 전용. RC cut gate 조건에서 제외 |
 | Real device | candidate 기준 required real-device signal success >= 1 (workflow TBD) |
 | App AI review | AI agent 가 candidate 기준 app-soak pass signal 제공 (입력 방식 TBD) |
@@ -75,7 +78,7 @@ GitHub Issue 는 source-of-truth 가 아니다. Gate 판정은 commit status con
 
 ```
 1. dev HEAD commit 에 GitHub commit status `dev-rc-cut-pass` set
-2. `dev-soak/backend-simulator`, `dev-soak/real-device`, `dev-soak/app-ai-review` 도 evaluator 가 success 로 확정
+2. required `dev-soak/*` status 도 evaluator 또는 writer 가 success 로 확정
 3. `dev-rc-cut` 이 `dev-rc-cut-pass` 를 source-of-truth 로 사용
 4. Mobile + backend prod 은 main 머지 후 `main-deploy` 에서 처리
 ```
@@ -117,7 +120,7 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 
 ### `monitor-event-flow-*`
 
-- 이벤트 플로우 시뮬레이터 batch. target 은 dev Supabase pg_cron `dev-event-flow-simulator` 5분 주기 small tick
+- 이벤트 플로우 시뮬레이터 batch. 대상은 dev Supabase pg_cron `dev-event-flow-simulator` 5분 주기 small tick
 - 시간은 고정 5분, 랜덤은 actor/user/partner/event sampling 에 적용한다
 - `seed.dev.sql` 은 계정/파트너 base 만 담당하고 party/event/ticket 은 EF 경유로 만든다
 - 유저 신청 대상은 DB prefix 필터가 아니라 `user-event-feed` 결과에서 선택한다

--- a/docs/infra/branch-strategy/dev-soak-status-model.md
+++ b/docs/infra/branch-strategy/dev-soak-status-model.md
@@ -1,13 +1,15 @@
-# Dev Soak Status Model
+# Dev Health Status Model
 
 `dev-rc-cut-gate` 는 테스트를 직접 실행하는 workflow 가 아니라, dev HEAD 가 RC cut source 로 충분히 안정적인지 판정하는 evaluator 다. 판정의 source-of-truth 는 GitHub Issue 가 아니라 **commit status context** 와 workflow run history 다. Issue 는 사람이 보는 incident/audit surface 로만 사용한다.
+
+파일명과 status prefix 의 `soak` 은 legacy compatibility 이름이다. 정책상 dev 단계의 24h soak 는 폐기하고, RC 단계에서만 5일 soak 를 운영한다. 전체 승격 계약은 [promotion-contract.md](./promotion-contract.md) 를 따른다.
 
 ## Source Of Truth
 
 | 데이터 | 역할 | SSOT 여부 |
 |--------|------|-----------|
-| Commit status | soak failure/pass marker. `dev-rc-cut-gate` 가 직접 판정에 사용 | yes |
-| Workflow run history | monitor 가 실제로 충분히 돌았는지 확인 | yes |
+| Commit status | dev health failure/pass marker. `dev-rc-cut-gate` 가 직접 판정에 사용 | yes |
+| Workflow run history | monitor 가 실제로 돌았는지 확인 | yes |
 | GitHub Issue | 로그, 담당, 원인, 후속 조치 기록 | no |
 | GitHub label | 사람이 보는 분류/필터 | no |
 
@@ -23,7 +25,7 @@ Release gate 는 "실패 기록이 없음" 을 pass 로 해석하지 않는다.
 | `failure` evidence 있음 | monitor/AI/workflow 가 blocker 를 발견 | fail/block |
 | evidence 없음 | 아직 검증되지 않았거나 run history 가 부족 | unknown, pass 금지 |
 
-따라서 `dev-rc-cut-pass` 는 `dev-rc-cut-gate` 가 candidate age, required run history, required signal success, failure context 부재를 모두 확인한 뒤에만 쓴다. GitHub Issue 가 열려 있지 않거나 label 이 없다는 사실은 판정에 사용하지 않는다.
+따라서 `dev-rc-cut-pass` 는 `dev-rc-cut-gate` 가 required run history, required signal success, failure context 부재를 모두 확인한 뒤에만 쓴다. GitHub Issue 가 열려 있지 않거나 label 이 없다는 사실은 판정에 사용하지 않는다.
 
 ## Status Write API
 
@@ -32,7 +34,7 @@ Workflow 와 AI agent 는 commit status context 를 직접 하드코딩하지 �
 | Workflow | 공개 범위 | 역할 |
 |----------|----------|------|
 | `shared-set-commit-status` | internal reusable | `sha`, `context`, `state`, `description`, `target_url` 를 받아 GitHub commit status 를 작성 |
-| `set-dev-soak-status` | public API (`workflow_call` + `workflow_dispatch`) | `signal` 을 `dev-soak/*` context 로 매핑한 뒤 `shared-set-commit-status` 호출 |
+| `set-dev-soak-status` | public API (`workflow_call` + `workflow_dispatch`) | `signal` 을 legacy `dev-soak/*` context 로 매핑한 뒤 `shared-set-commit-status` 호출 |
 | `set-rc-soak-status` | public API (`workflow_call` + `workflow_dispatch`) | `signal` 을 `rc-soak/*` context 로 매핑한 뒤 `shared-set-commit-status` 호출 |
 
 외부 consumer 는 `shared-set-commit-status` 를 직접 호출하지 않는다. 공통 writer 는 context 를 검증하지 않는 low-level primitive 이므로, 사람이 직접 쓰면 stage/signal naming 을 우회할 수 있다.
@@ -43,7 +45,7 @@ Workflow 와 AI agent 는 commit status context 를 직접 하드코딩하지 �
 
 | Input | 값 |
 |-------|----|
-| `signal` | `backend-simulator` \| `real-device` \| `app-ai-review` |
+| `signal` | `backend-simulator` \| `cuj-user` \| `cuj-partner` \| `real-device` \| `app-ai-review` |
 | `state` | `failure` \| `success` \| `pending` |
 | `sha` | status 를 붙일 commit SHA |
 | `target_url` | workflow run, artifact, screenshot, AI review 결과 URL |
@@ -54,6 +56,8 @@ Signal mapping:
 | Signal | Context |
 |--------|---------|
 | `backend-simulator` | `dev-soak/backend-simulator` |
+| `cuj-user` | `dev-soak/cuj-user` |
+| `cuj-partner` | `dev-soak/cuj-partner` |
 | `real-device` | `dev-soak/real-device` |
 | `app-ai-review` | `dev-soak/app-ai-review` |
 
@@ -85,12 +89,14 @@ RC soak 는 dev soak 와 signal set 이 달라질 수 있으므로 별도 entry 
 
 | Context | 작성자 | 실패 시점 | 성공 시점 | 의미 |
 |---------|--------|-----------|-----------|------|
-| `dev-soak/backend-simulator` | `event-flow-simulator` reporter / `dev-rc-cut-gate` | event-flow simulator 실패 즉시 `failure` | `dev-rc-cut-gate` 가 24h soak + cron install run 을 확인한 뒤 `success` | backend/event-flow soak signal |
+| `dev-soak/backend-simulator` | `event-flow-simulator` reporter / `dev-rc-cut-gate` | event-flow simulator 실패 즉시 `failure` | `dev-rc-cut-gate` 가 cron install run 을 확인한 뒤 `success` | backend/event-flow health signal |
+| `dev-soak/cuj-user` | `monitor-dev-cuj` / `set-dev-soak-status` | user CUJ 실패 즉시 `failure` | `monitor-dev-cuj` 성공 또는 `dev-rc-cut-gate` 확인 뒤 `success` | user app CUJ signal |
+| `dev-soak/cuj-partner` | `monitor-dev-cuj` / `set-dev-soak-status` | partner CUJ 실패 즉시 `failure` | `monitor-dev-cuj` 성공 또는 `dev-rc-cut-gate` 확인 뒤 `success` | partner app CUJ signal |
 | `dev-soak/real-device` | `set-dev-soak-status` via real-device workflow / `dev-rc-cut-gate` | Firebase Test Lab 또는 실디바이스 smoke 실패 즉시 `failure` | `dev-rc-cut-gate` 가 required run/signal 을 확인한 뒤 `success` | 실제 디바이스 안정성 signal |
-| `dev-soak/app-ai-review` | `set-dev-soak-status` via AI agent / `dev-rc-cut-gate` | AI/human 앱 소킹 중 blocker 발견 즉시 `failure` | `dev-rc-cut-gate` 가 AI review pass signal 을 확인한 뒤 `success` | screenshot/UX/manual-ish app soak signal |
-| `dev-rc-cut-pass` | `dev-rc-cut-gate` | 작성하지 않음 | 모든 dev soak 조건 통과 시 `success` | RC cut source marker |
+| `dev-soak/app-ai-review` | `set-dev-soak-status` via AI agent / `dev-rc-cut-gate` | AI/human 앱 review 중 blocker 발견 즉시 `failure` | `dev-rc-cut-gate` 가 AI review pass signal 을 확인한 뒤 `success` | screenshot/UX/manual-ish app review signal |
+| `dev-rc-cut-pass` | `dev-rc-cut-gate` | 작성하지 않음 | 모든 required dev health 조건 통과 시 `success` | RC cut source marker |
 
-실패 status 는 발견 즉시 찍는다. 성공 status 는 각 monitor 가 매번 찍지 않고, cut 직전 evaluator 인 `dev-rc-cut-gate` 가 검증 완료 후 찍는다.
+실패 status 는 발견 즉시 찍는다. `monitor-dev-cuj` 는 dev commit 의 CUJ 성공/실패 status 를 직접 쓴다. `dev-rc-cut-gate` 는 required run history 와 failure context 부재를 확인한 뒤 필요한 `dev-soak/*` success confirmation 과 `dev-rc-cut-pass` 를 쓴다.
 
 ## Labels
 
@@ -99,22 +105,22 @@ Issue label 은 분류용이다. Gate 판정에는 사용하지 않는다.
 | Label | 용도 |
 |-------|------|
 | `release-blocker` | release 관련 blocker incident |
-| `dev-soak` | dev soak window 에서 발견 |
+| `dev-soak` | legacy dev health context 에서 발견 |
 | `backend-simulator` | event-flow/backend simulator 계열 |
+| `cuj-user`, `cuj-partner` | app CUJ 계열 |
 | `real-device` | Firebase Test Lab/실디바이스 계열 |
-| `app-soak` | AI/human 앱 소킹 계열 |
+| `app-soak` | legacy AI/human 앱 review 계열 |
 | `P0-critical`, `P1-high` | 우선순위 |
 
 금지: `candidate-sha-*`, `commit-*`, `run-*`, `pr-*` 같은 동적 label.
 
-## Soak Window
+## Candidate Window
 
 기본 정책은 **latest `origin/dev` HEAD 만 평가**한다.
 
 1. `candidate_sha = origin/dev HEAD`
 2. `candidate_since = candidate_sha` 가 dev 에 들어온 시각
-3. `now - candidate_since >= 24h`
-4. candidate 이후 dev 에 새 commit 이 들어오면 candidate 와 soak clock 은 reset
+3. candidate 이후 dev 에 새 commit 이 들어오면 candidate 는 새 HEAD 로 교체
 
 여러 candidate 를 동시에 추적하지 않는다. Snapshot model 이므로 최신 dev HEAD 만 RC source 후보가 된다.
 
@@ -125,6 +131,7 @@ Issue label 은 분류용이다. Gate 판정에는 사용하지 않는다.
 | Signal | 최소 조건 |
 |--------|-----------|
 | `deploy-dev-event-flow-cron` | candidate SHA 에서 `success` run >= 1 |
+| `monitor-dev-cuj` | candidate SHA 에서 user/partner CUJ success >= 1 |
 | legacy `monitor-event-flow-hourly/daily` | 수동 smoke 전용. gate run requirement 에서 제외 |
 | real-device smoke | candidate 기준 required run/signal success >= 1 (workflow 이름 TBD) |
 | app AI review | AI agent 가 candidate 기준 pass signal 제공 (workflow/status 입력 방식 TBD) |
@@ -158,7 +165,7 @@ gh run list \
 실패 시 동작:
 
 1. `set-dev-soak-status` 를 호출해 status context `dev-soak/{signal}` 을 `failure` 로 설정
-2. Issue 생성/갱신 (`release-blocker`, `dev-soak`, signal label, severity label)
+2. Issue 생성/갱신 (`ci-failure`, `release-blocker`, `dev-soak`, signal label, severity label)
 3. Issue body 에 workflow/run/commit/PR 정보와 failed log tail 을 첨부
 
 Issue body 에는 machine-readable metadata 를 남긴다. 단, gate 판정은 이 metadata 를 SSOT 로 사용하지 않는다.
@@ -178,19 +185,19 @@ blocks_rc_cut: true
 
 ## `dev-rc-cut-gate` Evaluation
 
-`dev-rc-cut-gate` 는 schedule 또는 manual dispatch 로 동작한다. `push to dev` 직후 즉시 pass 를 찍지 않는다.
+`dev-rc-cut-gate` 는 schedule 또는 manual dispatch 로 동작한다. `push to dev` 직후 monitor evidence 없이 즉시 pass 를 찍지 않는다.
 
 평가 순서:
 
 1. `candidate_sha = origin/dev HEAD`
-2. candidate age 가 24h 이상인지 확인
-3. required workflow run history 로 candidate SHA 에 dev cron 이 설치됐는지 확인
-4. candidate 의 required signal success evidence 가 존재하는지 확인
-5. candidate 의 최신 commit status 중 아래 context 가 `failure` 인지 확인:
+2. required workflow run history 로 candidate SHA 에 dev cron/CUJ monitor 가 성공했는지 확인
+3. candidate 의 최신 commit status 중 아래 context 가 `failure` 인지 확인:
    - `dev-soak/backend-simulator`
+   - `dev-soak/cuj-user`
+   - `dev-soak/cuj-partner`
    - `dev-soak/real-device`
    - `dev-soak/app-ai-review`
-6. 모두 통과하면 각 `dev-soak/*` status 를 `success` 로 찍고 `dev-rc-cut-pass` 를 `success` 로 찍는다
+4. 모두 통과하면 각 required `dev-soak/*` status 를 `success` 로 찍고 `dev-rc-cut-pass` 를 `success` 로 찍는다
 
 실패 또는 미충족 시 `dev-rc-cut-pass` 는 쓰지 않는다.
 

--- a/docs/infra/branch-strategy/error-detection.md
+++ b/docs/infra/branch-strategy/error-detection.md
@@ -9,8 +9,8 @@
 | 개발자 로컬 | LSP, analyze, unit | 컴파일/타입/단위 | 초~분 |
 | dev-staging PR gate | `dev-staging-pr-gate` (unit, lint, pgTAP, EF, migration, `expand-migrate-contract`, `flag-registration`, gitleaks) | PR 회귀, 보안, migration 충돌, flag 미등록, contract 위반 | < 10분 |
 | dev-staging-dev-cut PR | `dev-pr-gate` (defensive) | 환경 차이 회귀 | < 10분 |
-| dev soak | `monitor-event-flow-*`, real-device workflow, AI app soak status writer via `set-dev-soak-status` | backend simulator, 외부 의존, 디바이스, UX/blocker | 즉시~24h |
-| RC cut 직전 | `dev-rc-cut-gate` evaluator | 24h soak 미충족, `dev-soak/*` failure status, monitor 미실행 | 분 |
+| dev health | `deploy-dev-event-flow-cron`, `monitor-dev-cuj`, real-device workflow, AI app review status writer via `set-dev-soak-status` | backend simulator, CUJ, 외부 의존, 디바이스, UX/blocker | 즉시~분 |
+| RC cut 직전 | `dev-rc-cut-gate` evaluator | required dev health evidence 미충족, `dev-soak/*` failure status, monitor 미실행 | 분 |
 | Backend/Web deploy validation | post-deploy smoke, Sentry release marker | deploy infra 회귀 | 분 |
 | rc soak (5일) | rc 의 nightly 재실행 + 내부 dogfooding | 누적 회귀, real-data 이슈 | 일 단위 |
 | main 머지 후 (auto-deploy) | smoke + Sentry/Crashlytics 알람 임계 | prod 회귀 | 분 |
@@ -48,7 +48,7 @@
 ### GitHub Actions
 - pr-gate / monitor / promotion workflow 의 자동 이슈 생성
 - `shared-notify` 는 release blocker incident 를 issue 로 남기고, gate 판정용 commit status 를 기록
-- **workflow infra 실패 → P0**, test/soak 실패 → P1-high
+- **workflow infra 실패 → P0**, test/health/soak 실패 → P1-high
 
 ## Detection → Action 책임
 
@@ -59,7 +59,7 @@
 | `dev-rc-cut-gate` evaluator 미충족 | release manager / AI agent | GitHub Actions run summary | RC cut 보류. failure status 또는 monitor run history 부족 원인 확인 |
 | Backend/web deploy validation 실패 | on-call | Slack `#release` | retry → P0 이슈, 해당 promotion/deploy 진행 차단 |
 | Backend/web/mobile prod deploy 실패 (main 머지) | on-call | Slack `#release` | retry → rollback ([main-promotion.md](./main-promotion.md) error-backoff) |
-| rc soak 중 회귀 | RC owner | Slack `#release` | hotfix PR → rc | 
+| rc soak 중 회귀 | RC owner | Slack `#release` | hotfix PR → rc |
 | deploy-android-*, deploy-ios-* 실패 | mobile 팀 | GitHub issue + Slack | retry + auto-issue ([main-promotion.md](./main-promotion.md) error-backoff) |
 | Sentry alert (error spike) | 영역 owner | Sentry → Slack | 영역 별 on-call 판단 |
 | Crashlytics velocity alert | mobile 팀 | Firebase → Slack | flag flip OFF 우선 |

--- a/docs/infra/branch-strategy/hotfix-policy.md
+++ b/docs/infra/branch-strategy/hotfix-policy.md
@@ -6,7 +6,7 @@
 
 | 대상 base | hotfix branch | 용도 |
 |-----------|---------------|------|
-| `dev` | `dev/hotfix/<slug>` | dev soak 를 막는 긴급 수정. 수정 후 다음 `dev-rc-cut-gate` 가 다시 검증 |
+| `dev` | `dev/hotfix/<slug>` | dev health / RC eligibility 를 막는 긴급 수정. 수정 후 다음 `dev-rc-cut-gate` 가 다시 검증 |
 | `rc/YYYY-Wxx` | `rc/hotfix/<slug>` | active RC 검증 중 발견된 release blocker 수정. 기본은 dev-staging fix commit 을 cherry-pick 한 PR |
 | `main` | `main/hotfix/<slug>` | prod incident 또는 store release 직전 치명 이슈 수정 |
 

--- a/docs/infra/branch-strategy/life-of-flag.md
+++ b/docs/infra/branch-strategy/life-of-flag.md
@@ -88,7 +88,7 @@ Feature flag (Statsig + Firebase Remote Config) 의 생성·soak·rollout·**자
 | 5. 전체 soak | prod 전체 | 1주 | 무이슈 |
 | 6. cleanup | - | 30일 후 자동 | codemod PR 자동 생성 |
 
-**왜 dev soak 가 짧고 prod allowlist 가 긴가**: Slack May 2020 outage 처럼 *prod load 와 실 데이터* 에서만 잡히는 버그 다수. dev soak 길이는 효과 약함 (literature).
+**왜 dev health 검증보다 prod allowlist 가 긴가**: Slack May 2020 outage 처럼 *prod load 와 실 데이터* 에서만 잡히는 버그 다수. dev health window 를 길게 잡는 것보다 prod allowlist/canary 가 더 효과적이다.
 
 ## 메트릭 게이트
 

--- a/docs/infra/branch-strategy/promotion-contract.md
+++ b/docs/infra/branch-strategy/promotion-contract.md
@@ -1,0 +1,108 @@
+# Promotion Contract
+
+`dev-staging -> dev -> rc -> main` 승격의 source-of-truth 계약. 이 문서는 정책 의도와 concrete workflow/status/tag contract 를 함께 둔다. stage별 상세 운영 설명은 `dev-pipeline.md`, `rc-promotion.md`, `main-promotion.md` 를 따르되, 승격 판정 marker 나 실패 처리 계약이 충돌하면 이 문서를 먼저 고친다.
+
+## Policy
+
+| Stage | 역할 | 승격 원칙 |
+|-------|------|-----------|
+| `dev-staging` | 일반 작업 진입점 | feature/agent/human PR 은 여기로만 들어오고 squash merge 한다 |
+| `dev` | integration health | daily snapshot 을 받고, 새 dev commit 마다 health/CUJ 를 검증한다. Dev 자체 24h soak 는 하지 않는다 |
+| `rc/YYYY-Wxx` | release candidate soak | `dev-rc-cut-pass` 가 붙은 dev commit 에서 cut 하고, RC HEAD 기준 5일 soak 한다 |
+| `main` | production snapshot | `rc-main-cut-pass` 가 붙은 RC 를 main 으로 promote 하고, main push 후 prod deploy 한다 |
+
+승격 PR 은 source ancestry 보존을 위해 merge commit 을 사용한다. 일반 작업 PR 은 `dev-staging` 에서 squash merge 한다. `dev`, `rc/*`, `main` 직접 PR 은 promotion 또는 승인된 hotfix 만 허용한다.
+
+## Promotion Edges
+
+| Edge | Entry workflow | Source | Target | Merge / mutation |
+|------|----------------|--------|--------|------------------|
+| work -> dev-staging | `dev-staging-pr-gate` | feature/fix/chore/docs branch | `dev-staging` | PR squash merge |
+| dev-staging -> dev | `dev-staging-dev-cut` + `dev-pr-gate` | `v*-dev-staging` tag SHA | `dev` | promotion PR merge commit |
+| dev -> rc | `dev-rc-cut-gate` + `dev-rc-cut` | latest `dev-rc-cut-pass` dev commit | `rc/YYYY-Wxx` | branch cut + `promo/rc-*` tag |
+| rc hotfix | `rc-pr-gate` | dev-staging-first fix cherry-pick branch | active `rc/YYYY-Wxx` | PR merge, RC soak clock reset |
+| rc -> main | `rc-main-cut-gate` + `rc-main-cut` + `main-pr-gate` | `rc-main-cut-pass` RC HEAD | `main` | promotion PR merge commit |
+| main -> prod | `main-deploy` | main merge commit | prod backend/mobile/web | deploy only, no source version bump |
+
+## Concrete Markers
+
+| Marker | Type | Writer | Consumer | Meaning |
+|--------|------|--------|----------|---------|
+| `vYY.MM.DD+YYMMDDNN-dev-staging` | git tag | `dev-staging-dev-cut` | dev promotion, deploy metadata | coherent dev-staging snapshot |
+| `dev-staging-health/*` | commit status | `monitor-dev-staging-health` | human/AI triage only | early regression signal, not a promotion gate |
+| `dev-soak/backend-simulator` | commit status | `deploy-dev-event-flow-cron`, simulator reporter, `dev-rc-cut-gate` | `dev-rc-cut-gate` | legacy-named dev health signal |
+| `dev-soak/cuj-user` | commit status | `monitor-dev-cuj` / `set-dev-soak-status` | `dev-rc-cut-gate` | user app CUJ result for the dev commit |
+| `dev-soak/cuj-partner` | commit status | `monitor-dev-cuj` / `set-dev-soak-status` | `dev-rc-cut-gate` | partner app CUJ result for the dev commit |
+| `dev-soak/real-device` | commit status | real-device workflow / AI agent | `dev-rc-cut-gate` | device smoke signal |
+| `dev-soak/app-ai-review` | commit status | AI agent / human-assisted review | `dev-rc-cut-gate` | app UX/blocker review signal |
+| `dev-rc-cut-pass` | commit status | `dev-rc-cut-gate` | `dev-rc-cut`, `main-pr-gate` | RC cut source marker |
+| `promo/rc-YYYY-Wxx` | git tag | `dev-rc-cut` | release audit/deploy metadata | RC branch creation marker |
+| `rc-soak/*` | commit status | RC monitor/dogfooding workflows | `rc-main-cut-gate` | RC soak/pre-main signal |
+| `rc-main-cut-pass` | commit status + PR label | `rc-main-cut-gate` / `rc-main-cut` | `rc-main-cut`, `main-pr-gate` | main promotion marker |
+| `promo/main-YYYY-Wxx` | git tag | `main-deploy` / promotion workflow | release audit/deploy metadata | main promotion marker |
+
+`dev-soak/*` 는 이름만 legacy 다. 정책상 dev soak 는 폐기하지만, existing consumers (`dev-rc-cut-gate`, event-flow simulator reporter, docs/spec tests) 와 호환하려면 prefix 를 즉시 `dev-health/*` 로 바꾸지 않는다. 새 이름을 쓰려면 dual-write 또는 일괄 rename 을 별도 PR 로 처리한다.
+
+`rc-eligible` 이라는 workflow/tag/status 는 없다. `rc-gate-pass` 는 과거 status 잔재로 취급하고 새 승격 계약에서 소비하지 않는다. RC eligibility 의 canonical marker 는 `dev-rc-cut-pass` 다.
+
+## Gate Evidence
+
+Release gate 는 true evidence 기반이다. 실패 이슈가 없다는 사실은 pass 가 아니다.
+
+| Gate | Required success evidence | Blocking evidence |
+|------|---------------------------|-------------------|
+| `dev-pr-gate` | reusable `pr-gate` success + source guard success | source guard failure, PR gate failure |
+| `dev-rc-cut-gate` | same-SHA `deploy-dev-event-flow-cron` success, same-SHA `monitor-dev-cuj` success, no required `dev-soak/*` failure status | any required `dev-soak/*=failure`, missing required success evidence, infra failure |
+| `rc-pr-gate` | reusable `pr-gate` success + source guard success | RC-only unapproved source, PR gate failure |
+| `rc-main-cut-gate` | RC age >= 5 days since last RC commit, required `rc-soak/*` success, pre-main validation success, dev-staging-first hotfix lineage | `rc-soak/*=failure`, hotfix lineage violation, missing evidence, age not met |
+| `main-pr-gate` | reusable `pr-gate` success, RC lineage contains `dev-rc-cut-pass=success`, RC HEAD has `rc-main-cut-pass=success` and PR label | missing lineage marker, missing RC marker, PR gate failure |
+
+## Failure Contract
+
+| Failure | Immediate action | Follow-up workflow | Promotion effect |
+|---------|------------------|--------------------|------------------|
+| `dev-staging-pr-gate` fails | PR stays unmerged | author/AI fixes same PR | no dev-staging merge |
+| `monitor-dev-staging-health` fails | set `dev-staging-health/*=failure`, create/update issue | AI fix PR to `dev-staging` | does not directly block promotion |
+| `dev-pr-gate` fails on promotion PR | promotion PR stays open/failed | fix in `dev-staging`, rerun or regenerate cut | dev does not advance |
+| `monitor-dev-cuj` user/partner fails on dev push | set `dev-soak/cuj-* = failure`, create/update issue with failed files | AI fix PR to `dev-staging`, next `dev-staging-dev-cut` creates new dev commit | `dev-rc-cut-gate` must not write `dev-rc-cut-pass` |
+| `deploy-dev-event-flow-cron` or simulator fails | set `dev-soak/backend-simulator=failure`, create/update issue | AI fix PR to `dev-staging` | `dev-rc-cut-gate` blocks RC eligibility |
+| `dev-rc-cut-gate` missing evidence | no pass marker; cut issue stays waiting | required monitor/status writer reruns or fix PR lands | `dev-rc-cut` skips this commit |
+| `dev-rc-cut` cannot find pass commit | skip and alert if prolonged | run/fix `dev-rc-cut-gate` evidence | no RC branch cut |
+| `rc-pr-gate` fails | hotfix PR stays unmerged | fix cherry-pick branch or source dev-staging PR | RC HEAD unchanged |
+| `rc-deploy` fails | create/update P0/P1 issue | fix via dev-staging-first hotfix, then RC cherry-pick | `rc-main-cut-gate` cannot pass |
+| `rc-soak/*` fails or dogfooding blocker appears | set `rc-soak/*=failure`, create/update issue | dev-staging fix PR -> RC cherry-pick PR -> `rc-deploy` | RC 5-day clock resets after hotfix merge |
+| `rc-main-cut-gate` missing evidence/age | no `rc-main-cut-pass` | wait, rerun monitor, or fix RC | `rc-main-cut` skips |
+| `main-pr-gate` fails | main promotion PR stays failed or is closed for hard policy violation | fix RC or regenerate promotion | main does not advance |
+| `main-deploy` fails | create P0/P1 deploy issue | deploy retry or hotfix via normal flow | source already on main; prod recovery is incident process |
+
+No automatic revert is part of the normal contract. Broken `dev` keeps moving through the normal dev-staging fix path. Broken RC is fixed by dev-staging-first hotfix and RC cherry-pick. Catastrophic RC can be abandoned by release manager.
+
+## CUJ Contract
+
+CUJ is not a PR gate. Every new `dev` commit must run user and partner CUJ unconditionally. The CUJ runner must execute every CUJ file and aggregate failures before returning non-zero, so one failed CUJ does not hide later failures.
+
+Workflow:
+
+| Workflow | Trigger | Writes |
+|----------|---------|--------|
+| `monitor-dev-cuj` | `push` to `dev`, manual dispatch | `dev-soak/cuj-user`, `dev-soak/cuj-partner`, CI issue with failed CUJ file list |
+
+## Query Examples
+
+```bash
+git tag -l 'v*-dev-staging'
+git tag -l 'promo/rc-*'
+git tag -l 'promo/main-*'
+```
+
+```bash
+gh api repos/<owner>/<repo>/commits/<sha>/status \
+  --jq '.statuses[] | select(.context == "dev-rc-cut-pass" or (.context | startswith("dev-soak/")))'
+```
+
+```bash
+gh workflow list --all --limit 200 | grep -E 'dev-rc-cut|rc-main-cut|monitor-dev-cuj'
+```
+
+---
+_Reviewed: 2026-06-03 15:15_

--- a/docs/infra/branch-strategy/rc-eligibility.md
+++ b/docs/infra/branch-strategy/rc-eligibility.md
@@ -1,0 +1,65 @@
+# RC Eligibility
+
+RC eligibility 는 `dev` commit 이 `rc/YYYY-Wxx` branch source 로 사용 가능한지 나타내는 release gate 계약이다. 전체 승격 계약은 [promotion-contract.md](./promotion-contract.md) 를 따르고, 이 문서는 RC source marker 호환성만 좁게 다룬다. Canonical marker 는 **`dev-rc-cut-pass` commit status** 이며, `rc-eligible` 은 workflow 이름이나 status context 로 쓰지 않는다.
+
+## Contract
+
+| 역할 | 구현 | 계약 |
+|------|------|------|
+| Eligibility writer | `dev-rc-cut-gate` | latest `origin/dev` 또는 수동 `candidate_sha` 를 평가하고 통과 시 `dev-rc-cut-pass=success` 를 쓴다 |
+| RC cutter | `dev-rc-cut` | `origin/dev` first-parent 최신 200 commit 중 `dev-rc-cut-pass=success` 인 첫 commit 을 RC source 로 고른다 |
+| Main promotion validator | `main-pr-gate` | RC branch first-parent lineage 안에 `dev-rc-cut-pass=success` source commit 이 있는지 확인한다 |
+| Tracking issue | `.github/actions/cut-issue` via `dev-rc-cut-gate` | 사람이 보는 projection 이며 eligibility source-of-truth 가 아니다 |
+
+`dev-rc-cut-pass` 는 deploy marker 가 아니다. 이 status 는 "이 dev commit 을 RC branch 로 cut 해도 된다"는 source marker 만 의미한다. Prod deploy 는 `main` 머지 후 `main-deploy` 에서만 수행한다.
+
+## Status Compatibility
+
+`dev-rc-cut-gate` 는 `shared-soak-gate` 를 통해 아래 evidence 를 소비한다.
+
+| Evidence | Context / workflow |
+|----------|-------------------------|
+| Backend simulator failure/pass | `dev-soak/backend-simulator` |
+| Dev cron install run | `deploy-dev-event-flow-cron.yml` success on same `headSha` |
+| User CUJ | `monitor-dev-cuj.yml` success on same `headSha` + `dev-soak/cuj-user` not failure |
+| Partner CUJ | `monitor-dev-cuj.yml` success on same `headSha` + `dev-soak/cuj-partner` not failure |
+| Final eligibility marker | `dev-rc-cut-pass` |
+
+따라서 새 dev health writer 를 만들 때도 `dev-rc-cut-pass` 호환을 깨면 안 된다. `dev-health/*` 같은 새 context 를 도입하려면 다음 중 하나를 같은 PR 에서 처리해야 한다.
+
+1. `dev-rc-cut-gate`, `dev-rc-cut`, `main-pr-gate`, contract test, docs 를 모두 새 context 로 전환한다.
+2. 전환 기간 동안 `dev-soak/*` 와 새 context 를 dual-write 하고, gate 는 둘 중 canonical source 를 명확히 하나만 소비한다.
+3. 이름만 정책상 health 로 바꾸고 status context 는 legacy compatibility 때문에 `dev-soak/*` 를 유지한다.
+
+권장 경로는 3번이다. Dev 단계에서 "soak" 정책을 폐기하더라도, 기존 status context 는 RC eligibility 소비자와 event-flow simulator reporter 가 이미 의존하고 있으므로 한 번에 rename 하지 않는다.
+
+## `rc-eligible` Naming
+
+`rc-eligible` 이라는 이름을 새로 쓰려면 alias 가 아니라 **breaking rename** 으로 취급한다. 최소 변경 범위는 다음과 같다.
+
+- `dev-rc-cut-gate` 의 `pass_context`
+- `dev-rc-cut` 의 status query
+- `main-pr-gate` 의 RC lineage status query
+- `check-dev-soak-workflow-contract.py` 같은 workflow contract tests
+- branch strategy docs 전체의 marker naming
+- GitHub status 를 직접 쓰는 외부 automation / AI agent 문서
+
+부분 적용은 금지한다. `dev-rc-cut-pass` 와 `rc-eligible` 을 동시에 source-of-truth 로 쓰면 RC source 선택이 비결정적이 된다.
+
+## Operator Checks
+
+repo 에 등록된 Actions 에는 `rc-eligible` workflow 가 없어야 한다.
+
+```bash
+gh workflow list --all --limit 200 | grep -E 'rc-eligible|rc eligible'
+```
+
+dev 에서 RC source 후보를 확인할 때는 다음 status 를 조회한다.
+
+```bash
+gh api repos/<owner>/<repo>/commits/<sha>/status \
+  --jq '.statuses[] | select(.context == "dev-rc-cut-pass") | .state'
+```
+
+---
+_Reviewed: 2026-06-03 15:05_

--- a/docs/infra/branch-strategy/rc-promotion.md
+++ b/docs/infra/branch-strategy/rc-promotion.md
@@ -16,11 +16,11 @@
 
 - **cron**: 매주 X 요일 KST 10:00 (TBD)
 - **manual**: `workflow_dispatch` (긴급 cut)
-- **현재 구현**: 매주 월요일 KST 10:00. 수동 실행은 `source_sha`, `rc_week`, `allow_active_rc` 입력을 지원한다. `dev-rc-cut-pass` commit 이 아직 없으면 실패 알림 없이 skip 한다.
+- **운영 계약**: 수동 실행은 `source_sha`, `rc_week`, `allow_active_rc` 입력을 지원한다. `dev-rc-cut-pass` commit 이 없으면 RC branch 를 만들지 않는다.
 - 동작:
   1. **active RC marker 확인** → 있으면 skip + Slack `#release` 알림. 기본 정책은 active RC 1개만 허용
   2. 없으면 dev 의 최신 `dev-rc-cut-pass` status 부여된 commit 찾기 (GitHub API: `GET /repos/.../commits/{sha}/status`)
-  3. 못 찾으면 cut 보류 (현재 구현은 초기 no-pass 상태를 skip, 3일+ green 없음 alert 는 후속 PR). failure 가 없다는 이유만으로 cut 하지 않음
+  3. 못 찾으면 cut 보류. failure 가 없다는 이유만으로 cut 하지 않음
   4. 찾았으면 그 commit 에서 `rc/YYYY-Wxx` branch cut
   5. Supabase branch 생성/검증은 `rc-deploy` 에 위임 (후속 PR)
   6. `promo/rc-YYYY-Wxx` tag 생성

--- a/docs/infra/branch-strategy/specs/execution-plan.md
+++ b/docs/infra/branch-strategy/specs/execution-plan.md
@@ -24,8 +24,8 @@
 | `pr-gate-core` (reusable) | `pr-gate` 의 step 들을 reusable workflow_call 로 추출 + stage parameter 추가 | **refactor** |
 | `version-bump` (reusable) | legacy/building block for source-controlled version file changes. Active daily cut uses direct `scripts/bump-version.sh` inside `dev-staging-dev-cut` | **refactor** |
 | `shared-set-commit-status` | commit status write 공통 reusable | **신규** |
-| `set-dev-soak-status`, `set-rc-soak-status` | stage별 soak status write API (`workflow_call` + `workflow_dispatch`) | **신규** |
-| dev soak monitor/status model | 기존 `monitor-event-flow-*`, real-device workflow, AI agent signal 을 `dev-soak/*` commit status 로 통합 | **신규 (조합)** |
+| `set-dev-soak-status`, `set-rc-soak-status` | stage별 status write API (`workflow_call` + `workflow_dispatch`). `dev-soak/*` 는 dev health legacy prefix | **신규** |
+| dev health monitor/status model | 기존 `monitor-event-flow-*`, `monitor-dev-cuj`, real-device workflow, AI agent signal 을 `dev-soak/*` commit status 로 통합 | **신규 (조합)** |
 | `auto-issue` (reusable) | (없음) | **신규** |
 | `cherry-pick-pr` (reusable) | (없음) | **신규** |
 | `dev-staging-pr-gate` | `pr-gate` 를 dev-staging base 로 재사용 (stage=dev-staging) | **신규 (얇은 wrapper)** |
@@ -111,7 +111,7 @@
 |------|------|------|
 | 4a | `shared-set-commit-status`, `set-dev-soak-status`, `set-rc-soak-status` 구현 | Phase 2 |
 | 4b | `shared-notify` 가 실패 시 `set-dev-soak-status` 호출 + issue title/body/log tail 개선 | 4a |
-| 4c | `dev-rc-cut-gate` 를 24h soak evaluator 로 변경 (run history + `dev-soak/*` status 확인) | 4a, 4b |
+| 4c | `dev-rc-cut-gate` 를 dev health evaluator 로 변경 (run history + `dev-soak/*` status 확인) | 4a, 4b |
 | 4d | `main-pr-gate` 에 RC lineage / `rc-main-cut-pass` / contract 재검증 추가 | Phase 2 |
 | 4e | `cherry-pick-pr` reusable, `rc-hotfix-apply` | Phase 2 |
 
@@ -230,7 +230,7 @@ Phase 1 (skeletal) → Phase 2 (CI/PR flow) → Phase 3 (branch CD)
 - **4a / 4b 는 같은 PR 가능**: `shared-set-commit-status` 와 `shared-notify` 연동은 API contract 가 작아서 같이 검증 가능하다. 단 `set-dev-soak-status` 수동 dispatch dry-run 은 먼저 통과해야 한다
 - **status write API → evaluator 사이 verification 필요**: `set-dev-soak-status` 는 AI agent/monitor 가 직접 쓰는 public API 이므로 context mapping, 권한, target SHA 를 먼저 검증한다
 - **4e 는 4d 와 독립 가능**: rc-hotfix-apply 는 rc promotion 흐름의 일부지만 main protection 적용과 직접 의존하지 않는다
-- **가장 critical**: `dev-rc-cut-gate` evaluator — 첫 verification 기간 1주 이상 추천 (24h soak/run history/status context 판정이 release cut 을 직접 막음)
+- **가장 critical**: `dev-rc-cut-gate` evaluator — 첫 verification 기간 1주 이상 추천 (run history/status context 판정이 release cut 을 직접 막음)
 
 권장 변경 없음. 위 순서 그대로 진행.
 

--- a/docs/infra/branch-strategy/specs/release-bot.md
+++ b/docs/infra/branch-strategy/specs/release-bot.md
@@ -87,11 +87,11 @@ git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 | `dev-staging-dev-cut-gate` | manual candidate inspect (read-only) |
 | `dev-staging-dev-cut` | dev-staging version bump/tag, immutable nightly branch 생성, dev PR 생성 |
 | `shared-set-commit-status` | commit status 를 쓰는 low-level reusable |
-| `set-dev-soak-status` | dev soak signal 을 `dev-soak/*` context 로 매핑 |
+| `set-dev-soak-status` | dev health signal 을 legacy `dev-soak/*` context 로 매핑 |
 | `set-rc-soak-status` | rc soak signal 을 `rc-soak/*` context 로 매핑 |
 | `monitor-event-flow-*` / `shared-notify` | backend simulator 실패 시 `set-dev-soak-status` 로 failure status + issue 기록 |
-| AI app soak status writer | 앱 소킹/실디바이스 이상 발견 시 `set-dev-soak-status` 로 failure status 기록 |
-| `dev-rc-cut-gate` | 24h soak run history 확인 후 `set-dev-soak-status` 로 `dev-soak/*` success + `dev-rc-cut-pass` status 기록 |
+| AI app review status writer | 앱 review/실디바이스 이상 발견 시 `set-dev-soak-status` 로 failure status 기록 |
+| `dev-rc-cut-gate` | required dev health run history 확인 후 `set-dev-soak-status` 로 `dev-soak/*` success + `dev-rc-cut-pass` status 기록 |
 | `dev-rc-cut` | `rc/YYYY-Wxx` branch 생성, `promo/rc-*` tag |
 | `rc-main-cut` | rc → main promotion PR 생성/auto-merge |
 | `rc-hotfix-apply` | dev-staging fix commit 을 active RC 로 cherry-pick 하는 branch/PR 생성 |

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -73,15 +73,15 @@ GitHub commit status 를 쓰는 low-level reusable workflow. Stage/signal mappin
 
 ### `set-dev-soak-status`
 
-Dev soak status write API. `workflow_call` 과 `workflow_dispatch` 를 모두 지원한다.
+Dev health status write API. `workflow_call` 과 `workflow_dispatch` 를 모두 지원한다. `dev-soak/*` prefix 는 legacy compatibility context 다.
 
 | 항목 | 값 |
 |------|----|
 | Trigger | `workflow_call` + `workflow_dispatch` |
-| Inputs | `signal`: backend-simulator\|real-device\|app-ai-review, `state`, `sha`, `target_url`, `description` |
-| Mapping | `backend-simulator` → `dev-soak/backend-simulator`; `real-device` → `dev-soak/real-device`; `app-ai-review` → `dev-soak/app-ai-review` |
+| Inputs | `signal`: backend-simulator\|cuj-user\|cuj-partner\|real-device\|app-ai-review, `state`, `sha`, `target_url`, `description` |
+| Mapping | `backend-simulator` → `dev-soak/backend-simulator`; `cuj-user` → `dev-soak/cuj-user`; `cuj-partner` → `dev-soak/cuj-partner`; `real-device` → `dev-soak/real-device`; `app-ai-review` → `dev-soak/app-ai-review` |
 | Steps | validate signal/state → context mapping → calls `shared-set-commit-status` |
-| Called by | `monitor-event-flow-*`, real-device workflow, AI agent, `dev-rc-cut-gate` |
+| Called by | `monitor-event-flow-*`, `monitor-dev-cuj`, real-device workflow, AI agent, `dev-rc-cut-gate` |
 
 ### `set-rc-soak-status`
 
@@ -199,12 +199,12 @@ Cross-branch cherry-pick PR 자동 생성.
 | Trigger | `schedule` (cut 직전, TBD) + `workflow_dispatch` |
 | Inputs | optional `candidate_sha` (default: latest `origin/dev` HEAD) |
 | Outputs | commit status `dev-rc-cut-pass` (success only) + `dev-soak/*` success confirmations + cut issue `gate/dev-rc` |
-| Steps | calls `shared-soak-gate` with candidate=`origin/dev`, min_soak_hours=24, required runs=`deploy-dev-event-flow-cron>=1` on matching SHA, failure context=`dev-soak/backend-simulator`, success context=`dev-soak/backend-simulator`, pass context=`dev-rc-cut-pass`; then upserts cut issue as `status/waiting` or `status/ready` |
+| Steps | calls `shared-soak-gate` with candidate=`origin/dev`, min_soak_hours=0, required runs=`deploy-dev-event-flow-cron>=1` and `monitor-dev-cuj>=1` on matching SHA, failure contexts=`dev-soak/backend-simulator` + `dev-soak/cuj-*`, success contexts=required `dev-soak/*`, pass context=`dev-rc-cut-pass`; then upserts cut issue as `status/waiting` or `status/ready` |
 | Failure path | 조건 미충족 또는 required success evidence 누락이면 `dev-rc-cut-pass` 를 쓰지 않는다. 실패를 발견한 monitor/AI agent 가 이미 `dev-soak/*` failure 를 쓴다 |
 
 > **No auto-revert** — snapshot 모델: 실패 = no `dev-rc-cut-pass`, dev keeps moving, 새 fix 가 자연스럽게 다음 dev-staging-dev-cut 후 새 candidate 로 검증됨.
 > **Naming** — `dev-rc-cut-pass` 가 canonical RC eligibility marker 이다. `rc-eligible` 은 현재 workflow/status 명칭이 아니다.
-> **SSOT** — dev soak 판정은 [../dev-soak-status-model.md](../dev-soak-status-model.md) 의 commit status + run history 를 따른다. GitHub Issue 는 사람이 보는 incident/audit surface 다.
+> **SSOT** — dev health / RC eligibility 판정은 [../promotion-contract.md](../promotion-contract.md) 와 [../dev-soak-status-model.md](../dev-soak-status-model.md) 의 commit status + run history 를 따른다. GitHub Issue 는 사람이 보는 incident/audit surface 다.
 > **True evidence** — failure status/issue 가 없다는 것은 `unknown` 이다. pass marker 는 required success status 와 run history 가 모두 존재할 때만 쓴다.
 
 #### `dev-deploy`
@@ -224,6 +224,15 @@ Cross-branch cherry-pick PR 자동 생성.
 | Branch/env | dev 를 계속 관찰. RC cut 후에는 RC env/Supabase branch 도 pre-main 검증 signal 로 사용 |
 | Outputs | event-flow simulation signal, `set-dev-soak-status(signal=backend-simulator,state=failure)`, issue/alert |
 | Note | fixed-time small tick. actor/user/partner/event sampling 만 랜덤화하고, party/event 는 partner EF, 신청 대상은 `user-event-feed` 로 만든다 |
+
+#### `monitor-dev-cuj`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `push` to `dev` + `workflow_dispatch` |
+| Branch/env | latest dev commit. User/partner app CUJ 를 각각 실행 |
+| Outputs | `set-dev-soak-status(signal=cuj-user|cuj-partner,state=success|failure)`, issue/alert with failed CUJ files |
+| Note | CUJ runner 는 첫 실패에서 중단하지 않고 모든 CUJ file 을 실행한 뒤 실패 목록을 aggregate 한다 |
 
 ### rc
 
@@ -372,7 +381,7 @@ Promotion/deploy entry workflows support `workflow_dispatch` dry-run where mutat
 | Workflow | Dry-run behavior |
 |----------|------------------|
 | `dev-staging-dev-cut` | computes/reuses dev-staging snapshot tag, computes cut branch, skips version bump/tag/branch push/PR/auto-merge |
-| `dev-rc-cut-gate` | evaluates soak/run/status inputs, skips `dev-soak/*` and `dev-rc-cut-pass` status writes |
+| `dev-rc-cut-gate` | evaluates dev health run/status inputs, skips `dev-soak/*` and `dev-rc-cut-pass` status writes |
 | `dev-rc-cut` | selects source SHA/RC week, skips RC branch push/promo tag |
 | `rc-main-cut-gate` | selects RC branch and evaluates soak, skips `rc-main-cut-pass` status write |
 | `rc-main-cut` | selects RC branch, skips main PR/auto-merge |
@@ -397,8 +406,8 @@ Use dry-run before connecting new deploy backends or changing branch rulesets. D
 ## 관련
 
 - [../branch-flow.md](../branch-flow.md) — workflow 가 흘러가는 branch 그림
-- [../test-strategy.md](../test-strategy.md) — pr-gate-core 와 dev soak signal 배치
-- [../dev-soak-status-model.md](../dev-soak-status-model.md) — dev soak commit status / run history SSOT
+- [../test-strategy.md](../test-strategy.md) — pr-gate-core 와 dev health signal 배치
+- [../dev-soak-status-model.md](../dev-soak-status-model.md) — legacy `dev-soak/*` commit status / run history SSOT
 - [../error-detection.md](../error-detection.md) — auto-issue 의 priority 와 채널
 - [../life-of-flag.md](../life-of-flag.md) — flag lifecycle
 - [../versioning.md](../versioning.md) — source snapshot version + deploy metadata

--- a/docs/infra/branch-strategy/test-strategy.md
+++ b/docs/infra/branch-strategy/test-strategy.md
@@ -1,16 +1,16 @@
 # Test Strategy
 
-4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = branch별 `*-pr-gate`, 지속 소킹 = dev Supabase pg_cron event-flow/real-device/app AI review, RC 후보 판정 = `dev-rc-cut-gate`, 프로덕션 검증 = `deploy-android-*, deploy-ios-*` smoke + flag staged.
+4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = branch별 `*-pr-gate`, dev push health = event-flow/CUJ/real-device/app AI review, RC 후보 판정 = `dev-rc-cut-gate`, RC 5일 soak = `rc-main-cut-gate`, 프로덕션 검증 = `deploy-android-*, deploy-ios-*` smoke + flag staged.
 
 ## 단계별 게이트
 
 | 단계 | 게이트 | 소요 | 실패 시 |
 |------|--------|------|---------|
 | dev-staging 머지 전 | `dev-staging-pr-gate` (unit · lint · analyze · pgTAP · EF test · migration check · `expand-migrate-contract` · `flag-registration` · gitleaks) | < 10분 | auto-merge 보류 |
-| dev-staging 머지 후 지속 검증 | `monitor-dev-staging-health` (EF unit/integration + user/partner CUJ) | 6시간마다 | 실패 즉시 issue/notify + `dev-staging-health/*` status |
+| dev-staging 머지 후 지속 검증 | `monitor-dev-staging-health` (EF unit/integration 중심) | 6시간마다 | 실패 즉시 issue/notify + `dev-staging-health/*` status |
 | dev 머지 전 | `dev-pr-gate` (dev-staging-pr-gate 와 동일 — defensive) | < 10분 | dev-staging-dev-cut PR drop |
-| dev 머지 후 24h soak | `monitor-event-flow-*` + real-device/app AI review status writer | 24h | 실패 즉시 `dev-soak/*` failure status + release-blocker issue |
-| RC cut 직전 | `dev-rc-cut-gate` evaluator (24h run history + `dev-soak/*` status 확인) | 분 | `dev-rc-cut-pass` 미부여 |
+| dev 머지 후 health | `deploy-dev-event-flow-cron` + `monitor-dev-cuj` + real-device/app AI review status writer | push/monitor cadence | 실패 즉시 `dev-soak/*` failure status + release-blocker issue |
+| RC cut 직전 | `dev-rc-cut-gate` evaluator (dev run history + `dev-soak/*` status 확인) | 분 | `dev-rc-cut-pass` 미부여 |
 | rc 머지 전 (hotfix) | dev-staging-first fix cherry-pick PR + `rc-pr-gate` (pr-gate + mobile smoke) | < 15분 | hotfix PR drop |
 | main 머지 전 (rc → main) | `main-pr-gate` (pr-gate + `expand-migrate-contract` 재검증 + RC HEAD 의 `dev-rc-cut-pass` 확인 + `rc-main-cut-pass` marker 확인) | 분 | promotion PR 보류 |
 | rc → main PR | workflow auto-merge (모든 check 통과 시) | 분 | check 실패 시 PR hold + alert |
@@ -39,26 +39,25 @@
 
 ### monitor-dev-staging-health — 6시간 health monitor
 
-`dev-staging` HEAD 를 하루 4번 검증한다. PR required check 는 아니며, nightly/dev cut 전에 앱/백엔드 계약 회귀를 빨리 발견하기 위한 지속 monitor 다.
+`dev-staging` HEAD 를 하루 4번 검증한다. PR required check 는 아니며, nightly/dev cut 전에 백엔드 계약 회귀를 빨리 발견하기 위한 지속 monitor 다. CUJ 는 dev push health 로 실행한다.
 
 - `ef-unit`: Edge Function Deno unit test + EF auth/lint guard
 - `ef-integration`: local Supabase + migration-only DB 에서 EF CUJ integration test
-- `cuj-user`: app_user emulator CUJ
-- `cuj-partner`: app_partner emulator CUJ
-
-결과는 candidate SHA 에 `dev-staging-health/ef-unit`, `dev-staging-health/ef-integration`, `dev-staging-health/cuj-user`, `dev-staging-health/cuj-partner` commit status 로 남긴다. 초기에는 alert/issue 용 signal 로만 사용하고, 안정화 후 `dev-staging-dev-cut-gate` 가 failure status 를 보면 dev promotion 을 보류하도록 연결한다.
+결과는 candidate SHA 에 `dev-staging-health/ef-unit`, `dev-staging-health/ef-integration` 등 commit status 로 남긴다. 초기에는 alert/issue 용 signal 로만 사용하고, 안정화 후 `dev-staging-dev-cut-gate` 가 failure status 를 보면 dev promotion 을 보류하도록 연결한다.
 
 ### dev-pr-gate
 
 `dev-staging-pr-gate` 와 동일한 test suite. 환경 차이로 인한 회귀만 잡는 defensive 검증. 대부분 통과.
 
-### dev soak signals
+### dev health signals
 
-dev 에 들어간 latest HEAD 만 RC candidate 로 평가한다. 새 dev commit 이 들어오면 candidate 와 24h soak clock 은 reset 된다.
+dev 에 들어간 latest HEAD 만 RC candidate 로 평가한다. 새 dev commit 이 들어오면 candidate 는 새 HEAD 로 교체된다.
 
 | Signal | 실행자 | 실패 status | 성공 status |
 |--------|--------|-------------|-------------|
 | backend simulator | `deploy-dev-event-flow-cron` + pg_cron `dev-event-flow-simulator` | `dev-soak/backend-simulator` failure 즉시 | `dev-rc-cut-gate` 가 cron install + 1회 simulator tick run + failure status 확인 |
+| user CUJ | `monitor-dev-cuj` | `dev-soak/cuj-user` failure 즉시 | `monitor-dev-cuj` 또는 `dev-rc-cut-gate` 가 success 확인 |
+| partner CUJ | `monitor-dev-cuj` | `dev-soak/cuj-partner` failure 즉시 | `monitor-dev-cuj` 또는 `dev-rc-cut-gate` 가 success 확인 |
 | real device | Test Lab/실디바이스 workflow | `dev-soak/real-device` failure 즉시 | `dev-rc-cut-gate` 가 required signal 확인 후 success |
 | app AI review | AI agent | `dev-soak/app-ai-review` failure 즉시 | `dev-rc-cut-gate` 가 pass signal 확인 후 success |
 
@@ -66,9 +65,10 @@ dev 에 들어간 latest HEAD 만 RC candidate 로 평가한다. 새 dev commit 
 
 cut 직전 schedule/manual 로 실행한다. 통과 시 commit 에 GitHub status `dev-rc-cut-pass` 를 set 한다.
 
-- candidate age >= 24h
 - candidate SHA 에서 `deploy-dev-event-flow-cron` success >= 1
 - `dev-soak/backend-simulator` failure status 없음
+- candidate SHA 에서 `monitor-dev-cuj` success >= 1
+- `dev-soak/cuj-user`, `dev-soak/cuj-partner` failure status 없음
 - legacy hourly/daily 는 수동 smoke 로만 실행
 - candidate 의 최신 `dev-soak/*` status 가 failure 가 아님
 - real-device/app AI review required signal 충족
@@ -105,9 +105,10 @@ RC 의 hotfix 만 받음. 기본은 dev-staging 에 먼저 머지된 fix commit/
 | 테스트 성격 | 배치 위치 | 이유 |
 |-------------|-----------|------|
 | 결정론적, < 10분 | `dev-staging-pr-gate` | PR 사이클 안 막음 |
-| flaky 또는 느림 (10분+) | dev soak monitor / real-device workflow | PR 머지 게이트의 신뢰도 보호 |
-| 10분+ 이지만 nightly 전에 잡아야 하는 앱/EF 회귀 | `monitor-dev-staging-health` | dev-staging 머지는 빠르게 유지하고 최대 6시간 내 발견 |
-| 외부 의존성 (실 결제 등) | dev soak + flag canary | 비용·side effect 통제 |
+| flaky 또는 느림 (10분+) | dev health monitor / real-device workflow | PR 머지 게이트의 신뢰도 보호 |
+| CUJ | `monitor-dev-cuj` on dev push | PR gate 대신 새 dev version 마다 무조건 실행 |
+| 10분+ 이지만 nightly 전에 잡아야 하는 EF 회귀 | `monitor-dev-staging-health` | dev-staging 머지는 빠르게 유지하고 최대 6시간 내 발견 |
+| 외부 의존성 (실 결제 등) | dev health + flag canary | 비용·side effect 통제 |
 | 부하/성능 | scheduled monitor or staged rollout 메트릭 | 매일 무거움 |
 | backend ↔ mobile 계약 호환 | `expand-migrate-contract` CI + flag canary 메트릭 | 다층 안전망 |
 | 실 디바이스 다양성 | real-device workflow + `dev-soak/real-device` status | 시뮬레이터 한계 보완 |


### PR DESCRIPTION
## Summary
- Move CUJ from branch PR/dev-staging health gates into a new `monitor-dev-cuj` workflow on `dev` push
- Write `dev-soak/cuj-user` and `dev-soak/cuj-partner` statuses, create/update failure issues, and keep `dev-rc-cut-pass` compatibility
- Document the promotion contract and RC eligibility marker, and extend workflow contract tests

## Validation
- `bash -n .github/scripts/run-user-cuj.sh && bash -n .github/scripts/run-partner-cuj.sh`
- `python3 .github/scripts/check-dev-soak-workflow-contract.py`
- `python3 .github/scripts/check-dev-cut-workflow-contract.py`
- Workflow YAML parse via PyYAML
- `git diff --check`

No linked issue: release workflow policy/contract update.