### PR TITLE
ci: assign dev promotion cut issues to SWE

### DIFF
--- a/.github/actions/BLUEDOC.md
+++ b/.github/actions/BLUEDOC.md
@@ -6,7 +6,7 @@
 
 | Action | 내용 |
 |--------|------|
-| [cut-issue](./cut-issue/action.yml) | cut-gate tracking issue 생성/갱신/닫기 공통 action |
+| [cut-issue](./cut-issue/action.yml) | cut-gate tracking issue 생성/갱신/닫기 공통 action. `needs-swe` 같은 추가 label 적용 지원 |
 | [deploy-flutter-app](./deploy-flutter-app/action.yml) | Flutter app deploy 공통 action |
 | [deploy-nextjs-app](./deploy-nextjs-app/action.yml) | Next.js app deploy 공통 action |
 | [ios-deploy](./ios-deploy/action.yml) | iOS deploy 공통 action |
@@ -19,4 +19,4 @@
 - Protected branch/tag write 용 token 은 `release-bot-token` 을 통해 mint 한다.
 
 ---
-_Reviewed: 2026-05-25 11:40_
+_Reviewed: 2026-06-03 15:15_

--- a/.github/actions/cut-issue/action.yml
+++ b/.github/actions/cut-issue/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Additional markdown details.
     required: false
     default: ''
+  extra-labels:
+    description: Optional comma/newline separated labels to apply in addition to cut-gate labels.
+    required: false
+    default: ''
   close-comment:
     description: Comment used when closing an issue.
     required: false
@@ -57,6 +61,7 @@ runs:
         INPUT_STATUS: ${{ inputs.status }}
         INPUT_SUMMARY: ${{ inputs.summary }}
         INPUT_DETAILS: ${{ inputs.details }}
+        INPUT_EXTRA_LABELS: ${{ inputs.extra-labels }}
         INPUT_CLOSE_COMMENT: ${{ inputs.close-comment }}
       run: |
         set -euo pipefail
@@ -100,6 +105,21 @@ runs:
         create_label "status/ready" "0E8A16" "Cut gate is ready"
         create_label "status/promoting" "1D76DB" "Promotion is in progress"
         create_label "status/done" "C2E0C6" "Cut gate tracking is complete"
+        create_label "needs-swe" "BFDADC" "Needs SWE agent care"
+        create_label "exec-report" "D93F0B" "Agent cannot safely continue; operator action is required"
+
+        EXTRA_LABELS_FILE="$(mktemp)"
+        printf '%s\n' "${INPUT_EXTRA_LABELS}" \
+          | tr ',' '\n' \
+          | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+          | awk 'NF' \
+          | sort -u > "${EXTRA_LABELS_FILE}"
+        while IFS= read -r label; do
+          case "${label}" in
+            needs-swe|exec-report) ;;
+            *) create_label "${label}" "BFDADC" "Additional cut-gate label" ;;
+          esac
+        done < "${EXTRA_LABELS_FILE}"
 
         ISSUE_NUMBER="$(gh api \
           --method GET \
@@ -177,6 +197,11 @@ runs:
         gh issue edit "${ISSUE_NUMBER}" \
           --repo "${REPO}" \
           --add-label "cut-gate,${GATE_LABEL},${STATUS_LABEL}" >/dev/null
+        if [ -s "${EXTRA_LABELS_FILE}" ]; then
+          gh issue edit "${ISSUE_NUMBER}" \
+            --repo "${REPO}" \
+            --add-label "$(paste -sd, "${EXTRA_LABELS_FILE}")" >/dev/null
+        fi
 
         if [ "${INPUT_OPERATION}" = "close" ]; then
           COMMENT="${INPUT_CLOSE_COMMENT}"

--- a/.github/scripts/check-dev-cut-workflow-contract.py
+++ b/.github/scripts/check-dev-cut-workflow-contract.py
@@ -14,6 +14,7 @@ ROOT = Path(__file__).resolve().parents[2]
 DEV_STAGING_DEV_CUT = ROOT / ".github/workflows/dev-staging-dev-cut.yml"
 RC_MAIN_CUT = ROOT / ".github/workflows/rc-main-cut.yml"
 SHARED_NOTIFY = ROOT / ".github/workflows/shared-notify.yml"
+CUT_ISSUE_ACTION = ROOT / ".github/actions/cut-issue/action.yml"
 
 
 def fail(message: str) -> None:
@@ -83,13 +84,56 @@ def assert_dev_staging_dev_cut_contract() -> None:
     if str(with_config.get("fetch-depth")) != "0":
         fail("dev-staging-dev-cut checkout fetch-depth must be 0")
 
+    required_order = [
+        "Create dev promotion PR",
+        "Track dev promotion issue",
+        "Update dev promotion PR and enable auto-merge",
+    ]
+    positions: dict[str, int] = {}
+    for name in required_order:
+        for index, step in enumerate(steps):
+            if isinstance(step, dict) and step.get("name") == name:
+                positions[name] = index
+                break
+        else:
+            fail(f"dev-staging-dev-cut must define step '{name}'")
+    if positions[required_order[0]] > positions[required_order[1]]:
+        fail("dev-staging-dev-cut must create promotion PR before tracking the cut issue")
+    if positions[required_order[1]] > positions[required_order[2]]:
+        fail("dev-staging-dev-cut must track the cut issue before updating/enabling PR auto-merge")
+
+    track_step = steps[positions["Track dev promotion issue"]]
+    if not isinstance(track_step, dict):
+        fail("Track dev promotion issue step did not parse as a mapping")
+    if track_step.get("uses") != "./.github/actions/cut-issue":
+        fail("Track dev promotion issue must use ./.github/actions/cut-issue")
+    track_with = track_step.get("with", {})
+    if not isinstance(track_with, dict):
+        fail("Track dev promotion issue with block did not parse as a mapping")
+    if track_with.get("extra-labels") != "needs-swe":
+        fail("dev-staging-dev-cut cut issue must apply needs-swe")
+    details = str(track_with.get("details", ""))
+    required_details = [
+        "## Agent Contract",
+        "목표: 최신 `dev-staging` snapshot이 최종적으로 `dev`에 승격되도록 케어한다.",
+        "종료 조건",
+        "`exec-report` 조건 예시",
+        "fix PR만 `dev`로 cherry-pick하지 않는다.",
+        "위 목록은 예시다.",
+        "protected branch에 직접 push하지 않는다.",
+        "minglit:swe-task",
+    ]
+    for fragment in required_details:
+        if fragment not in details:
+            fail(f"dev-staging-dev-cut cut issue details missing fragment: {fragment}")
+
 
 def assert_promotion_auto_merge_mode_contract() -> None:
     promotion_steps = [
         (
             DEV_STAGING_DEV_CUT,
             "create-dev-cut-pr",
-            "Create dev promotion PR and enable auto-merge",
+            "Update dev promotion PR and enable auto-merge",
         ),
         (
             RC_MAIN_CUT,
@@ -124,10 +168,25 @@ def assert_shared_notify_contract() -> None:
         fail("shared-notify must call gh run view with explicit --repo context")
 
 
+def assert_cut_issue_action_contract() -> None:
+    text = CUT_ISSUE_ACTION.read_text(encoding="utf-8")
+    required_fragments = [
+        "extra-labels:",
+        'create_label "needs-swe"',
+        'create_label "exec-report"',
+        "INPUT_EXTRA_LABELS",
+        '--add-label "$(paste -sd, "${EXTRA_LABELS_FILE}")"',
+    ]
+    for fragment in required_fragments:
+        if fragment not in text:
+            fail(f"cut-issue action missing fragment: {fragment}")
+
+
 def main() -> None:
     assert_dev_staging_dev_cut_contract()
     assert_promotion_auto_merge_mode_contract()
     assert_shared_notify_contract()
+    assert_cut_issue_action_contract()
     print("Dev cut workflow contract OK")
 
 

--- a/.github/workflows/dev-staging-dev-cut.yml
+++ b/.github/workflows/dev-staging-dev-cut.yml
@@ -200,27 +200,7 @@ jobs:
           git push origin "${TAG_SHA}:refs/heads/${BRANCH_NAME}"
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 
-      - name: Track dev promotion issue
-        id: cut-issue
-        if: steps.prepare.outputs.skipped != 'true'
-        uses: ./.github/actions/cut-issue
-        with:
-          github-token: ${{ github.token }}
-          operation: upsert
-          gate-key: dev-staging-dev
-          subject-id: ${{ steps.prepare.outputs.tag_name }}
-          title: 'cut-gate(dev-staging-dev): ${{ steps.prepare.outputs.tag_name }}'
-          status: ${{ inputs.dry_run == true && 'ready' || 'promoting' }}
-          summary: 'dev-staging -> dev promotion is planned for `${{ steps.prepare.outputs.tag_name }}`.'
-          details: |
-            - Source tag: `${{ steps.prepare.outputs.tag_name }}`
-            - Source SHA: `${{ steps.prepare.outputs.tag_sha }}`
-            - Promotion branch: `${{ steps.prepare.outputs.branch_name }}`
-            - Target branch: `dev`
-            - Deploy after merge: `dev-deploy` on `push` to `dev`
-            - Dry run: `${{ inputs.dry_run || false }}`
-
-      - name: Create dev promotion PR and enable auto-merge
+      - name: Create dev promotion PR
         id: pr
         if: steps.prepare.outputs.skipped != 'true' && inputs.dry_run != true
         env:
@@ -228,18 +208,8 @@ jobs:
           TAG_NAME: ${{ steps.prepare.outputs.tag_name }}
           TAG_SHA: ${{ steps.prepare.outputs.tag_sha }}
           BRANCH_NAME: ${{ steps.prepare.outputs.branch_name }}
-          CUT_ISSUE_NUMBER: ${{ steps.cut-issue.outputs.issue-number }}
-          CUT_ISSUE_URL: ${{ steps.cut-issue.outputs.issue-url }}
         run: |
           set -euo pipefail
-          CUT_ISSUE_CLOSER=""
-          CUT_ISSUE_MARKER=""
-          CUT_ISSUE_LINE="- Tracking issue: none"
-          if [ -n "${CUT_ISSUE_NUMBER}" ]; then
-            CUT_ISSUE_CLOSER="Closes #${CUT_ISSUE_NUMBER}"
-            CUT_ISSUE_MARKER="<!-- minglit:cut-issue-number:${CUT_ISSUE_NUMBER} -->"
-            CUT_ISSUE_LINE="- Tracking issue: #${CUT_ISSUE_NUMBER} (${CUT_ISSUE_URL})"
-          fi
 
           BODY="$(cat <<EOF
           Promotes \`${TAG_NAME}\` from \`dev-staging\` to \`dev\`.
@@ -248,12 +218,8 @@ jobs:
           - Source SHA: ${TAG_SHA}
           - Target branch: dev
           - Deploy after merge: dev-deploy on push to dev
-          ${CUT_ISSUE_LINE}
+          - Tracking issue: pending; workflow will attach after PR creation.
           - Merge mode: merge commit, preserving the dev-staging snapshot ancestry in dev.
-
-          ${CUT_ISSUE_CLOSER}
-
-          ${CUT_ISSUE_MARKER}
           EOF
           )"
 
@@ -264,8 +230,119 @@ jobs:
             --body "${BODY}")"
           PR_NUMBER="${PR_URL##*/}"
 
-          gh pr merge "${PR_NUMBER}" --auto --merge --delete-branch
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Track dev promotion issue
+        id: cut-issue
+        if: steps.prepare.outputs.skipped != 'true' && inputs.dry_run != true
+        uses: ./.github/actions/cut-issue
+        with:
+          github-token: ${{ github.token }}
+          operation: upsert
+          gate-key: dev-staging-dev
+          subject-id: ${{ steps.prepare.outputs.tag_name }}
+          title: 'cut-gate(dev-staging-dev): ${{ steps.prepare.outputs.tag_name }}'
+          status: promoting
+          extra-labels: needs-swe
+          summary: 'dev-staging -> dev promotion is planned for `${{ steps.prepare.outputs.tag_name }}`.'
+          details: |
+            ## Promotion Evidence
+
+            | Field | Value |
+            |---|---|
+            | Source tag | `${{ steps.prepare.outputs.tag_name }}` |
+            | Source SHA | `${{ steps.prepare.outputs.tag_sha }}` |
+            | Promotion branch | `${{ steps.prepare.outputs.branch_name }}` |
+            | Promotion PR | ${{ steps.pr.outputs.pr_url }} |
+            | Target branch | `dev` |
+            | Deploy after merge | `dev-deploy` on `push` to `dev` |
+
+            ## Agent Contract
+
+            목표: 최신 `dev-staging` snapshot이 최종적으로 `dev`에 승격되도록 케어한다.
+
+            ### 에이전트의 판단 기준
+
+            - 목표 달성을 위해 코드/테스트/문서 수정이 필요하면 fix PR을 `dev-staging`에 생성한다.
+            - fix PR이 머지되면 새 `dev-staging-dev-cut` 승격을 다시 시도한다.
+            - 단순히 현재 promotion PR이 실패했다는 이유만으로 종료하지 않는다.
+            - 종료 여부는 "에이전트가 안전하게 다음 조치를 수행할 수 있는가"를 기준으로 판단한다.
+
+            ### 종료 조건
+
+            - 최신 `dev-staging` snapshot이 `dev`에 머지되면 종료한다.
+            - 또는 에이전트가 안전하게 더 진행할 수 없는 blocker가 있으면 `exec-report` 라벨을 붙이고 종료한다.
+            - 종료 전 이슈 댓글에 root cause, 실패한 check/log URL, 이미 시도한 조치, 필요한 사람 조치사항을 남긴다.
+
+            ### Fix handling
+
+            - fix PR은 `dev-staging`에 머지한다.
+            - fix PR만 `dev`로 cherry-pick하지 않는다.
+            - fix가 머지된 뒤 새 `dev-staging-dev-cut`을 실행해 최신 `dev-staging` snapshot 전체를 다시 `dev`로 승격한다.
+            - 따라서 재시도 승격에는 fix PR뿐 아니라 그 시점까지 `dev-staging`에 포함된 변경 전체가 포함된다.
+
+            ### `exec-report` 조건 예시
+
+            - GitHub Actions runner 장애, Actions outage, job이 장시간 queued/stuck 상태로 반복됨.
+            - release bot token, GitHub App permission, ruleset 권한 문제로 branch/tag/PR 생성 또는 merge가 불가능함.
+            - branch protection/ruleset required check 이름이 workflow와 불일치해서 통과한 PR도 머지할 수 없음.
+            - repository secret/env 누락으로 CI가 재현 가능하게 실패하지만 에이전트가 값을 만들 수 없음.
+            - Supabase/Firebase/GitHub API 같은 외부 서비스 장애 또는 rate limit로 승격 workflow가 반복 실패함.
+            - promotion branch가 정책적으로 판단이 필요한 충돌/lineage 문제에 걸림.
+            - 동일 원인으로 fix/retry 후에도 3회 이상 승격이 실패하고 추가 진행이 추측에 의존함.
+            - active RC, hotfix override, ruleset/admin bypass 같은 release manager 결정이 필요한 상태임.
+
+            주의: 위 목록은 예시다. 에이전트는 목표 달성 가능성과 안전성을 기준으로 계속 진행할지, `exec-report`로 넘길지 판단한다.
+            `exec-report`는 코드/테스트 수정이 가능한 실패에는 사용하지 않는다.
+
+            ### 금지 사항
+
+            - protected branch에 직접 push하지 않는다.
+            - ruleset bypass 또는 admin merge를 사용하지 않는다.
+            - `dev`를 직접 수정하지 않는다.
+            - 실패한 기존 승격 PR만 닫고 이슈를 완료 처리하지 않는다.
+            - 원인 분석 없이 테스트 기대값만 바꾸지 않는다.
+
+            <!-- minglit:swe-task
+            type: promotion-care
+            lane: dev-staging-dev
+            source_tag: ${{ steps.prepare.outputs.tag_name }}
+            source_sha: ${{ steps.prepare.outputs.tag_sha }}
+            promotion_pr: ${{ steps.pr.outputs.pr_url }}
+            target_branch: dev
+            -->
+
+      - name: Update dev promotion PR and enable auto-merge
+        if: steps.prepare.outputs.skipped != 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          TAG_NAME: ${{ steps.prepare.outputs.tag_name }}
+          TAG_SHA: ${{ steps.prepare.outputs.tag_sha }}
+          CUT_ISSUE_NUMBER: ${{ steps.cut-issue.outputs.issue-number }}
+          CUT_ISSUE_URL: ${{ steps.cut-issue.outputs.issue-url }}
+        run: |
+          set -euo pipefail
+
+          BODY="$(cat <<EOF
+          Promotes \`${TAG_NAME}\` from \`dev-staging\` to \`dev\`.
+
+          - Source tag: ${TAG_NAME}
+          - Source SHA: ${TAG_SHA}
+          - Target branch: dev
+          - Deploy after merge: dev-deploy on push to dev
+          - Tracking issue: #${CUT_ISSUE_NUMBER} (${CUT_ISSUE_URL})
+          - Merge mode: merge commit, preserving the dev-staging snapshot ancestry in dev.
+
+          Closes #${CUT_ISSUE_NUMBER}
+
+          <!-- minglit:cut-issue-number:${CUT_ISSUE_NUMBER} -->
+          EOF
+          )"
+
+          gh pr edit "${PR_NUMBER}" --body "${BODY}"
+          gh pr merge "${PR_NUMBER}" --auto --merge --delete-branch
 
       - name: Dry run summary
         if: steps.prepare.outputs.skipped != 'true' && inputs.dry_run == true

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -117,7 +117,7 @@ Cut gate 추적용 GitHub Issue 를 생성/갱신/닫는 UI surface. Gate 판정
 | 항목 | 값 |
 |------|----|
 | Trigger | composite action (`.github/actions/cut-issue`) + `pull_request.closed` workflow |
-| Inputs | `operation`, `gate-key`, `subject-id`, `title`, `status`, `summary`, `details` |
+| Inputs | `operation`, `gate-key`, `subject-id`, `title`, `status`, `summary`, `details`, optional `extra-labels` |
 | Outputs | `issue-number`, `issue-url` |
 | Labels | `cut-gate`, `gate/{lane}`, `status/{waiting,blocked,ready,promoting,done}` |
 | Marker | `<!-- minglit:cut-gate:{gate-key}:{subject-id} -->` |
@@ -182,7 +182,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Inputs | optional `tag_name` (`v*-dev-staging`) |
 | Outputs | PR number (dev-staging → dev) or skip |
 | PR title | `ci(dev-staging-dev-cut): promote {tag_name} to dev` |
-| Steps | (1) 이전 `dev-staging-dev-cut` PR open 이면 skip (2) 입력 `tag_name` 이 있으면 해당 tag 를 promote 대상으로 사용 (3) 입력이 없으면 `origin/dev-staging` HEAD 가 이미 dev 에 포함됐는지 확인 (4) HEAD 에 기존 snapshot tag 가 있으면 재사용 (5) tag 가 없으면 `YY.MM.DD-dev-staging` + `YYMMDDNN` build number 로 version bump commit 을 만들고 release bot 이 protected `dev-staging` 에 fast-forward push (6) 같은 commit 에 `vYY.MM.DD+YYMMDDNN-dev-staging` tag push (7) `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` promotion branch 를 tag SHA 에서 생성 (8) cut tracking issue 를 `status/promoting` 으로 갱신 (9) `gh pr create` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}`) + issue close marker + auto-merge 활성화 (`merge commit`, dev-staging snapshot ancestry 보존) |
+| Steps | (1) 이전 `dev-staging-dev-cut` PR open 이면 skip (2) 입력 `tag_name` 이 있으면 해당 tag 를 promote 대상으로 사용 (3) 입력이 없으면 `origin/dev-staging` HEAD 가 이미 dev 에 포함됐는지 확인 (4) HEAD 에 기존 snapshot tag 가 있으면 재사용 (5) tag 가 없으면 `YY.MM.DD-dev-staging` + `YYMMDDNN` build number 로 version bump commit 을 만들고 release bot 이 protected `dev-staging` 에 fast-forward push (6) 같은 commit 에 `vYY.MM.DD+YYMMDDNN-dev-staging` tag push (7) `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` promotion branch 를 tag SHA 에서 생성 (8) `gh pr create` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}`) (9) PR URL 을 포함한 cut tracking issue 를 `status/promoting` + `needs-swe` 로 갱신 (10) PR body 에 issue close marker 를 다시 쓰고 auto-merge 활성화 (`merge commit`, dev-staging snapshot ancestry 보존) |
 
 #### `dev-pr-gate`
 


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- Create the dev promotion PR before the cut issue so the issue body can include the PR URL
- Add `needs-swe` support to cut-gate issues and define the Agent Contract for dev-staging -> dev promotion care
- Document fix handling, `exec-report` handoff examples, and snapshot re-promotion behavior
- Extend workflow contract checks to lock the PR -> issue -> PR update order

## Validation
- `python3 .github/scripts/check-dev-cut-workflow-contract.py`
- `python3 .github/scripts/check-dev-soak-workflow-contract.py`
- Workflow/action YAML parse via PyYAML
- `git diff --check origin/dev-staging..HEAD`

No linked issue: release workflow policy/contract update.