### PR TITLE
security: route remaining repository writes through Edge Functions

### DIFF
--- a/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
+++ b/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
@@ -61,7 +61,12 @@ class EventCreateController extends _$EventCreateController {
 
     // 3. Map entry group templates to instances
     final initialEntryGroups =
-        party.entryGroups?.map(EntryGroup.createFromTemplate).toList() ?? [];
+        party.entryGroups
+            ?.map(
+              (group) => EntryGroup.createFromTemplate(group, id: group.id),
+            )
+            .toList() ??
+        [];
 
     state = state.copyWith(
       title: baseEvent.title ?? '',
@@ -131,7 +136,8 @@ class EventCreateController extends _$EventCreateController {
   Future<void> submit() async {
     state = state.copyWith(status: const AsyncValue<void>.loading());
 
-    // Fix #1037: snapshot recurrence state before any await to avoid race conditions
+    // Fix #1037: snapshot recurrence state before any await to avoid race
+    // conditions.
     final recurrenceSnapshot = ref.read(recurrenceSettingsControllerProvider);
 
     final result = await AsyncValue.guard(() async {
@@ -193,7 +199,8 @@ class EventCreateController extends _$EventCreateController {
       }
 
       ref.invalidate(partyEventsProvider(state.partyId));
-      // Fix #1943: bump shared signal so dashboard refreshes without cross-feature import
+      // Fix #1943: bump shared signal so dashboard refreshes without
+      // cross-feature import.
       ref.read(dashboardRefreshProvider.notifier).bump();
     });
 

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -402,8 +402,8 @@ Flutter 앱(publishable key = anon/authenticated role)은 **READ 전용**이다.
 | 계층 | 수단 | 상태 |
 |------|------|------|
 | IDE | `no_supabase_writes_outside_ef` custom_lint 룰 | ✅ 운영 중 (`shared/packages/minglit_lints/`) |
-| CI | `dart run custom_lint` PR-gate 스텝 | 진행 중 (issue #2392) |
-| DB | `REVOKE INSERT/UPDATE/DELETE/TRUNCATE FROM anon, authenticated` | 진행 중 (issue #2393 Phase 3) |
+| CI | `dart run custom_lint` PR-gate 스텝 | ✅ 운영 중 (`.github/workflows/pr-gate.yml`) |
+| DB | `REVOKE INSERT/UPDATE/DELETE/TRUNCATE FROM anon, authenticated` | 진행 중 (issue #2991 / #2393 Phase 3) |
 
 #### lint 룰: `no_supabase_writes_outside_ef`
 

--- a/docs/security/rls-strict-migration-plan.md
+++ b/docs/security/rls-strict-migration-plan.md
@@ -2,7 +2,7 @@
 
 > **Issue**: #2393  
 > **Date**: 2026-05-17  
-> **Status**: Phase 1 완료 — Phase 2~5 pending
+> **Status**: Phase 2 완료 (#2990) — Phase 3~5 pending (#2991)
 
 ## 목표
 
@@ -75,7 +75,9 @@ Flutter 앱(publishable key)의 Supabase 직접 write를 전면 차단하고, �
 | `submitApplication()` | `partner-register` |
 | `saveDraft()` | `partner-register` |
 
-### 신규 EF가 필요한 항목
+### Phase 1 당시 EF 보강 필요 항목
+
+아래 항목은 Phase 2 (#2990)에서 처리 완료.
 
 | 항목 | 근거 |
 |------|------|
@@ -86,30 +88,37 @@ Flutter 앱(publishable key)의 Supabase 직접 write를 전면 차단하고, �
 
 ---
 
-## Phase 2: 직접 write → EF 마이그레이션 (미착수)
+## Phase 2: 직접 write → EF 마이그레이션 (완료)
 
-### 우선순위
+> Tracking issue: #2990
+> Verification date: 2026-06-03
 
-**Group A — EF 이미 존재, Flutter만 수정**
-- `social_repository.dart` 3개 write → `user-manage-social` 사용
-- `notification_repository.dart` 3개 write → `user-manage-notification` 사용
-- `party_event_repository.dart` + `location_repository.dart` + `ticket_repository.dart` → `partner-manage-party` / `partner-manage-event` 사용
+### 완료 범위
 
-**Group B — EF 기능 확장 후 Flutter 수정**
-- `settlement_repository.dart` → `partner-manage-settlement` 확인 후 upsert 액션 추가
-- `verification_command_repository.dart:301` → `partner-approve-application` / `partner-reject-application` 확인
-- `ticket_repository.dart:185` (DELETE) → `partner-manage-event`에 delete_ticket_template 액션 추가
+| 영역 | 처리 |
+|------|------|
+| Social / Notification write | `user-manage-social`, `user-manage-notification` 경유 |
+| Event create/update, entry groups, tickets | `partner-manage-event` 경유 |
+| Location, ticket template, entry group template | `partner-manage-party` 경유 |
+| Partner settlement bank account | `partner-manage-settlement` 경유 |
+| Partner application review | `partner-register` `review` action 경유 |
+| Event application approve/reject | `partner-approve-application`, `partner-reject-application` 경유 |
+| User application delete/cancel | `user-cancel-order` 경유 |
 
-**Group C — 신규 EF 필요**
-- `event_applications.DELETE` → `user-cancel-order` 확장 or 별도 EF
-- `partner_applications.UPDATE` → `partner-review-application` EF 신규 생성
-- `entry_group_templates` CRUD → 기존 EF에 통합 or 별도
+### 완료 검증
+
+```bash
+rg -n "\.(insert|update|upsert|delete)\s*\(" \
+  shared/packages/minglit_kit/lib/src/data/repositories --glob '*.dart'
+```
+
+2026-06-03 기준 결과 0건. Repository layer의 Supabase DB 직접 write는 제거되어 Phase 3 GRANT 회수 진행 가능.
 
 ---
 
-## Phase 3: GRANT 회수 Migration (미착수)
+## Phase 3: GRANT 회수 Migration (미착수, #2991)
 
-> **전제조건**: Phase 2 완료 후 진행. Phase 2 미완료 시 진행 금지.
+> **전제조건**: Phase 2 완료. 진행 전 dev DB에서 GRANT 현황과 EF smoke test를 확인한다.
 
 ```sql
 -- Migration: supabase/migrations/YYYYMMDD000001_revoke_write_grants_from_publishable_key.sql

--- a/shared/packages/minglit_kit/lib/src/data/models/event.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/event.dart
@@ -89,7 +89,7 @@ abstract class Event with _$Event {
       minConfirmedCount: party.minConfirmedCount,
       maxParticipants: party.maxParticipants,
       entryGroups: party.entryGroups
-          ?.map(EntryGroup.createFromTemplate)
+          ?.map((group) => EntryGroup.createFromTemplate(group, id: group.id))
           .toList(),
     );
   }

--- a/shared/packages/minglit_kit/lib/src/data/models/party_entry_group.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/party_entry_group.dart
@@ -63,10 +63,11 @@ abstract class EntryGroup with _$EntryGroup {
   factory EntryGroup.createFromTemplate(
     EntryGroupTemplate template, {
     String eventId = '',
+    String? id,
   }) {
     final now = DateTime.now();
     return EntryGroup(
-      id: '',
+      id: id ?? '',
       eventId: eventId,
       label: template.label,
       gender: template.gender,

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
@@ -37,11 +37,20 @@ mixin _EventRepositoryCommands on _SupabaseEventContext {
   }) async {
     Log.d('deleteApplication called | event: $eventId, user: $userId');
     try {
-      await supabaseClient
-          .from('event_applications')
-          .delete()
-          .eq('event_id', eventId)
-          .eq('user_id', userId);
+      final response = await supabaseClient.functions.invoke(
+        'user-cancel-order',
+        body: {
+          'event_id': eventId,
+          'reason': 'application_deleted',
+        },
+      );
+      if (response.status != 200) {
+        final data = response.data;
+        final errorMsg = data is Map
+            ? (data['error'] as String?) ?? '신청 삭제에 실패했습니다.'
+            : '신청 삭제에 실패했습니다.';
+        throw MinglitUserException(errorMsg);
+      }
       Log.i('✅ [EventRepo] Application deleted.');
     } catch (e, st) {
       Log.e('❌ [EventRepo] deleteApplication Error', e, st);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/location_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/location_repository.dart
@@ -78,10 +78,12 @@ class LocationRepository {
       // Format: POINT(longitude latitude)
       final point = 'POINT(${location.longitude} ${location.latitude})';
 
-      final data = await _supabase
-          .from('locations')
-          .insert({
-            'partner_id': location.partnerId,
+      final response = await _supabase.functions.invoke(
+        'partner-manage-party',
+        body: {
+          'action': 'create_location',
+          'partner_id': location.partnerId,
+          'location': {
             'name': location.name,
             'address': location.address,
             'address_detail': location.addressDetail,
@@ -91,17 +93,20 @@ class LocationRepository {
             'directions_guide': location.directionsGuide,
             'postal_code': location.postalCode,
             'geo_point': point,
-          })
-          .select()
-          .single();
+          },
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ?? 'Failed to create location'
+            : 'Failed to create location';
+        throw Exception(error);
+      }
 
-      // Merging input lat/lng into response data since insert().select()
-      // returns table columns (geo_point WKB) not view columns (lat/lng).
-      final mergedData = Map<String, dynamic>.from(data);
-      mergedData['lat'] = location.latitude;
-      mergedData['lng'] = location.longitude;
-
-      final result = Location.fromJson(mergedData);
+      final data = response.data as Map<String, dynamic>;
+      final locationId = data['location_id'] as String;
+      final result = await getLocationById(locationId);
+      if (result == null) throw Exception('Created location not found');
       Log.d('createLocation success | id: ${result.id}');
       return result;
     } catch (e, st) {
@@ -122,14 +127,23 @@ class LocationRepository {
   }) async {
     Log.d('updateLocationDetails called | locationId: $locationId');
     try {
-      await _supabase
-          .from('locations')
-          .update({
+      final response = await _supabase.functions.invoke(
+        'partner-manage-party',
+        body: {
+          'action': 'update_location',
+          'location_id': locationId,
+          'location': {
             'address_detail': addressDetail,
             'directions_guide': directionsGuide,
-            'updated_at': DateTime.now().toIso8601String(),
-          })
-          .eq('id', locationId);
+          },
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ?? 'Failed to update location'
+            : 'Failed to update location';
+        throw Exception(error);
+      }
       Log.d('updateLocationDetails success');
     } catch (e, st) {
       Log.e('❌ [LocationRepo] updateLocationDetails Error', e, st);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/partner_application_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/partner_application_repository.dart
@@ -159,14 +159,18 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
       '''reviewApplication called | id: $applicationId, status: $status, comment: $adminComment''',
     );
     try {
-      await supabaseClient
-          .from('partner_applications')
-          .update({
-            'status': status,
-            'admin_comment': adminComment,
-            'updated_at': DateTime.now().toIso8601String(),
-          })
-          .eq('id', applicationId);
+      final response = await supabaseClient.functions.invoke(
+        'partner-register',
+        body: {
+          'action': 'review',
+          'application_id': applicationId,
+          'status': status,
+          if (adminComment != null) 'admin_comment': adminComment,
+        },
+      );
+      if (response.status != 200) {
+        throw _efError(response, 'Failed to review application');
+      }
       Log.d('reviewApplication success');
     } catch (e, st) {
       Log.e('❌ [PartnerRepo] reviewApplication Error', e, st);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/party_event_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/party_event_repository.dart
@@ -26,35 +26,41 @@ mixin _PartyEventRepository on _SupabasePartyContext {
     try {
       final eventJson = event.toDbJson();
 
-      final data = await supabaseClient
-          .from('events')
-          .insert(eventJson)
-          .select()
-          .single();
+      final body = <String, dynamic>{
+        'action': 'create',
+        'party_id': event.partyId,
+        'event': eventJson..remove('party_id'),
+        if (event.entryGroups != null)
+          'entry_groups': event.entryGroups!.map((g) {
+            final sourceId = g.id.trim();
+            final groupJson = g.toDbJson()..remove('event_id');
+            if (sourceId.isNotEmpty) {
+              groupJson['source_entry_group_id'] = sourceId;
+            }
+            return groupJson;
+          }).toList(),
+        if (event.tickets != null)
+          'tickets': event.tickets!
+              .map(
+                (t) => t.toDbJson()..remove('event_id'),
+              )
+              .toList(),
+      };
 
-      final createdEvent = Event.fromJson(data);
-
-      // Create associated entry groups if provided
-      final eventGroups = event.entryGroups;
-      if (eventGroups != null && eventGroups.isNotEmpty) {
-        final groupsJson = eventGroups
-            .map((g) => g.copyWith(eventId: createdEvent.id).toDbJson())
-            .toList();
-        // minglit_lints: allow-supabase-write — reason: EF migration pending (Phase 2 partner-side, tracked in #2392)
-        await supabaseClient.from('entry_groups').insert(groupsJson);
+      final response = await supabaseClient.functions.invoke(
+        'partner-manage-event',
+        body: body,
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ?? 'Failed to create event'
+            : 'Failed to create event';
+        throw Exception(error);
       }
 
-      // Create associated tickets if provided
-      final eventTickets = event.tickets;
-      if (eventTickets != null && eventTickets.isNotEmpty) {
-        final ticketsJson = eventTickets
-            .map((t) => t.toDbJson(eventId: createdEvent.id))
-            .toList();
-
-        // minglit_lints: allow-supabase-write — reason: EF migration pending (Phase 2 partner-side, tracked in #2392)
-        await supabaseClient.from('tickets').insert(ticketsJson);
-      }
-
+      final data = response.data as Map<String, dynamic>;
+      final eventId = data['event_id'] as String;
+      final createdEvent = await _getEventById(eventId);
       Log.d('createEvent success | id: ${createdEvent.id}');
       return createdEvent;
     } catch (e, st) {
@@ -69,20 +75,39 @@ mixin _PartyEventRepository on _SupabasePartyContext {
     try {
       final json = event.toDbJson();
 
-      final data = await supabaseClient
-          .from('events')
-          .update(json)
-          .eq('id', event.id)
-          .select()
-          .single();
+      final response = await supabaseClient.functions.invoke(
+        'partner-manage-event',
+        body: {
+          'action': 'update',
+          'event_id': event.id,
+          'event': json
+            ..remove('party_id')
+            ..remove('location'),
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ?? 'Failed to update event'
+            : 'Failed to update event';
+        throw Exception(error);
+      }
 
-      final result = Event.fromJson(data);
+      final result = await _getEventById(event.id);
       Log.d('updateEvent success | id: ${result.id}');
       return result;
     } catch (e, st) {
       Log.e('❌ [PartyRepo] updateEvent Error', e, st);
       rethrow;
     }
+  }
+
+  Future<Event> _getEventById(String eventId) async {
+    final data = await supabaseClient
+        .from('events')
+        .select('*, entry_groups(*), tickets(*)')
+        .eq('id', eventId)
+        .single();
+    return Event.fromJson(data);
   }
 
   /// Updates only the status of an event.

--- a/shared/packages/minglit_kit/lib/src/data/repositories/party_matching_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/party_matching_repository.dart
@@ -11,14 +11,6 @@ mixin _PartyMatchingRepository on _SupabasePartyContext {
       'count: ${templates.length}',
     );
     try {
-      // Fix #1740: entry_groups(Event Level)은 party_id 컬럼 없음 — entry_group_templates(Party Level) 사용
-      await supabaseClient
-          .from('entry_group_templates')
-          .delete()
-          .eq('party_id', partyId);
-
-      if (templates.isEmpty) return;
-
       final groupsJson = templates
           .map(
             (group) => group.copyWith(partyId: partyId).toJson()
@@ -27,8 +19,21 @@ mixin _PartyMatchingRepository on _SupabasePartyContext {
           )
           .toList();
 
-      // minglit_lints: allow-supabase-write — reason: EF migration pending (Phase 2 partner-side, tracked in #2392)
-      await supabaseClient.from('entry_group_templates').insert(groupsJson);
+      final response = await supabaseClient.functions.invoke(
+        'partner-manage-party',
+        body: {
+          'action': 'update',
+          'party_id': partyId,
+          'entry_group_templates': groupsJson,
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ??
+                  'Failed to replace entry group templates'
+            : 'Failed to replace entry group templates';
+        throw Exception(error);
+      }
       Log.d('replaceEntryGroupTemplates success');
     } catch (e, st) {
       Log.e('❌ [PartyRepo] replaceEntryGroupTemplates Error', e, st);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/settlement_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/settlement_repository.dart
@@ -274,13 +274,22 @@ class SettlementRepository {
       'upsertBankAccount called | partnerId: $partnerId, bankName: $bankName',
     );
     try {
-      // minglit_lints: allow-supabase-write — reason: EF migration pending (Phase 2 partner-side, tracked in #2392)
-      await _supabase.from('partner_settlements').upsert({
-        'partner_id': partnerId,
-        'bank_name': bankName,
-        'account_holder': accountHolder,
-        'account_number': accountNumber,
-      }, onConflict: 'partner_id');
+      final response = await _supabase.functions.invoke(
+        'partner-manage-settlement',
+        body: {
+          'action': 'upsert_bank_account',
+          'partner_id': partnerId,
+          'bank_name': bankName,
+          'account_holder': accountHolder,
+          'account_number': accountNumber,
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ?? 'Failed to upsert bank account'
+            : 'Failed to upsert bank account';
+        throw Exception(error);
+      }
 
       Log.d('upsertBankAccount success | partnerId: $partnerId');
     } catch (e, st) {

--- a/shared/packages/minglit_kit/lib/src/data/repositories/ticket_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/ticket_repository.dart
@@ -142,14 +142,23 @@ class TicketRepository {
     try {
       final json = template.toDbJson();
 
-      final data = await _supabase
-          .from('ticket_templates')
-          .update(json)
-          .eq('id', template.id)
-          .select()
-          .single();
+      final response = await _supabase.functions.invoke(
+        'partner-manage-party',
+        body: {
+          'action': 'update_ticket_template',
+          'ticket_template_id': template.id,
+          'ticket_template': json..remove('party_id'),
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ??
+                  'Failed to update ticket template'
+            : 'Failed to update ticket template';
+        throw Exception(error);
+      }
 
-      final result = TicketTemplate.fromJson(data);
+      final result = await getTicketTemplateById(template.id);
       Log.d('updateTicketTemplate success | id: ${result.id}');
       return result;
     } catch (e, st) {
@@ -164,13 +173,24 @@ class TicketRepository {
     try {
       final json = template.toDbJson();
 
-      final data = await _supabase
-          .from('ticket_templates')
-          .insert(json)
-          .select()
-          .single();
+      final response = await _supabase.functions.invoke(
+        'partner-manage-party',
+        body: {
+          'action': 'create_ticket_template',
+          'ticket_template': json,
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ??
+                  'Failed to create ticket template'
+            : 'Failed to create ticket template';
+        throw Exception(error);
+      }
 
-      final result = TicketTemplate.fromJson(data);
+      final data = response.data as Map<String, dynamic>;
+      final templateId = data['ticket_template_id'] as String;
+      final result = await getTicketTemplateById(templateId);
       Log.d('createTicketTemplate success | id: ${result.id}');
       return result;
     } catch (e, st) {
@@ -183,8 +203,20 @@ class TicketRepository {
   Future<void> deleteTicketTemplate(String id) async {
     Log.d('deleteTicketTemplate called | id: $id');
     try {
-      // minglit_lints: allow-supabase-write — reason: EF migration pending (Phase 2 partner-side, tracked in #2392)
-      await _supabase.from('ticket_templates').delete().eq('id', id);
+      final response = await _supabase.functions.invoke(
+        'partner-manage-party',
+        body: {
+          'action': 'delete_ticket_template',
+          'ticket_template_id': id,
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ??
+                  'Failed to delete ticket template'
+            : 'Failed to delete ticket template';
+        throw Exception(error);
+      }
       Log.d('deleteTicketTemplate success | id: $id');
     } catch (e, st) {
       Log.e('deleteTicketTemplate failed: $id', e, st);
@@ -202,13 +234,23 @@ class TicketRepository {
         ..remove('updated_at')
         ..remove('sold_count');
 
-      final data = await _supabase
-          .from('tickets')
-          .insert(json)
-          .select()
-          .single();
+      final response = await _supabase.functions.invoke(
+        'partner-manage-event',
+        body: {
+          'action': 'create_ticket',
+          'ticket': json,
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ?? 'Failed to create ticket'
+            : 'Failed to create ticket';
+        throw Exception(error);
+      }
 
-      final result = Ticket.fromJson(data);
+      final data = response.data as Map<String, dynamic>;
+      final ticketId = data['ticket_id'] as String;
+      final result = await getTicketById(ticketId);
       Log.d('createTicket success | id: ${result.id}');
       return result;
     } catch (e, st) {
@@ -232,19 +274,37 @@ class TicketRepository {
         );
       }
 
+      final eventId = ticket.eventId;
+      if (eventId == null || eventId.isEmpty) {
+        throw const MinglitUserException('이벤트 정보가 없는 티켓은 수정할 수 없습니다.');
+      }
+
       final json = ticket.toJson()
         ..remove('created_at')
         ..remove('updated_at') // moddatetime trigger handles this
         ..remove('sold_count'); // sold_count is managed by system
 
-      final data = await _supabase
-          .from('tickets')
-          .update(json)
-          .eq('id', ticket.id)
-          .select()
-          .single();
+      final response = await _supabase.functions.invoke(
+        'partner-manage-event',
+        body: {
+          'action': 'update_tickets',
+          'event_id': eventId,
+          'tickets': [
+            {
+              ...json,
+              'ticket_id': ticket.id,
+            },
+          ],
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ?? 'Failed to update ticket'
+            : 'Failed to update ticket';
+        throw Exception(error);
+      }
 
-      final result = Ticket.fromJson(data);
+      final result = await getTicketById(ticket.id);
       Log.d('updateTicket success | id: ${result.id}');
       return result;
     } catch (e, st) {

--- a/shared/packages/minglit_kit/lib/src/data/repositories/verification_command_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/verification_command_repository.dart
@@ -296,13 +296,39 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
       ' status: $status',
     );
     try {
-      await supabaseClient
-          .from('event_applications')
-          .update({
-            'status': status,
-            'rejection_reason': ?rejectionReason,
-          })
-          .eq('id', applicationId);
+      final FunctionResponse response;
+      if (status == 'approved') {
+        response = await supabaseClient.functions.invoke(
+          'partner-approve-application',
+          body: {
+            'action': 'approve',
+            'application_id': applicationId,
+          },
+        );
+      } else if (status == 'rejected') {
+        final trimmedReason = rejectionReason?.trim();
+        final reason = trimmedReason == null || trimmedReason.isEmpty
+            ? '신청이 거절되었습니다.'
+            : trimmedReason;
+        response = await supabaseClient.functions.invoke(
+          'partner-reject-application',
+          body: {
+            'application_id': applicationId,
+            'reason': reason,
+          },
+        );
+      } else {
+        throw MinglitUserException('지원하지 않는 신청 상태입니다: $status');
+      }
+
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ??
+                  'Failed to update application status'
+            : 'Failed to update application status';
+        throw MinglitUserException(errorMsg);
+      }
       Log.d('updateApplicationStatus success');
     } catch (e, st) {
       Log.e('❌ [VerificationRepo] updateApplicationStatus Error', e, st);

--- a/shared/packages/minglit_kit/test/src/data/models/event_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/models/event_test.dart
@@ -189,6 +189,35 @@ void main() {
       expect(event.metadata['show_participant_list'], false);
     });
 
+    test(
+      'createFromParty preserves entry group template ids as source ids',
+      () {
+        final party = Party.fromJson({
+          'id': 'party_1',
+          'partner_id': 'pt_1',
+          'title': 'Template Party',
+          'created_at': now.toIso8601String(),
+          'updated_at': now.toIso8601String(),
+          'entry_group_templates': [
+            {
+              'id': 'egt_1',
+              'party_id': 'party_1',
+              'label': 'VIP',
+            },
+          ],
+        });
+
+        final event = Event.createFromParty(
+          party,
+          startTime: now,
+          endTime: later,
+        );
+
+        expect(event.entryGroups, isNotNull);
+        expect(event.entryGroups!.single.id, 'egt_1');
+      },
+    );
+
     test('createFromParty metadata is a deep copy', () {
       final party = Party.fromJson({
         'id': 'party_1',
@@ -328,7 +357,8 @@ void main() {
       expect(event.description, isNotNull);
       expect(event.description!['ops'], isA<List<dynamic>>());
       final ops = event.description!['ops'] as List<dynamic>;
-      expect(ops.first['insert'], '파티 설명입니다\n');
+      final firstOp = ops.first as Map<String, dynamic>;
+      expect(firstOp['insert'], '파티 설명입니다\n');
     });
 
     test('returns null description when value is null', () {

--- a/shared/packages/minglit_kit/test/src/data/models/party_entry_group_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/models/party_entry_group_test.dart
@@ -160,6 +160,18 @@ void main() {
       expect(group.createdAt, isNotNull);
     });
 
+    test('createFromTemplate can preserve a source id for EF remapping', () {
+      final template = EntryGroupTemplate.fromJson({
+        'id': 'egt_1',
+        'party_id': 'party_1',
+        'label': 'VIP',
+      });
+
+      final group = EntryGroup.createFromTemplate(template, id: template.id);
+
+      expect(group.id, 'egt_1');
+    });
+
     test('toTemplate converts to EntryGroupTemplate', () {
       final group = EntryGroup.fromJson(groupJson());
       final template = group.toTemplate();

--- a/shared/packages/minglit_kit/test/src/data/repositories/event_repository_commands_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/event_repository_commands_test.dart
@@ -516,7 +516,14 @@ void main() {
 
   group('EventRepository.deleteApplication', () {
     test('completes without error', () async {
-      mockTable(mockClient, 'event_applications');
+      when(
+        () => mockFunctions.invoke(
+          'user-cancel-order',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(status: 200, data: {'success': true}),
+      );
 
       await expectLater(
         repository.deleteApplication(
@@ -528,10 +535,16 @@ void main() {
     });
 
     test('rethrows on error', () async {
-      mockTable(
-        mockClient,
-        'event_applications',
-        shouldThrow: Exception('delete error'),
+      when(
+        () => mockFunctions.invoke(
+          'user-cancel-order',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(
+          status: 500,
+          data: {'error': 'delete error'},
+        ),
       );
 
       await expectLater(

--- a/shared/packages/minglit_kit/test/src/data/repositories/location_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/location_repository_test.dart
@@ -1,12 +1,15 @@
 import 'dart:async' show unawaited;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/repositories/location_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../helpers/mocks.dart';
 import '../../../helpers/supabase_mock_helpers.dart';
 
 void main() {
   late MockSupabaseClient mockClient;
+  late MockFunctionsClient mockFunctions;
   late LocationRepository repository;
 
   final now = DateTime.now();
@@ -29,6 +32,7 @@ void main() {
 
   setUp(() {
     mockClient = createMockSupabase();
+    mockFunctions = mockClient.functions as MockFunctionsClient;
     repository = LocationRepository(supabase: mockClient);
   });
 
@@ -107,49 +111,53 @@ void main() {
           'updated_at': now.toIso8601String(),
         };
 
-        unawaited(
-          mockTable(
-            mockClient,
-            'locations',
-            insertReturnData: createdJson,
+        final createdViewJson = {
+          ...createdJson,
+          'lat': 37.5555,
+          'lng': 126.9220,
+        };
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-party',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'location_id': 'loc_new'},
           ),
         );
 
-        // Parse it manually since Location.fromJson
-        // expects locations_view format
         unawaited(
           mockTable(
             mockClient,
-            'locations',
-            insertReturnData: {
-              ...createdJson,
-              'lat': 37.5555,
-              'lng': 126.9220,
-            },
+            'locations_view',
+            maybeSingleData: createdViewJson,
           ),
         );
-
-        // We test that createLocation does not throw
         final newLoc = await repository.createLocation(
-          await (() async {
-            unawaited(
-              mockTable(
-                mockClient,
-                'locations_view',
-                maybeSingleData: locationJson,
-              ),
-            );
-            return (await repository.getLocationById('loc_1'))!;
-          })(),
+          await (() async => repository.getLocationById('loc_new'))().then(
+            (location) => location!,
+          ),
         );
 
-        expect(newLoc.id, isNotEmpty);
+        expect(newLoc.id, 'loc_new');
       });
     });
 
     group('updateLocationDetails', () {
       test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'locations'));
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-party',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
 
         await expectLater(
           repository.updateLocationDetails(

--- a/shared/packages/minglit_kit/test/src/data/repositories/partner_application_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/partner_application_repository_test.dart
@@ -127,7 +127,14 @@ void main() {
 
     group('reviewApplication', () {
       test('completes successfully', () async {
-        unawaited(mockTable(mockClient, 'partner_applications'));
+        when(
+          () => mockFunctions.invoke(
+            'partner-register',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 200, data: {'success': true}),
+        );
 
         await expectLater(
           repository.reviewApplication(
@@ -140,11 +147,15 @@ void main() {
       });
 
       test('throws on error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'partner_applications',
-            shouldThrow: Exception('review failed'),
+        when(
+          () => mockFunctions.invoke(
+            'partner-register',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 500,
+            data: {'error': 'review failed'},
           ),
         );
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/models/event.dart';
 import 'package:minglit_kit/src/data/models/party.dart';
 import 'package:minglit_kit/src/data/models/party_entry_group.dart';
+import 'package:minglit_kit/src/data/models/ticket.dart';
 import 'package:minglit_kit/src/data/repositories/party_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -630,6 +631,17 @@ void main() {
 
     group('createEvent', () {
       test('returns created event on success', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-event',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'event_id': 'event_1'},
+          ),
+        );
         unawaited(mockTable(mockClient, 'events', singleData: eventJson));
 
         final event = Event.fromJson(eventJson);
@@ -639,9 +651,77 @@ void main() {
         expect(result.partyId, 'party_1');
       });
 
+      test(
+        'passes entry group source ids for ticket target remapping',
+        () async {
+          when(
+            () => mockFunctions.invoke(
+              'partner-manage-event',
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => FunctionResponse(
+              status: 200,
+              data: {'success': true, 'event_id': 'event_1'},
+            ),
+          );
+          unawaited(mockTable(mockClient, 'events', singleData: eventJson));
+
+          final event = Event.fromJson(eventJson).copyWith(
+            entryGroups: [
+              EntryGroup(
+                id: 'egt_1',
+                eventId: '',
+                label: 'VIP',
+                createdAt: now,
+                updatedAt: now,
+              ),
+            ],
+            tickets: [
+              Ticket(
+                id: '',
+                name: 'VIP 티켓',
+                createdAt: now,
+                updatedAt: now,
+                price: 30000,
+                quantity: 20,
+                targetEntryGroupIds: ['egt_1'],
+              ),
+            ],
+          );
+
+          await repository.createEvent(event);
+
+          final captured =
+              verify(
+                    () => mockFunctions.invoke(
+                      'partner-manage-event',
+                      body: captureAny(named: 'body'),
+                    ),
+                  ).captured.single
+                  as Map<String, dynamic>;
+          final groups = captured['entry_groups'] as List;
+          final tickets = captured['tickets'] as List;
+          expect(groups.single, isNot(containsPair('id', anything)));
+          expect(groups.single, containsPair('source_entry_group_id', 'egt_1'));
+          expect(
+            tickets.single,
+            containsPair('target_entry_group_ids', ['egt_1']),
+          );
+        },
+      );
+
       test('throws on error', () async {
-        unawaited(
-          mockTable(mockClient, 'events', shouldThrow: Exception('error')),
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-event',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 500,
+            data: {'error': 'error'},
+          ),
         );
 
         final event = Event.fromJson(eventJson);
@@ -654,6 +734,17 @@ void main() {
 
     group('updateEvent', () {
       test('returns updated event on success', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-event',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
         unawaited(mockTable(mockClient, 'events', singleData: eventJson));
 
         final event = Event.fromJson(eventJson);
@@ -663,8 +754,16 @@ void main() {
       });
 
       test('throws on error', () async {
-        unawaited(
-          mockTable(mockClient, 'events', shouldThrow: Exception('error')),
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-event',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 500,
+            data: {'error': 'error'},
+          ),
         );
 
         final event = Event.fromJson(eventJson);
@@ -793,7 +892,14 @@ void main() {
       // entry_group_templates(Party Level) 테이블 사용으로 수정.
 
       test('completes with empty templates (delete only)', () async {
-        unawaited(mockTable(mockClient, 'entry_group_templates'));
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-party',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 200, data: {'success': true}),
+        );
 
         await expectLater(
           repository.replaceEntryGroupTemplates('party_1', []),
@@ -802,7 +908,14 @@ void main() {
       });
 
       test('completes with templates (delete + insert)', () async {
-        unawaited(mockTable(mockClient, 'entry_group_templates'));
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-party',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 200, data: {'success': true}),
+        );
 
         final templates = [
           const EntryGroupTemplate(
@@ -822,11 +935,15 @@ void main() {
       });
 
       test('throws on error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'entry_group_templates',
-            shouldThrow: Exception('error'),
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-party',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 500,
+            data: {'error': 'error'},
           ),
         );
 
@@ -837,23 +954,30 @@ void main() {
       });
 
       test(
-        'Fix #1740: uses entry_group_templates table (not entry_groups)',
+        'Fix #1740: sends entry_group_templates via partner-manage-party',
         () async {
-          final templatesBuilder = mockTable(
-            mockClient,
-            'entry_group_templates',
+          when(
+            () => mockFunctions.invoke(
+              'partner-manage-party',
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => FunctionResponse(status: 200, data: {'success': true}),
           );
 
           await repository.replaceEntryGroupTemplates('party_1', []);
 
-          final eqFilters = templatesBuilder.recordedFilters
-              .where((f) => f.method == 'eq')
-              .toList();
-          expect(
-            eqFilters.any((f) => f.column == 'party_id'),
-            isTrue,
-            reason: 'entry_group_templates must be filtered by party_id',
-          );
+          final captured =
+              verify(
+                    () => mockFunctions.invoke(
+                      'partner-manage-party',
+                      body: captureAny(named: 'body'),
+                    ),
+                  ).captured.single
+                  as Map<String, dynamic>;
+          expect(captured['action'], 'update');
+          expect(captured['party_id'], 'party_1');
+          expect(captured['entry_group_templates'], isEmpty);
           // entry_groups 테이블 호출 없음 확인
           verifyNever(() => mockClient.from('entry_groups'));
         },

--- a/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
@@ -53,10 +53,12 @@ Map<String, dynamic> _settlementItemJson({String id = 'item_1'}) => {
 
 void main() {
   late MockSupabaseClient mockClient;
+  late MockFunctionsClient mockFunctions;
   late SettlementRepository repository;
 
   setUp(() {
     mockClient = createMockSupabase();
+    mockFunctions = mockClient.functions as MockFunctionsClient;
     repository = SettlementRepository(supabase: mockClient);
   });
 
@@ -479,7 +481,17 @@ void main() {
     // -------------------------------------------------------------------------
     group('upsertBankAccount', () {
       test('completes without error', () async {
-        mockTable(mockClient, 'partner_settlements');
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-settlement',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
 
         await expectLater(
           repository.upsertBankAccount(
@@ -493,10 +505,16 @@ void main() {
       });
 
       test('throws on db error', () async {
-        mockTable(
-          mockClient,
-          'partner_settlements',
-          shouldThrow: Exception('upsert failed'),
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-settlement',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 500,
+            data: {'error': 'upsert failed'},
+          ),
         );
 
         await expectLater(

--- a/shared/packages/minglit_kit/test/src/data/repositories/ticket_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/ticket_repository_test.dart
@@ -4,12 +4,15 @@ import 'package:minglit_kit/src/data/models/ticket.dart';
 import 'package:minglit_kit/src/data/models/ticket_template.dart';
 import 'package:minglit_kit/src/data/repositories/ticket_repository.dart';
 import 'package:minglit_kit/src/utils/exceptions.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../helpers/mocks.dart';
 import '../../../helpers/supabase_mock_helpers.dart';
 
 void main() {
   late MockSupabaseClient mockClient;
+  late MockFunctionsClient mockFunctions;
   late TicketRepository repository;
 
   final now = DateTime.now();
@@ -41,6 +44,7 @@ void main() {
 
   setUp(() {
     mockClient = createMockSupabase();
+    mockFunctions = mockClient.functions as MockFunctionsClient;
     repository = TicketRepository(supabase: mockClient);
   });
 
@@ -145,13 +149,23 @@ void main() {
 
     group('createTicket', () {
       test('creates and returns new ticket', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-event',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'ticket_id': 'ticket_1'},
+          ),
+        );
         unawaited(
           mockTable(
             mockClient,
             'tickets',
             selectData: [ticketJson],
             singleData: ticketJson,
-            insertReturnData: ticketJson,
           ),
         );
 
@@ -165,13 +179,23 @@ void main() {
 
     group('createTicketTemplate', () {
       test('creates and returns new template', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-party',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'ticket_template_id': 'template_1'},
+          ),
+        );
         unawaited(
           mockTable(
             mockClient,
             'ticket_templates',
             selectData: [templateJson],
             singleData: templateJson,
-            insertReturnData: templateJson,
           ),
         );
 
@@ -215,7 +239,19 @@ void main() {
           'ticket_1',
         )).copyWith(quantity: 200); // 200 >= 10 (soldCount)
 
-        // Re-setup: getTicketById + update chain
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-event',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
+
+        // Re-setup: getTicketById after EF update
         unawaited(mockTable(mockClient, 'tickets', singleData: updatedJson));
 
         final result = await repository.updateTicket(ticket);
@@ -232,6 +268,17 @@ void main() {
         final template = await repository.getTicketTemplateById('template_1');
 
         final updatedJson = {...templateJson, 'name': '업데이트된 템플릿'};
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-party',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
         unawaited(
           mockTable(
             mockClient,
@@ -249,7 +296,17 @@ void main() {
 
     group('deleteTicketTemplate', () {
       test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'ticket_templates'));
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-party',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
 
         await expectLater(
           repository.deleteTicketTemplate('template_1'),

--- a/supabase/functions/BLUEDOC.md
+++ b/supabase/functions/BLUEDOC.md
@@ -18,6 +18,7 @@ minglit 의 backend API 진입점. 60+ EF 와 공용 `_shared/`, 테스트 유�
 | [user-create-order/](./user-create-order/BLUEDOC.md)                     | 이벤트 신청/주문 생성 EF                                         |
 | [payment-verify/](./payment-verify/BLUEDOC.md)                           | PortOne 결제 검증/승인 EF                                        |
 | [user-cancel-order/](./user-cancel-order/BLUEDOC.md)                     | 유저 신청 취소/환불 EF                                           |
+| [partner-manage-party/](./partner-manage-party/)                         | 파티/장소/티켓 템플릿/매칭 템플릿 파트너 관리 EF                 |
 | [partner-approve-application/](./partner-approve-application/BLUEDOC.md) | 파트너 신청 승인 EF                                              |
 
 ## 핵심 컨벤션
@@ -40,4 +41,4 @@ minglit 의 backend API 진입점. 60+ EF 와 공용 `_shared/`, 테스트 유�
 
 ---
 
-_Reviewed: 2026-05-25 16:20_
+_Reviewed: 2026-06-03 16:00_

--- a/supabase/functions/partner-manage-event/index.ts
+++ b/supabase/functions/partner-manage-event/index.ts
@@ -2,12 +2,12 @@
 // Issue #317: RLS write strategy 전환 — 이벤트/티켓 CRUD
 // Fix #2185 (Batch 6): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
-import type { SupabaseClient } from "@supabase/supabase-js";
 import {
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
 import { parseAction } from "../_shared/request_utils.ts";
 import { isEventEditableByPartner } from "../_shared/domains/event/availability.ts";
@@ -17,6 +17,7 @@ const _VALID_GENDERS = ["male", "female"];
 
 // Fields allowed in event create/update
 const EVENT_FIELDS = [
+  "location_id",
   "start_time",
   "end_time",
   "max_participants",
@@ -27,21 +28,32 @@ const EVENT_FIELDS = [
   "contact_options",
   "vote_start_at",
   "vote_end_at",
+  "visibility",
   "metadata",
 ] as const;
 
 // Fields allowed in ticket update
 // Fix #317: 이슈 스펙에 맞게 price/quantity만 허용
 const TICKET_UPDATE_FIELDS = [
+  "name",
+  "description",
   "price",
   "quantity",
+  "target_entry_group_ids",
+  "required_verification_ids",
+  "status",
 ] as const;
 
-export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
   const { supabase } = ctx;
-  if (ctx.auth.type !== "user") return errorResponse("Unexpected auth type", 500);
+  if (ctx.auth.type !== "user") {
+    return errorResponse("Unexpected auth type", 500);
+  }
   const userId = ctx.auth.userId;
 
   try {
@@ -54,7 +66,11 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
 
 minglitEdgeFunction(handler);
 
-async function handleRequest(supabase: SupabaseClient, userId: string, req: Request): Promise<Response> {
+async function handleRequest(
+  supabase: SupabaseClient,
+  userId: string,
+  req: Request,
+): Promise<Response> {
   // Parse body
   const result = await parseAction(req);
   if (result instanceof Response) return result;
@@ -79,6 +95,11 @@ async function handleRequest(supabase: SupabaseClient, userId: string, req: Requ
   // ─── update_tickets ───
   if (action === "update_tickets") {
     return handleUpdateTickets(supabase, body, userId);
+  }
+
+  // ─── create_ticket ───
+  if (action === "create_ticket") {
+    return handleCreateTicket(supabase, body, userId);
   }
 
   return errorResponse(`Unknown action: ${action}`, 400);
@@ -136,40 +157,128 @@ async function handleCreate(
   if (!party) return errorResponse("Party not found", 404);
 
   // Check partner permission
-  const permCheck = await requirePartnerPermission(supabase, party.partner_id, userId, ["PARTY_MANAGE", "EVENT_MANAGE"]);
+  const permCheck = await requirePartnerPermission(
+    supabase,
+    party.partner_id,
+    userId,
+    ["PARTY_MANAGE", "EVENT_MANAGE"],
+  );
   if (permCheck) return permCheck;
 
-  // ── Pre-validate ticket template references ──
+  // ── Pre-validate child inputs before writing the event ──
+  const directEntryGroups = body.entry_groups;
+  const directEntryGroupSourceIds: Array<string | null> = [];
+  const directEntryGroupSourceIdSet = new Set<string>();
+  if (directEntryGroups !== undefined) {
+    if (!Array.isArray(directEntryGroups)) {
+      return errorResponse("entry_groups must be an array", 400);
+    }
+    for (let i = 0; i < directEntryGroups.length; i++) {
+      const group = buildEntryGroupRecord(
+        directEntryGroups[i],
+        "__pending__",
+        i,
+      );
+      if (group instanceof Response) return group;
+      const sourceId = extractDirectEntryGroupSourceId(
+        directEntryGroups[i],
+        i,
+      );
+      if (sourceId instanceof Response) return sourceId;
+      directEntryGroupSourceIds.push(sourceId);
+      if (sourceId) {
+        if (directEntryGroupSourceIdSet.has(sourceId)) {
+          return errorResponse(
+            `entry_groups[${i}].source_entry_group_id must be unique`,
+            400,
+          );
+        }
+        directEntryGroupSourceIdSet.add(sourceId);
+      }
+    }
+  }
+
   const ticketInputs = body.tickets;
   if (ticketInputs !== undefined) {
     if (!Array.isArray(ticketInputs)) {
       return errorResponse("tickets must be an array", 400);
     }
+    let templateRefCount = 0;
     for (let i = 0; i < ticketInputs.length; i++) {
       const t = ticketInputs[i] as Record<string, unknown>;
       if (typeof t !== "object" || t === null || Array.isArray(t)) {
         return errorResponse(`tickets[${i}] must be an object`, 400);
       }
-      if (typeof t.template_id !== "string" || !t.template_id) {
+      if (typeof t.template_id === "string") templateRefCount++;
+    }
+    const usesTemplateRefs = templateRefCount === ticketInputs.length;
+    if (templateRefCount > 0 && !usesTemplateRefs) {
+      return errorResponse(
+        "tickets must use either template_id references or direct ticket objects, not both",
+        400,
+      );
+    }
+    for (let i = 0; i < ticketInputs.length; i++) {
+      const t = ticketInputs[i] as Record<string, unknown>;
+      if (usesTemplateRefs && typeof t.template_id !== "string") {
         return errorResponse(`tickets[${i}].template_id is required`, 400);
       }
-      if (typeof t.quantity !== "number" || t.quantity < 0) {
+      if (
+        usesTemplateRefs &&
+        (typeof t.quantity !== "number" || t.quantity < 0)
+      ) {
         return errorResponse(
           `tickets[${i}].quantity must be a non-negative number`,
           400,
         );
+      }
+      if (!usesTemplateRefs) {
+        const ticket = buildTicketRecord(t, "__pending__");
+        if (ticket instanceof Response) return ticket;
+        if (directEntryGroups !== undefined) {
+          const targetCheck = validateDirectTicketTargets(
+            t,
+            i,
+            directEntryGroupSourceIdSet,
+          );
+          if (targetCheck) return targetCheck;
+        }
       }
     }
   }
 
   // ── DB writes ──
 
+  const locationIdInput = event.location_id;
+  let locationId = party.location_id;
+  if (locationIdInput !== undefined && typeof locationIdInput !== "string") {
+    return errorResponse("event.location_id must be a string", 400);
+  }
+  if (typeof locationIdInput === "string" && locationIdInput) {
+    const { data: location, error: locationError } = await supabase
+      .from("locations")
+      .select("id, partner_id")
+      .eq("id", locationIdInput)
+      .maybeSingle();
+
+    if (locationError) return errorResponse("Failed to verify location", 500);
+    if (!location) return errorResponse("Location not found", 404);
+    if (location.partner_id !== party.partner_id) {
+      return errorResponse(
+        "Forbidden: location belongs to another partner",
+        403,
+      );
+    }
+    locationId = locationIdInput;
+  }
+
   // Build event record
   const eventRecord: Record<string, unknown> = {
     party_id: partyId,
-    location_id: party.location_id,
+    location_id: locationId,
   };
   for (const field of EVENT_FIELDS) {
+    if (field === "location_id") continue;
     if (event[field] !== undefined) {
       eventRecord[field] = event[field];
     }
@@ -191,112 +300,172 @@ async function handleCreate(
 
   const eventId = newEvent.id as string;
 
-  // Copy entry_group_templates → entry_groups
-  // Fix #317: ID를 포함해서 조회하여 target_entry_group_ids 재매핑에 사용
-  const { data: templates, error: tplError } = await supabase
-    .from("entry_group_templates")
-    .select(
-      "id, label, gender, birth_year_min, birth_year_max, required_verification_ids",
-    )
-    .eq("party_id", partyId);
+  const sourceToGroupMap = new Map<string, string>();
 
-  if (tplError) {
-    return errorResponse(
-      `Failed to fetch entry group templates: ${tplError.message}`,
-      500,
-    );
-  }
+  if (directEntryGroups !== undefined) {
+    const entryGroups: Record<string, unknown>[] = [];
+    for (let i = 0; i < directEntryGroups.length; i++) {
+      const group = buildEntryGroupRecord(directEntryGroups[i], eventId, i);
+      if (group instanceof Response) return group;
+      entryGroups.push(group);
+    }
 
-  // Map: template ID → new entry_group ID (for target_entry_group_ids remapping)
-  const templateToGroupMap = new Map<string, string>();
+    if (entryGroups.length > 0) {
+      const { data: insertedGroups, error: egError } = await supabase
+        .from("entry_groups")
+        .insert(entryGroups)
+        .select("id");
 
-  if (templates && templates.length > 0) {
-    const entryGroups = templates.map((t: Record<string, unknown>) => ({
-      event_id: eventId,
-      label: t.label ?? null,
-      gender: t.gender ?? null,
-      birth_year_min: t.birth_year_min ?? null,
-      birth_year_max: t.birth_year_max ?? null,
-      required_verification_ids: t.required_verification_ids ?? [],
-    }));
+      if (egError) {
+        return errorResponse(
+          `Failed to create entry groups: ${egError.message}`,
+          500,
+        );
+      }
+      if (!insertedGroups || insertedGroups.length !== entryGroups.length) {
+        return errorResponse("Failed to resolve created entry groups", 500);
+      }
+      for (let i = 0; i < insertedGroups.length; i++) {
+        const sourceId = directEntryGroupSourceIds[i];
+        if (sourceId) {
+          sourceToGroupMap.set(
+            sourceId,
+            (insertedGroups[i] as Record<string, unknown>).id as string,
+          );
+        }
+      }
+    }
+  } else {
+    // Copy entry_group_templates → entry_groups
+    // Fix #317: ID를 포함해서 조회하여 target_entry_group_ids 재매핑에 사용
+    const { data: templates, error: tplError } = await supabase
+      .from("entry_group_templates")
+      .select(
+        "id, label, gender, birth_year_min, birth_year_max, required_verification_ids",
+      )
+      .eq("party_id", partyId);
 
-    const { data: insertedGroups, error: egError } = await supabase
-      .from("entry_groups")
-      .insert(entryGroups)
-      .select("id");
-
-    if (egError) {
+    if (tplError) {
       return errorResponse(
-        `Failed to create entry groups: ${egError.message}`,
+        `Failed to fetch entry group templates: ${tplError.message}`,
         500,
       );
     }
 
-    // Build mapping from template ID to new entry_group ID (same order)
-    if (insertedGroups) {
-      for (let i = 0; i < templates.length; i++) {
-        templateToGroupMap.set(
-          templates[i].id as string,
-          (insertedGroups[i] as Record<string, unknown>).id as string,
+    if (templates && templates.length > 0) {
+      const entryGroups = templates.map((t: Record<string, unknown>) => ({
+        event_id: eventId,
+        label: t.label ?? null,
+        gender: t.gender ?? null,
+        birth_year_min: t.birth_year_min ?? null,
+        birth_year_max: t.birth_year_max ?? null,
+        required_verification_ids: t.required_verification_ids ?? [],
+      }));
+
+      const { data: insertedGroups, error: egError } = await supabase
+        .from("entry_groups")
+        .insert(entryGroups)
+        .select("id");
+
+      if (egError) {
+        return errorResponse(
+          `Failed to create entry groups: ${egError.message}`,
+          500,
         );
+      }
+
+      // Build mapping from template ID to new entry_group ID (same order)
+      if (insertedGroups) {
+        for (let i = 0; i < templates.length; i++) {
+          sourceToGroupMap.set(
+            templates[i].id as string,
+            (insertedGroups[i] as Record<string, unknown>).id as string,
+          );
+        }
       }
     }
   }
 
   // Create tickets from ticket_templates
   if (Array.isArray(ticketInputs) && ticketInputs.length > 0) {
-    // Fetch referenced ticket templates
-    const templateIds = ticketInputs.map((t: Record<string, unknown>) =>
-      t.template_id as string
+    const usesTemplateRefs = ticketInputs.every((t) =>
+      typeof (t as Record<string, unknown>).template_id === "string"
     );
-    const { data: ticketTemplates, error: ttError } = await supabase
-      .from("ticket_templates")
-      .select(
-        "id, name, description, price, target_entry_group_ids, required_verification_ids",
-      )
-      .eq("party_id", partyId)
-      .in("id", templateIds);
 
-    if (ttError) {
-      return errorResponse(
-        `Failed to fetch ticket templates: ${ttError.message}`,
-        500,
+    let tickets: Record<string, unknown>[];
+    if (usesTemplateRefs) {
+      // Fetch referenced ticket templates
+      const templateIds = ticketInputs.map((t: Record<string, unknown>) =>
+        t.template_id as string
       );
-    }
+      const { data: ticketTemplates, error: ttError } = await supabase
+        .from("ticket_templates")
+        .select(
+          "id, name, description, price, target_entry_group_ids, required_verification_ids",
+        )
+        .eq("party_id", partyId)
+        .in("id", templateIds);
 
-    const templateMap = new Map(
-      (ticketTemplates ?? []).map((t: Record<string, unknown>) => [t.id, t]),
-    );
-
-    // Verify all template_ids exist
-    for (let i = 0; i < ticketInputs.length; i++) {
-      const input = ticketInputs[i] as Record<string, unknown>;
-      if (!templateMap.has(input.template_id)) {
+      if (ttError) {
         return errorResponse(
-          `tickets[${i}].template_id not found in party templates`,
-          400,
+          `Failed to fetch ticket templates: ${ttError.message}`,
+          500,
         );
       }
+
+      const templateMap = new Map(
+        (ticketTemplates ?? []).map((t: Record<string, unknown>) => [t.id, t]),
+      );
+
+      // Verify all template_ids exist
+      for (let i = 0; i < ticketInputs.length; i++) {
+        const input = ticketInputs[i] as Record<string, unknown>;
+        if (!templateMap.has(input.template_id)) {
+          return errorResponse(
+            `tickets[${i}].template_id not found in party templates`,
+            400,
+          );
+        }
+      }
+
+      tickets = ticketInputs.map((input: Record<string, unknown>) => {
+        const tpl = templateMap.get(input.template_id) as Record<
+          string,
+          unknown
+        >;
+        // Fix #317: target_entry_group_ids를 새 entry_group ID로 재매핑
+        const originalTargetIds = (tpl.target_entry_group_ids as string[]) ??
+          [];
+        const remappedTargetIds = originalTargetIds
+          .map((id: string) => sourceToGroupMap.get(id))
+          .filter((id): id is string => id !== undefined);
+
+        return {
+          event_id: eventId,
+          name: tpl.name,
+          description: tpl.description ?? null,
+          price: tpl.price ?? 0,
+          quantity: input.quantity,
+          target_entry_group_ids: remappedTargetIds,
+          required_verification_ids: tpl.required_verification_ids ?? [],
+        };
+      });
+    } else {
+      tickets = [];
+      for (let i = 0; i < ticketInputs.length; i++) {
+        const input = ticketInputs[i] as Record<string, unknown>;
+        const ticket = buildTicketRecord(input, eventId);
+        if (ticket instanceof Response) {
+          return ticket;
+        }
+        if (directEntryGroups !== undefined) {
+          ticket.target_entry_group_ids = (
+            ticket.target_entry_group_ids as string[]
+          ).map((id) => sourceToGroupMap.get(id) ?? id);
+        }
+        tickets.push(ticket);
+      }
     }
-
-    const tickets = ticketInputs.map((input: Record<string, unknown>) => {
-      const tpl = templateMap.get(input.template_id) as Record<string, unknown>;
-      // Fix #317: target_entry_group_ids를 새 entry_group ID로 재매핑
-      const originalTargetIds = (tpl.target_entry_group_ids as string[]) ?? [];
-      const remappedTargetIds = originalTargetIds
-        .map((id: string) => templateToGroupMap.get(id))
-        .filter((id): id is string => id !== undefined);
-
-      return {
-        event_id: eventId,
-        name: tpl.name,
-        description: tpl.description ?? null,
-        price: tpl.price ?? 0,
-        quantity: input.quantity,
-        target_entry_group_ids: remappedTargetIds,
-        required_verification_ids: tpl.required_verification_ids ?? [],
-      };
-    });
 
     const { error: ticketInsertError } = await supabase
       .from("tickets")
@@ -311,6 +480,43 @@ async function handleCreate(
   }
 
   return successResponse({ success: true, event_id: eventId });
+}
+
+async function handleCreateTicket(
+  supabase: SupabaseClient,
+  body: Record<string, unknown>,
+  userId: string,
+): Promise<Response> {
+  const ticketData = body.ticket;
+  if (
+    typeof ticketData !== "object" || ticketData === null ||
+    Array.isArray(ticketData)
+  ) {
+    return errorResponse("Missing or invalid ticket object", 400);
+  }
+  const input = ticketData as Record<string, unknown>;
+  const eventId = input.event_id;
+  if (typeof eventId !== "string" || !eventId) {
+    return errorResponse("Missing ticket.event_id", 400);
+  }
+
+  const eventCheck = await verifyEventPermission(supabase, eventId, userId);
+  if (eventCheck instanceof Response) return eventCheck;
+
+  const ticket = buildTicketRecord(input, eventId);
+  if (ticket instanceof Response) return ticket;
+
+  const { data, error } = await supabase
+    .from("tickets")
+    .insert(ticket)
+    .select("id")
+    .single();
+
+  if (error) {
+    return errorResponse(`Failed to create ticket: ${error.message}`, 500);
+  }
+
+  return successResponse({ success: true, ticket_id: data.id });
 }
 
 async function handleUpdate(
@@ -333,11 +539,16 @@ async function handleUpdate(
   if (fetchError) return errorResponse("Failed to load event", 500);
   if (!oldEvent) return errorResponse("Event not found", 404);
 
-  const partnerId = (oldEvent.parties as Record<string, unknown>)
-    .partner_id as string;
+  const partnerId = extractRelatedPartnerId(oldEvent);
+  if (!partnerId) return errorResponse("Failed to resolve partner", 500);
 
   // Check partner permission
-  const permCheck = await requirePartnerPermission(supabase, partnerId, userId, ["PARTY_MANAGE", "EVENT_MANAGE"]);
+  const permCheck = await requirePartnerPermission(
+    supabase,
+    partnerId,
+    userId,
+    ["PARTY_MANAGE", "EVENT_MANAGE"],
+  );
   if (permCheck) return permCheck;
 
   // Build update fields
@@ -359,6 +570,27 @@ async function handleUpdate(
 
   if (Object.keys(updates).length === 0) {
     return errorResponse("No fields to update", 400);
+  }
+
+  if (updates.location_id !== undefined) {
+    if (typeof updates.location_id !== "string" || !updates.location_id) {
+      return errorResponse("event.location_id must be a string", 400);
+    }
+
+    const { data: location, error: locationError } = await supabase
+      .from("locations")
+      .select("id, partner_id")
+      .eq("id", updates.location_id)
+      .maybeSingle();
+
+    if (locationError) return errorResponse("Failed to verify location", 500);
+    if (!location) return errorResponse("Location not found", 404);
+    if (location.partner_id !== partnerId) {
+      return errorResponse(
+        "Forbidden: location belongs to another partner",
+        403,
+      );
+    }
   }
 
   // Validate time fields if provided
@@ -394,9 +626,8 @@ async function handleUpdate(
   // Constraint: reason-enriched notification body + SMS fan-out deferred
   // (tracked separately — notification-worker extension needed).
   const reason = typeof body.reason === "string" ? body.reason.trim() : null;
-  const isScheduleChanged =
-    (updates.start_time !== undefined &&
-      updates.start_time !== (oldEvent as Record<string, unknown>).start_time) ||
+  const isScheduleChanged = (updates.start_time !== undefined &&
+    updates.start_time !== (oldEvent as Record<string, unknown>).start_time) ||
     (updates.end_time !== undefined &&
       updates.end_time !== (oldEvent as Record<string, unknown>).end_time);
 
@@ -406,9 +637,11 @@ async function handleUpdate(
       changed_by: userId,
       reason,
       previous_start_time: (oldEvent as Record<string, unknown>).start_time,
-      new_start_time: updates.start_time ?? (oldEvent as Record<string, unknown>).start_time,
+      new_start_time: updates.start_time ??
+        (oldEvent as Record<string, unknown>).start_time,
       previous_end_time: (oldEvent as Record<string, unknown>).end_time,
-      new_end_time: updates.end_time ?? (oldEvent as Record<string, unknown>).end_time,
+      new_end_time: updates.end_time ??
+        (oldEvent as Record<string, unknown>).end_time,
     };
     // Use service_role client — event_change_logs has no INSERT RLS for users.
     const { error: logError } = await supabase
@@ -469,11 +702,16 @@ async function handleUpdateStatus(
     );
   }
 
-  const partnerId = (event.parties as Record<string, unknown>)
-    .partner_id as string;
+  const partnerId = extractRelatedPartnerId(event);
+  if (!partnerId) return errorResponse("Failed to resolve partner", 500);
 
   // Check partner permission
-  const permCheck = await requirePartnerPermission(supabase, partnerId, userId, ["PARTY_MANAGE", "EVENT_MANAGE"]);
+  const permCheck = await requirePartnerPermission(
+    supabase,
+    partnerId,
+    userId,
+    ["PARTY_MANAGE", "EVENT_MANAGE"],
+  );
   if (permCheck) return permCheck;
 
   const { error: updateError } = await supabase
@@ -539,11 +777,16 @@ async function handleUpdateTickets(
   if (fetchError) return errorResponse("Failed to load event", 500);
   if (!event) return errorResponse("Event not found", 404);
 
-  const partnerId = (event.parties as Record<string, unknown>)
-    .partner_id as string;
+  const partnerId = extractRelatedPartnerId(event);
+  if (!partnerId) return errorResponse("Failed to resolve partner", 500);
 
   // Check partner permission
-  const permCheck = await requirePartnerPermission(supabase, partnerId, userId, ["PARTY_MANAGE", "EVENT_MANAGE"]);
+  const permCheck = await requirePartnerPermission(
+    supabase,
+    partnerId,
+    userId,
+    ["PARTY_MANAGE", "EVENT_MANAGE"],
+  );
   if (permCheck) return permCheck;
 
   // Fetch existing tickets to validate sold_count
@@ -617,3 +860,175 @@ async function handleUpdateTickets(
 }
 
 // ─── Helpers ───
+
+function extractRelatedPartnerId(row: { parties?: unknown }): string | null {
+  const relation = row.parties;
+  const party = Array.isArray(relation) ? relation[0] : relation;
+  if (typeof party !== "object" || party === null) return null;
+
+  const partnerId = (party as Record<string, unknown>).partner_id;
+  return typeof partnerId === "string" && partnerId ? partnerId : null;
+}
+
+async function verifyEventPermission(
+  supabase: SupabaseClient,
+  eventId: string,
+  userId: string,
+): Promise<true | Response> {
+  const { data: event, error: fetchError } = await supabase
+    .from("events")
+    .select("id, party_id, parties!inner(partner_id)")
+    .eq("id", eventId)
+    .maybeSingle();
+
+  if (fetchError) return errorResponse("Failed to load event", 500);
+  if (!event) return errorResponse("Event not found", 404);
+
+  const partnerId = extractRelatedPartnerId(event);
+  if (!partnerId) return errorResponse("Failed to resolve partner", 500);
+  const permCheck = await requirePartnerPermission(
+    supabase,
+    partnerId,
+    userId,
+    [
+      "PARTY_MANAGE",
+      "EVENT_MANAGE",
+    ],
+  );
+  if (permCheck) return permCheck;
+  return true;
+}
+
+function extractDirectEntryGroupSourceId(
+  input: unknown,
+  index: number,
+): string | null | Response {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return errorResponse(`entry_groups[${index}] must be an object`, 400);
+  }
+  const group = input as Record<string, unknown>;
+  const sourceId = [
+    group.source_entry_group_id,
+    group.source_template_id,
+    group.template_id,
+    group.id,
+  ].find((value) => value !== undefined && value !== null && value !== "");
+  if (sourceId === undefined) {
+    return null;
+  }
+  if (typeof sourceId !== "string") {
+    return errorResponse(
+      `entry_groups[${index}].source_entry_group_id must be a string`,
+      400,
+    );
+  }
+  return sourceId;
+}
+
+function validateDirectTicketTargets(
+  input: Record<string, unknown>,
+  ticketIndex: number,
+  sourceIds: Set<string>,
+): Response | null {
+  const targetIds = input.target_entry_group_ids;
+  if (targetIds === undefined || targetIds === null) return null;
+  if (!Array.isArray(targetIds)) {
+    return errorResponse(
+      `tickets[${ticketIndex}].target_entry_group_ids must be an array`,
+      400,
+    );
+  }
+  for (let i = 0; i < targetIds.length; i++) {
+    const targetId = targetIds[i];
+    if (typeof targetId !== "string" || !targetId) {
+      return errorResponse(
+        `tickets[${ticketIndex}].target_entry_group_ids[${i}] must be a string`,
+        400,
+      );
+    }
+    if (!sourceIds.has(targetId)) {
+      return errorResponse(
+        `tickets[${ticketIndex}].target_entry_group_ids[${i}] must reference entry_groups[].source_entry_group_id`,
+        400,
+      );
+    }
+  }
+  return null;
+}
+
+function buildEntryGroupRecord(
+  input: unknown,
+  eventId: string,
+  index: number,
+): Record<string, unknown> | Response {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return errorResponse(`entry_groups[${index}] must be an object`, 400);
+  }
+
+  const group = input as Record<string, unknown>;
+  if (
+    group.gender !== undefined &&
+    group.gender !== null &&
+    (typeof group.gender !== "string" || !_VALID_GENDERS.includes(group.gender))
+  ) {
+    return errorResponse(
+      `entry_groups[${index}].gender must be one of: ${
+        _VALID_GENDERS.join(", ")
+      }`,
+      400,
+    );
+  }
+
+  return {
+    event_id: eventId,
+    label: group.label ?? null,
+    gender: group.gender ?? null,
+    birth_year_min: group.birth_year_min ?? null,
+    birth_year_max: group.birth_year_max ?? null,
+    required_verification_ids: group.required_verification_ids ?? [],
+  };
+}
+
+function buildTicketRecord(
+  input: Record<string, unknown>,
+  eventId: string,
+): Record<string, unknown> | Response {
+  if (typeof input.name !== "string" || !input.name.trim()) {
+    return errorResponse("Missing ticket name", 400);
+  }
+  if (
+    input.price !== undefined &&
+    (typeof input.price !== "number" || input.price < 0)
+  ) {
+    return errorResponse("ticket.price must be >= 0", 400);
+  }
+  if (
+    input.quantity !== undefined &&
+    (typeof input.quantity !== "number" || input.quantity < 0)
+  ) {
+    return errorResponse("ticket.quantity must be a non-negative number", 400);
+  }
+  const targetIds = input.target_entry_group_ids ?? [];
+  if (!Array.isArray(targetIds)) {
+    return errorResponse("ticket.target_entry_group_ids must be an array", 400);
+  }
+  for (let i = 0; i < targetIds.length; i++) {
+    if (typeof targetIds[i] !== "string" || !targetIds[i]) {
+      return errorResponse(
+        `ticket.target_entry_group_ids[${i}] must be a string`,
+        400,
+      );
+    }
+  }
+
+  return {
+    event_id: eventId,
+    name: input.name,
+    description: input.description ?? null,
+    price: input.price ?? 0,
+    quantity: input.quantity ?? 0,
+    target_entry_group_ids: targetIds,
+    required_verification_ids: input.required_verification_ids ?? [],
+    status: input.status ?? "on_sale",
+  };
+}

--- a/supabase/functions/partner-manage-event/partner_manage_event_test.ts
+++ b/supabase/functions/partner-manage-event/partner_manage_event_test.ts
@@ -3,13 +3,13 @@ import {
   authenticatedJsonRequest,
   captureServeHandler,
   createFetchMock,
+  type FetchRoute,
   jsonRequest,
   jsonResponse,
   readJson,
   withEnv,
   withMockedFetch,
   withNoIntervals,
-  type FetchRoute,
 } from "../_test_utils/mock_http.ts";
 
 const TEST_USER_ID = "user-partner-owner";
@@ -55,7 +55,10 @@ function permRoute(hasPermission = true): FetchRoute {
     handler: () =>
       jsonResponse(
         hasPermission
-          ? { partner_id: TEST_PARTNER_ID, permissions: ["PARTNER_EDIT", "PARTY_MANAGE"] }
+          ? {
+            partner_id: TEST_PARTNER_ID,
+            permissions: ["PARTNER_EDIT", "PARTY_MANAGE"],
+          }
           : null,
       ),
   };
@@ -66,7 +69,10 @@ function permNoEventManageRoute(): FetchRoute {
     matcher: (req) =>
       req.url.includes("partner_member_permissions") && req.method === "GET",
     handler: () =>
-      jsonResponse({ partner_id: TEST_PARTNER_ID, permissions: ["PARTNER_EDIT"] }),
+      jsonResponse({
+        partner_id: TEST_PARTNER_ID,
+        permissions: ["PARTNER_EDIT"],
+      }),
   };
 }
 
@@ -81,7 +87,11 @@ function selectPartyRoute(
       req.url.includes("select=") &&
       req.method === "GET",
     handler: () =>
-      jsonResponse({ id: TEST_PARTY_ID, partner_id: partnerId, location_id: locationId }),
+      jsonResponse({
+        id: TEST_PARTY_ID,
+        partner_id: partnerId,
+        location_id: locationId,
+      }),
   };
 }
 
@@ -141,15 +151,66 @@ function updateEventRoute(): FetchRoute {
   };
 }
 
+function insertEventChangeLogRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/event_change_logs") && req.method === "POST",
+    handler: () => jsonResponse({ id: "change-log-001" }),
+  };
+}
+
+function selectLocationRoute(partnerId = TEST_PARTNER_ID): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/locations") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () => jsonResponse({ id: "loc-001", partner_id: partnerId }),
+  };
+}
+
+function selectLocationNotFoundRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/locations") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () => jsonResponse(null),
+  };
+}
+
+function selectLocationErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/locations") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () => jsonResponse({ message: "load error" }, { status: 500 }),
+  };
+}
+
 // Entry group templates/groups routes
 function selectEntryGroupTemplatesRoute(): FetchRoute {
   return {
     matcher: (req) =>
-      req.url.includes("/rest/v1/entry_group_templates") && req.method === "GET",
+      req.url.includes("/rest/v1/entry_group_templates") &&
+      req.method === "GET",
     handler: () =>
       jsonResponse([
-        { label: "남성", gender: "male", birth_year_min: 2000, birth_year_max: 2005, required_verification_ids: [] },
-        { label: "여성", gender: "female", birth_year_min: 2000, birth_year_max: 2005, required_verification_ids: [] },
+        {
+          label: "남성",
+          gender: "male",
+          birth_year_min: 2000,
+          birth_year_max: 2005,
+          required_verification_ids: [],
+        },
+        {
+          label: "여성",
+          gender: "female",
+          birth_year_min: 2000,
+          birth_year_max: 2005,
+          required_verification_ids: [],
+        },
       ]),
   };
 }
@@ -157,8 +218,18 @@ function selectEntryGroupTemplatesRoute(): FetchRoute {
 function selectEntryGroupTemplatesEmptyRoute(): FetchRoute {
   return {
     matcher: (req) =>
-      req.url.includes("/rest/v1/entry_group_templates") && req.method === "GET",
+      req.url.includes("/rest/v1/entry_group_templates") &&
+      req.method === "GET",
     handler: () => jsonResponse([]),
+  };
+}
+
+function selectEntryGroupTemplatesErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/entry_group_templates") &&
+      req.method === "GET",
+    handler: () => jsonResponse({ message: "load error" }, { status: 500 }),
   };
 }
 
@@ -166,7 +237,23 @@ function insertEntryGroupsRoute(): FetchRoute {
   return {
     matcher: (req) =>
       req.url.includes("/rest/v1/entry_groups") && req.method === "POST",
-    handler: () => jsonResponse([{ id: "eg-001" }, { id: "eg-002" }]),
+    handler: async (req) => {
+      const rows = await req.json();
+      const length = Array.isArray(rows) ? rows.length : 1;
+      return jsonResponse(
+        Array.from({ length }, (_, i) => ({
+          id: `eg-${String(i + 1).padStart(3, "0")}`,
+        })),
+      );
+    },
+  };
+}
+
+function insertEntryGroupsErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/entry_groups") && req.method === "POST",
+    handler: () => jsonResponse({ message: "insert error" }, { status: 500 }),
   };
 }
 
@@ -177,9 +264,39 @@ function selectTicketTemplatesRoute(): FetchRoute {
       req.url.includes("/rest/v1/ticket_templates") && req.method === "GET",
     handler: () =>
       jsonResponse([
-        { id: TEST_TEMPLATE_ID_1, name: "남성 티켓", description: null, price: 30000, target_entry_group_ids: [], required_verification_ids: [] },
-        { id: TEST_TEMPLATE_ID_2, name: "여성 티켓", description: null, price: 20000, target_entry_group_ids: [], required_verification_ids: [] },
+        {
+          id: TEST_TEMPLATE_ID_1,
+          name: "남성 티켓",
+          description: null,
+          price: 30000,
+          target_entry_group_ids: [],
+          required_verification_ids: [],
+        },
+        {
+          id: TEST_TEMPLATE_ID_2,
+          name: "여성 티켓",
+          description: null,
+          price: 20000,
+          target_entry_group_ids: [],
+          required_verification_ids: [],
+        },
       ]),
+  };
+}
+
+function selectTicketTemplatesEmptyRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") && req.method === "GET",
+    handler: () => jsonResponse([]),
+  };
+}
+
+function selectTicketTemplatesErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") && req.method === "GET",
+    handler: () => jsonResponse({ message: "load error" }, { status: 500 }),
   };
 }
 
@@ -188,6 +305,30 @@ function insertTicketsRoute(): FetchRoute {
     matcher: (req) =>
       req.url.includes("/rest/v1/tickets") && req.method === "POST",
     handler: () => jsonResponse([]),
+  };
+}
+
+function insertTicketsErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/tickets") && req.method === "POST",
+    handler: () => jsonResponse({ message: "insert error" }, { status: 500 }),
+  };
+}
+
+function insertSingleTicketRoute(id = TEST_TICKET_ID_1): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/tickets") && req.method === "POST",
+    handler: () => jsonResponse({ id }),
+  };
+}
+
+function insertSingleTicketErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/tickets") && req.method === "POST",
+    handler: () => jsonResponse({ message: "insert error" }, { status: 500 }),
   };
 }
 
@@ -200,8 +341,16 @@ function selectTicketsRoute(soldCount1 = 0, soldCount2 = 0): FetchRoute {
       req.method === "GET",
     handler: () =>
       jsonResponse([
-        { id: TEST_TICKET_ID_1, sold_count: soldCount1, event_id: TEST_EVENT_ID },
-        { id: TEST_TICKET_ID_2, sold_count: soldCount2, event_id: TEST_EVENT_ID },
+        {
+          id: TEST_TICKET_ID_1,
+          sold_count: soldCount1,
+          event_id: TEST_EVENT_ID,
+        },
+        {
+          id: TEST_TICKET_ID_2,
+          sold_count: soldCount2,
+          event_id: TEST_EVENT_ID,
+        },
       ]),
   };
 }
@@ -221,7 +370,9 @@ Deno.test({
   fn: async () => {
     await withEnv(ENV, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
         const req = new Request("http://localhost", { method: "OPTIONS" });
         const res = await handler(req);
         assertEquals(res.status, 200);
@@ -238,7 +389,9 @@ Deno.test({
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
-          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
           const req = new Request("http://localhost", {
             method: "GET",
             headers: { Authorization: "Bearer test-token" },
@@ -254,7 +407,9 @@ Deno.test({
 Deno.test({
   name: "Missing auth returns 401",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authFailRoute()]);
 
     await withEnv(ENV, async () => {
@@ -270,7 +425,9 @@ Deno.test({
 Deno.test({
   name: "Invalid JSON body returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -293,7 +450,9 @@ Deno.test({
 Deno.test({
   name: "Missing action returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -302,7 +461,7 @@ Deno.test({
         const res = await handler(req);
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing or invalid \"action\" field");
+        assertEquals(body.error, 'Missing or invalid "action" field');
       });
     });
   },
@@ -311,12 +470,16 @@ Deno.test({
 Deno.test({
   name: "Unknown action returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest("http://localhost", { action: "delete" });
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "delete",
+        });
         const res = await handler(req);
         assertEquals(res.status, 400);
         const body = await readJson(res);
@@ -331,7 +494,9 @@ Deno.test({
 Deno.test({
   name: "create: event + entry_groups + tickets from templates",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyRoute(),
@@ -348,7 +513,11 @@ Deno.test({
         const req = authenticatedJsonRequest("http://localhost", {
           action: "create",
           party_id: TEST_PARTY_ID,
-          event: { start_time: FUTURE_START, end_time: FUTURE_END, max_participants: 20 },
+          event: {
+            start_time: FUTURE_START,
+            end_time: FUTURE_END,
+            max_participants: 20,
+          },
           tickets: [
             { template_id: TEST_TEMPLATE_ID_1, quantity: 10 },
             { template_id: TEST_TEMPLATE_ID_2, quantity: 10 },
@@ -367,7 +536,9 @@ Deno.test({
 Deno.test({
   name: "create: event with vote_start_at/vote_end_at",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyRoute(),
@@ -403,7 +574,9 @@ Deno.test({
 Deno.test({
   name: "create: past start_time returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyRoute(),
@@ -429,7 +602,9 @@ Deno.test({
 Deno.test({
   name: "create: start_time >= end_time returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -451,7 +626,9 @@ Deno.test({
 Deno.test({
   name: "create: missing party_id returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -472,7 +649,9 @@ Deno.test({
 Deno.test({
   name: "create: missing event object returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -491,7 +670,9 @@ Deno.test({
 Deno.test({
   name: "create: no partner membership returns 403",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyRoute(),
@@ -515,7 +696,9 @@ Deno.test({
 Deno.test({
   name: "create: no PARTY_MANAGE/EVENT_MANAGE permission returns 403",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyRoute(),
@@ -541,7 +724,9 @@ Deno.test({
 Deno.test({
   name: "update: start_time change",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectEventRoute(),
@@ -569,7 +754,9 @@ Deno.test({
 Deno.test({
   name: "update: missing event_id returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -590,7 +777,9 @@ Deno.test({
 Deno.test({
   name: "update: event not found returns 404",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectEventNotFoundRoute(),
@@ -613,7 +802,9 @@ Deno.test({
 Deno.test({
   name: "update: other partner's event returns 403",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectEventRoute("scheduled", "other-partner"),
@@ -637,7 +828,9 @@ Deno.test({
 Deno.test({
   name: "update: no fields to update returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectEventRoute(),
@@ -665,7 +858,9 @@ Deno.test({
 Deno.test({
   name: "update_status: scheduled → cancelled",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectEventRoute("scheduled"),
@@ -692,7 +887,9 @@ Deno.test({
 Deno.test({
   name: "update_status: completed → 400 (system only)",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -705,7 +902,10 @@ Deno.test({
         const res = await handler(req);
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Cannot set status to completed — system only");
+        assertEquals(
+          body.error,
+          "Cannot set status to completed — system only",
+        );
       });
     });
   },
@@ -714,7 +914,9 @@ Deno.test({
 Deno.test({
   name: "update_status: cancelled event cannot change status",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectEventRoute("cancelled"),
@@ -740,7 +942,9 @@ Deno.test({
 Deno.test({
   name: "update_status: missing event_id returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -759,7 +963,9 @@ Deno.test({
 Deno.test({
   name: "update_status: event not found returns 404",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectEventNotFoundRoute(),
@@ -782,7 +988,9 @@ Deno.test({
 Deno.test({
   name: "update_status: other partner's event returns 403",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectEventRoute("scheduled", "other-partner"),
@@ -808,7 +1016,9 @@ Deno.test({
 Deno.test({
   name: "update_tickets: price change",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectEventRoute(),
@@ -838,7 +1048,9 @@ Deno.test({
 Deno.test({
   name: "update_tickets: quantity below sold_count returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectEventRoute(),
@@ -867,7 +1079,9 @@ Deno.test({
 Deno.test({
   name: "update_tickets: missing event_id returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -888,7 +1102,9 @@ Deno.test({
 Deno.test({
   name: "update_tickets: empty tickets array returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -908,7 +1124,9 @@ Deno.test({
 Deno.test({
   name: "update_tickets: other partner's event returns 403",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectEventRoute("scheduled", "other-partner"),
@@ -924,6 +1142,581 @@ Deno.test({
         });
         const res = await handler(req);
         assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: accepts direct entry_groups and tickets",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+      insertEventRoute(),
+      insertEntryGroupsRoute(),
+      insertTicketsRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create",
+          party_id: TEST_PARTY_ID,
+          event: {
+            start_time: FUTURE_START,
+            end_time: FUTURE_END,
+            title: "Direct event",
+          },
+          entry_groups: [
+            {
+              label: "전체",
+              gender: null,
+              required_verification_ids: [],
+            },
+          ],
+          tickets: [
+            {
+              name: "일반 티켓",
+              price: 30000,
+              quantity: 20,
+              target_entry_group_ids: [],
+              required_verification_ids: [],
+            },
+          ],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.event_id, TEST_EVENT_ID);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: remaps direct ticket target ids to inserted entry group ids",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock, calls } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+      insertEventRoute(),
+      insertEntryGroupsRoute(),
+      insertTicketsRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create",
+          party_id: TEST_PARTY_ID,
+          event: {
+            start_time: FUTURE_START,
+            end_time: FUTURE_END,
+            title: "Direct event",
+          },
+          entry_groups: [
+            {
+              source_entry_group_id: "egt_male",
+              label: "남성",
+              gender: "male",
+              required_verification_ids: [],
+            },
+            {
+              source_entry_group_id: "egt_female",
+              label: "여성",
+              gender: "female",
+              required_verification_ids: [],
+            },
+          ],
+          tickets: [
+            {
+              name: "여성 티켓",
+              price: 30000,
+              quantity: 20,
+              target_entry_group_ids: ["egt_female"],
+              required_verification_ids: [],
+            },
+          ],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+      });
+    });
+
+    const entryGroupInsert = calls.find((c) =>
+      c.url.includes("/rest/v1/entry_groups") && c.method === "POST"
+    );
+    const ticketInsert = calls.find((c) =>
+      c.url.includes("/rest/v1/tickets") && c.method === "POST"
+    );
+    const insertedEntryGroups = JSON.parse(entryGroupInsert?.body ?? "[]");
+    const insertedTickets = JSON.parse(ticketInsert?.body ?? "[]");
+    assertEquals(insertedEntryGroups[1].source_entry_group_id, undefined);
+    assertEquals(insertedTickets[0].target_entry_group_ids, ["eg-002"]);
+  },
+});
+
+Deno.test({
+  name:
+    "create: rejects direct ticket target ids without matching entry group source",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock, calls } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create",
+          party_id: TEST_PARTY_ID,
+          event: {
+            start_time: FUTURE_START,
+            end_time: FUTURE_END,
+            title: "Direct event",
+          },
+          entry_groups: [
+            {
+              label: "전체",
+              required_verification_ids: [],
+            },
+          ],
+          tickets: [
+            {
+              name: "조건 티켓",
+              price: 30000,
+              quantity: 20,
+              target_entry_group_ids: ["egt_missing"],
+              required_verification_ids: [],
+            },
+          ],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(
+          body.error,
+          "tickets[0].target_entry_group_ids[0] must reference entry_groups[].source_entry_group_id",
+        );
+      });
+    });
+
+    const eventInserts = calls.filter((c) =>
+      c.url.includes("/rest/v1/events") && c.method === "POST"
+    );
+    assertEquals(eventInserts.length, 0);
+  },
+});
+
+Deno.test({
+  name: "create_ticket: inserts a ticket for permitted event",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectEventRoute(),
+      permRoute(),
+      insertSingleTicketRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create_ticket",
+          ticket: {
+            event_id: TEST_EVENT_ID,
+            name: "추가 티켓",
+            price: 10000,
+            quantity: 5,
+          },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.ticket_id, TEST_TICKET_ID_1);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: rejects invalid direct child inputs before event insert",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+    ]);
+
+    const baseBody = {
+      action: "create",
+      party_id: TEST_PARTY_ID,
+      event: { start_time: FUTURE_START, end_time: FUTURE_END },
+    };
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const cases: Array<Record<string, unknown>> = [
+          { ...baseBody, entry_groups: "invalid" },
+          { ...baseBody, entry_groups: ["invalid"] },
+          { ...baseBody, entry_groups: [{ gender: "unknown" }] },
+          { ...baseBody, tickets: "invalid" },
+          { ...baseBody, tickets: ["invalid"] },
+          {
+            ...baseBody,
+            tickets: [
+              { template_id: TEST_TEMPLATE_ID_1, quantity: 1 },
+              { name: "직접 티켓", quantity: 1 },
+            ],
+          },
+          {
+            ...baseBody,
+            tickets: [{ template_id: TEST_TEMPLATE_ID_1, quantity: -1 }],
+          },
+          { ...baseBody, tickets: [{ quantity: 1 }] },
+          { ...baseBody, tickets: [{ name: "티켓", price: -1 }] },
+          { ...baseBody, tickets: [{ name: "티켓", quantity: -1 }] },
+          {
+            ...baseBody,
+            event: {
+              start_time: FUTURE_START,
+              end_time: FUTURE_END,
+              location_id: 123,
+            },
+          },
+        ];
+
+        for (const body of cases) {
+          const res = await handler(
+            authenticatedJsonRequest("http://localhost", body),
+          );
+          assertEquals(res.status, 400);
+        }
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: handles location and child insert/fetch failures",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    const bodyWithLocation = {
+      action: "create",
+      party_id: TEST_PARTY_ID,
+      event: {
+        start_time: FUTURE_START,
+        end_time: FUTURE_END,
+        location_id: "loc-001",
+      },
+    };
+
+    await withEnv(ENV, async () => {
+      let fetchMock = createFetchMock([
+        authRoute(),
+        selectPartyRoute(),
+        permRoute(),
+        selectLocationErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", bodyWithLocation),
+        );
+        assertEquals(res.status, 500);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectPartyRoute(),
+        permRoute(),
+        selectLocationNotFoundRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", bodyWithLocation),
+        );
+        assertEquals(res.status, 404);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectPartyRoute(),
+        permRoute(),
+        selectLocationRoute("other-partner"),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", bodyWithLocation),
+        );
+        assertEquals(res.status, 403);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectPartyRoute(),
+        permRoute(),
+        insertEventRoute(),
+        insertEntryGroupsErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create",
+            party_id: TEST_PARTY_ID,
+            event: { start_time: FUTURE_START, end_time: FUTURE_END },
+            entry_groups: [{ label: "전체" }],
+          }),
+        );
+        assertEquals(res.status, 500);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectPartyRoute(),
+        permRoute(),
+        insertEventRoute(),
+        selectEntryGroupTemplatesErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create",
+            party_id: TEST_PARTY_ID,
+            event: { start_time: FUTURE_START, end_time: FUTURE_END },
+          }),
+        );
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: handles ticket template and ticket insert failures",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const baseBody = {
+      action: "create",
+      party_id: TEST_PARTY_ID,
+      event: { start_time: FUTURE_START, end_time: FUTURE_END },
+      tickets: [{ template_id: TEST_TEMPLATE_ID_1, quantity: 1 }],
+    };
+
+    await withEnv(ENV, async () => {
+      let fetchMock = createFetchMock([
+        authRoute(),
+        selectPartyRoute(),
+        permRoute(),
+        insertEventRoute(),
+        selectEntryGroupTemplatesEmptyRoute(),
+        selectTicketTemplatesErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", baseBody),
+        );
+        assertEquals(res.status, 500);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectPartyRoute(),
+        permRoute(),
+        insertEventRoute(),
+        selectEntryGroupTemplatesEmptyRoute(),
+        selectTicketTemplatesEmptyRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", baseBody),
+        );
+        assertEquals(res.status, 400);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectPartyRoute(),
+        permRoute(),
+        insertEventRoute(),
+        selectEntryGroupTemplatesEmptyRoute(),
+        selectTicketTemplatesRoute(),
+        insertTicketsErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", baseBody),
+        );
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create_ticket: rejects invalid payloads and handles insert failure",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    await withEnv(ENV, async () => {
+      let fetchMock = createFetchMock([authRoute()]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        let res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create_ticket",
+            ticket: null,
+          }),
+        );
+        assertEquals(res.status, 400);
+
+        res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create_ticket",
+            ticket: { name: "티켓", quantity: 1 },
+          }),
+        );
+        assertEquals(res.status, 400);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectEventRoute(),
+        permRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create_ticket",
+            ticket: { event_id: TEST_EVENT_ID, quantity: 1 },
+          }),
+        );
+        assertEquals(res.status, 400);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectEventRoute(),
+        permRoute(),
+        insertSingleTicketErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create_ticket",
+            ticket: {
+              event_id: TEST_EVENT_ID,
+              name: "티켓",
+              quantity: 1,
+            },
+          }),
+        );
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "update: validates location_id and writes change log when reason is set",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    await withEnv(ENV, async () => {
+      let fetchMock = createFetchMock([
+        authRoute(),
+        selectEventRoute(),
+        permRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            event_id: TEST_EVENT_ID,
+            event: { location_id: 123 },
+          }),
+        );
+        assertEquals(res.status, 400);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectEventRoute(),
+        permRoute(),
+        selectLocationNotFoundRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            event_id: TEST_EVENT_ID,
+            event: { location_id: "loc-001" },
+          }),
+        );
+        assertEquals(res.status, 404);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectEventRoute(),
+        permRoute(),
+        selectLocationRoute("other-partner"),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            event_id: TEST_EVENT_ID,
+            event: { location_id: "loc-001" },
+          }),
+        );
+        assertEquals(res.status, 403);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectEventRoute(),
+        permRoute(),
+        updateEventRoute(),
+        insertEventChangeLogRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const newStart = new Date(Date.now() + 86400000 * 4).toISOString();
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            event_id: TEST_EVENT_ID,
+            event: { start_time: newStart },
+            reason: "일정 변경",
+          }),
+        );
+        assertEquals(res.status, 200);
       });
     });
   },

--- a/supabase/functions/partner-manage-party/_handlers/location.ts
+++ b/supabase/functions/partner-manage-party/_handlers/location.ts
@@ -1,0 +1,121 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  errorResponse,
+  successResponse,
+} from "../../_shared/response_utils.ts";
+import { requirePartnerPermission } from "../../_shared/partner_permissions.ts";
+import { LOCATION_FIELDS } from "../_lib/constants.ts";
+
+export async function handleCreateLocation(
+  body: Record<string, unknown>,
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<Response> {
+  const partnerId = body.partner_id;
+  if (typeof partnerId !== "string" || !partnerId) {
+    return errorResponse("Missing partner_id", 400);
+  }
+
+  const locationData = body.location;
+  if (
+    typeof locationData !== "object" || locationData === null ||
+    Array.isArray(locationData)
+  ) {
+    return errorResponse("Missing or invalid location object", 400);
+  }
+  const location = locationData as Record<string, unknown>;
+
+  if (typeof location.name !== "string" || !location.name.trim()) {
+    return errorResponse("Missing location name", 400);
+  }
+  if (typeof location.address !== "string" || !location.address.trim()) {
+    return errorResponse("Missing location address", 400);
+  }
+
+  const permCheck = await requirePartnerPermission(
+    supabase,
+    partnerId,
+    userId,
+    [
+      "PARTY_MANAGE",
+    ],
+  );
+  if (permCheck) return permCheck;
+
+  const record: Record<string, unknown> = { partner_id: partnerId };
+  for (const field of LOCATION_FIELDS) {
+    if (location[field] !== undefined) record[field] = location[field];
+  }
+
+  const { data, error } = await supabase
+    .from("locations")
+    .insert(record)
+    .select("id")
+    .single();
+
+  if (error) {
+    return errorResponse(`Failed to create location: ${error.message}`, 500);
+  }
+
+  return successResponse({ success: true, location_id: data.id });
+}
+
+export async function handleUpdateLocation(
+  body: Record<string, unknown>,
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<Response> {
+  const locationId = body.location_id;
+  if (typeof locationId !== "string" || !locationId) {
+    return errorResponse("Missing location_id", 400);
+  }
+
+  const locationData = body.location;
+  if (
+    typeof locationData !== "object" || locationData === null ||
+    Array.isArray(locationData)
+  ) {
+    return errorResponse("Missing or invalid location object", 400);
+  }
+  const location = locationData as Record<string, unknown>;
+
+  const { data: existing, error: fetchError } = await supabase
+    .from("locations")
+    .select("id, partner_id")
+    .eq("id", locationId)
+    .maybeSingle();
+
+  if (fetchError) return errorResponse("Failed to load location", 500);
+  if (!existing) return errorResponse("Location not found", 404);
+
+  const permCheck = await requirePartnerPermission(
+    supabase,
+    existing.partner_id,
+    userId,
+    ["PARTY_MANAGE"],
+  );
+  if (permCheck) return permCheck;
+
+  const updates: Record<string, unknown> = {};
+  for (const field of LOCATION_FIELDS) {
+    if (location[field] !== undefined) updates[field] = location[field];
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return errorResponse("No fields to update", 400);
+  }
+
+  const { error: updateError } = await supabase
+    .from("locations")
+    .update(updates)
+    .eq("id", locationId);
+
+  if (updateError) {
+    return errorResponse(
+      `Failed to update location: ${updateError.message}`,
+      500,
+    );
+  }
+
+  return successResponse({ success: true });
+}

--- a/supabase/functions/partner-manage-party/_handlers/ticket_template.ts
+++ b/supabase/functions/partner-manage-party/_handlers/ticket_template.ts
@@ -1,0 +1,199 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  errorResponse,
+  successResponse,
+} from "../../_shared/response_utils.ts";
+import { requirePartnerPermission } from "../../_shared/partner_permissions.ts";
+import { validateTicketTemplates } from "../_lib/validators.ts";
+
+const TICKET_TEMPLATE_FIELDS = [
+  "name",
+  "description",
+  "price",
+  "quantity",
+  "target_entry_group_ids",
+  "required_verification_ids",
+] as const;
+
+export async function handleCreateTicketTemplate(
+  body: Record<string, unknown>,
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<Response> {
+  const templateData = body.ticket_template;
+  if (
+    typeof templateData !== "object" || templateData === null ||
+    Array.isArray(templateData)
+  ) {
+    return errorResponse("Missing or invalid ticket_template object", 400);
+  }
+  const template = templateData as Record<string, unknown>;
+
+  const partyId = template.party_id;
+  if (typeof partyId !== "string" || !partyId) {
+    return errorResponse("Missing ticket_template.party_id", 400);
+  }
+
+  const partyCheck = await verifyPartyPermission(supabase, partyId, userId);
+  if (partyCheck instanceof Response) return partyCheck;
+
+  const validationError = validateTicketTemplates([template]);
+  if (validationError) return validationError;
+
+  const record = buildTicketTemplateRecord(template, partyId);
+  const { data, error } = await supabase
+    .from("ticket_templates")
+    .insert(record)
+    .select("id")
+    .single();
+
+  if (error) {
+    return errorResponse(
+      `Failed to create ticket template: ${error.message}`,
+      500,
+    );
+  }
+
+  return successResponse({ success: true, ticket_template_id: data.id });
+}
+
+export async function handleUpdateTicketTemplate(
+  body: Record<string, unknown>,
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<Response> {
+  const templateId = body.ticket_template_id;
+  if (typeof templateId !== "string" || !templateId) {
+    return errorResponse("Missing ticket_template_id", 400);
+  }
+
+  const templateData = body.ticket_template;
+  if (
+    typeof templateData !== "object" || templateData === null ||
+    Array.isArray(templateData)
+  ) {
+    return errorResponse("Missing or invalid ticket_template object", 400);
+  }
+  const template = templateData as Record<string, unknown>;
+
+  const { data: existing, error: fetchError } = await supabase
+    .from("ticket_templates")
+    .select("id, party_id")
+    .eq("id", templateId)
+    .maybeSingle();
+
+  if (fetchError) return errorResponse("Failed to load ticket template", 500);
+  if (!existing) return errorResponse("Ticket template not found", 404);
+
+  const partyCheck = await verifyPartyPermission(
+    supabase,
+    existing.party_id,
+    userId,
+  );
+  if (partyCheck instanceof Response) return partyCheck;
+
+  const validationError = validateTicketTemplates([{
+    ...template,
+    party_id: existing.party_id,
+  }]);
+  if (validationError) return validationError;
+
+  const updates: Record<string, unknown> = {};
+  for (const field of TICKET_TEMPLATE_FIELDS) {
+    if (template[field] !== undefined) updates[field] = template[field];
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return errorResponse("No fields to update", 400);
+  }
+
+  const { error: updateError } = await supabase
+    .from("ticket_templates")
+    .update(updates)
+    .eq("id", templateId);
+
+  if (updateError) {
+    return errorResponse(
+      `Failed to update ticket template: ${updateError.message}`,
+      500,
+    );
+  }
+
+  return successResponse({ success: true });
+}
+
+export async function handleDeleteTicketTemplate(
+  body: Record<string, unknown>,
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<Response> {
+  const templateId = body.ticket_template_id;
+  if (typeof templateId !== "string" || !templateId) {
+    return errorResponse("Missing ticket_template_id", 400);
+  }
+
+  const { data: existing, error: fetchError } = await supabase
+    .from("ticket_templates")
+    .select("id, party_id")
+    .eq("id", templateId)
+    .maybeSingle();
+
+  if (fetchError) return errorResponse("Failed to load ticket template", 500);
+  if (!existing) return errorResponse("Ticket template not found", 404);
+
+  const partyCheck = await verifyPartyPermission(
+    supabase,
+    existing.party_id,
+    userId,
+  );
+  if (partyCheck instanceof Response) return partyCheck;
+
+  const { error: deleteError } = await supabase
+    .from("ticket_templates")
+    .delete()
+    .eq("id", templateId);
+
+  if (deleteError) {
+    return errorResponse(
+      `Failed to delete ticket template: ${deleteError.message}`,
+      500,
+    );
+  }
+
+  return successResponse({ success: true });
+}
+
+async function verifyPartyPermission(
+  supabase: SupabaseClient,
+  partyId: string,
+  userId: string,
+): Promise<true | Response> {
+  const { data: party, error } = await supabase
+    .from("parties")
+    .select("id, partner_id")
+    .eq("id", partyId)
+    .maybeSingle();
+
+  if (error) return errorResponse("Failed to load party", 500);
+  if (!party) return errorResponse("Party not found", 404);
+
+  const permCheck = await requirePartnerPermission(
+    supabase,
+    party.partner_id,
+    userId,
+    ["PARTY_MANAGE"],
+  );
+  if (permCheck) return permCheck;
+  return true;
+}
+
+function buildTicketTemplateRecord(
+  template: Record<string, unknown>,
+  partyId: string,
+): Record<string, unknown> {
+  const record: Record<string, unknown> = { party_id: partyId };
+  for (const field of TICKET_TEMPLATE_FIELDS) {
+    if (template[field] !== undefined) record[field] = template[field];
+  }
+  return record;
+}

--- a/supabase/functions/partner-manage-party/_handlers/update.ts
+++ b/supabase/functions/partner-manage-party/_handlers/update.ts
@@ -4,7 +4,11 @@ import {
   successResponse,
 } from "../../_shared/response_utils.ts";
 import { requirePartnerPermission } from "../../_shared/partner_permissions.ts";
-import { LOCATION_FIELDS, PARTY_FIELDS, VALID_STATUSES } from "../_lib/constants.ts";
+import {
+  LOCATION_FIELDS,
+  PARTY_FIELDS,
+  VALID_STATUSES,
+} from "../_lib/constants.ts";
 import { validateEntryGroupTemplates } from "../_lib/validators.ts";
 
 export async function handleUpdate(
@@ -56,7 +60,9 @@ export async function handleUpdate(
     if (partyUpdates.status !== undefined) {
       if (
         typeof partyUpdates.status !== "string" ||
-        !VALID_STATUSES.includes(partyUpdates.status as typeof VALID_STATUSES[number])
+        !VALID_STATUSES.includes(
+          partyUpdates.status as typeof VALID_STATUSES[number],
+        )
       ) {
         return errorResponse(
           `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`,
@@ -261,11 +267,14 @@ export async function handleUpdate(
     const existingIds = (existing ?? []).map((r: { id: string }) =>
       r.id as string
     );
+    const existingIdSet = new Set(existingIds);
     const incomingWithId = templates.filter((t) =>
-      typeof t.id === "string" && (t.id as string).length > 0
+      typeof t.id === "string" && (t.id as string).length > 0 &&
+      existingIdSet.has(t.id as string)
     );
     const incomingWithoutId = templates.filter((t) =>
-      !t.id || (t.id as string).length === 0
+      !t.id || (t.id as string).length === 0 ||
+      !existingIdSet.has(t.id as string)
     );
     const keptIds = incomingWithId.map((t) => t.id as string);
     const toDeleteIds = existingIds.filter((id: string) =>
@@ -273,11 +282,10 @@ export async function handleUpdate(
     );
 
     if (toDeleteIds.length > 0) {
-      const { data: affectedTickets, error: fetchTicketsError } =
-        await supabase
-          .from("ticket_templates")
-          .select("id, target_entry_group_ids")
-          .eq("party_id", partyId);
+      const { data: affectedTickets, error: fetchTicketsError } = await supabase
+        .from("ticket_templates")
+        .select("id, target_entry_group_ids")
+        .eq("party_id", partyId);
       if (fetchTicketsError) {
         return errorResponse(
           `Failed to fetch ticket templates: ${fetchTicketsError.message}`,
@@ -287,7 +295,7 @@ export async function handleUpdate(
 
       for (const ticket of (affectedTickets ?? [])) {
         const tt = ticket as { id: string; target_entry_group_ids: string[] };
-        const hadAny = toDeleteIds.some((d) =>
+        const hadAny = toDeleteIds.some((d: string) =>
           tt.target_entry_group_ids?.includes(d)
         );
         if (hadAny) {

--- a/supabase/functions/partner-manage-party/index.ts
+++ b/supabase/functions/partner-manage-party/index.ts
@@ -1,13 +1,23 @@
 // partner-manage-party — Party/location/template CRUD for partners
 // Issue #316: RLS write strategy 전환
 
-import {
-  errorResponse,
-} from "../_shared/response_utils.ts";
+import { errorResponse } from "../_shared/response_utils.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
+import {
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { handleCreate } from "./_handlers/create.ts";
+import {
+  handleCreateLocation,
+  handleUpdateLocation,
+} from "./_handlers/location.ts";
+import {
+  handleCreateTicketTemplate,
+  handleDeleteTicketTemplate,
+  handleUpdateTicketTemplate,
+} from "./_handlers/ticket_template.ts";
 import { handleUpdate } from "./_handlers/update.ts";
 import { handleUpdateStatus } from "./_handlers/update_status.ts";
 
@@ -21,13 +31,23 @@ const DISPATCH: Record<string, ActionHandler> = {
   create: handleCreate,
   update: handleUpdate,
   update_status: handleUpdateStatus,
+  create_location: handleCreateLocation,
+  update_location: handleUpdateLocation,
+  create_ticket_template: handleCreateTicketTemplate,
+  update_ticket_template: handleUpdateTicketTemplate,
+  delete_ticket_template: handleDeleteTicketTemplate,
 };
 
-export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
   const { supabase } = ctx;
-  if (ctx.auth.type !== "user") return errorResponse("Unexpected auth type", 500);
+  if (ctx.auth.type !== "user") {
+    return errorResponse("Unexpected auth type", 500);
+  }
   const userId = ctx.auth.userId;
 
   const result = await parseAction(req);

--- a/supabase/functions/partner-manage-party/partner_manage_party_test.ts
+++ b/supabase/functions/partner-manage-party/partner_manage_party_test.ts
@@ -88,6 +88,26 @@ function selectLocationRoute(partnerId = TEST_PARTNER_ID): FetchRoute {
   };
 }
 
+function selectLocationNotFoundRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/locations") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () => jsonResponse(null),
+  };
+}
+
+function selectLocationErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/locations") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () => jsonResponse({ message: "load error" }, { status: 500 }),
+  };
+}
+
 function insertLocationRoute(id = TEST_LOCATION_ID): FetchRoute {
   return {
     matcher: (req) =>
@@ -96,11 +116,27 @@ function insertLocationRoute(id = TEST_LOCATION_ID): FetchRoute {
   };
 }
 
+function insertLocationErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/locations") && req.method === "POST",
+    handler: () => jsonResponse({ message: "insert error" }, { status: 500 }),
+  };
+}
+
 function updateLocationRoute(): FetchRoute {
   return {
     matcher: (req) =>
       req.url.includes("/rest/v1/locations") && req.method === "PATCH",
     handler: () => new Response(null, { status: 200 }),
+  };
+}
+
+function updateLocationErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/locations") && req.method === "PATCH",
+    handler: () => jsonResponse({ message: "update error" }, { status: 500 }),
   };
 }
 
@@ -243,6 +279,77 @@ function updateTicketTemplateRoute(): FetchRoute {
   };
 }
 
+function selectTicketTemplateByIdRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () =>
+      jsonResponse({ id: "ticket-template-001", party_id: TEST_PARTY_ID }),
+  };
+}
+
+function selectTicketTemplateNotFoundRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () => jsonResponse(null),
+  };
+}
+
+function selectTicketTemplateErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () => jsonResponse({ message: "load error" }, { status: 500 }),
+  };
+}
+
+function insertSingleTicketTemplateRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") && req.method === "POST",
+    handler: () => jsonResponse({ id: "ticket-template-001" }),
+  };
+}
+
+function insertSingleTicketTemplateErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") && req.method === "POST",
+    handler: () => jsonResponse({ message: "insert error" }, { status: 500 }),
+  };
+}
+
+function deleteTicketTemplateRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") && req.method === "DELETE",
+    handler: () => new Response(null, { status: 200 }),
+  };
+}
+
+function updateTicketTemplateErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") && req.method === "PATCH",
+    handler: () => jsonResponse({ message: "update error" }, { status: 500 }),
+  };
+}
+
+function deleteTicketTemplateErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") && req.method === "DELETE",
+    handler: () => jsonResponse({ message: "delete error" }, { status: 500 }),
+  };
+}
+
 function insertTicketTemplatesRoute(): FetchRoute {
   return {
     matcher: (req) =>
@@ -273,7 +380,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "GET returns 405 (requires auth — wrapper checks auth before handler checks method)",
+  name:
+    "GET returns 405 (requires auth — wrapper checks auth before handler checks method)",
   fn: async () => {
     const { fetchMock } = createFetchMock([authRoute()]);
     await withEnv(ENV, async () => {
@@ -351,7 +459,7 @@ Deno.test({
         const res = await handler(req);
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing or invalid \"action\" field");
+        assertEquals(body.error, 'Missing or invalid "action" field');
       });
     });
   },
@@ -966,6 +1074,78 @@ Deno.test({
 
     assertEquals(entryGroupInserts.length, 1);
     assertEquals(entryGroupUpdates.length, 0);
+    assertEquals(
+      JSON.parse(entryGroupInserts[0].body ?? "[]"),
+      [
+        {
+          party_id: TEST_PARTY_ID,
+          label: "신규 그룹",
+          gender: "female",
+          birth_year_min: 1995,
+          birth_year_max: 2005,
+          required_verification_ids: [],
+        },
+      ],
+    );
+  },
+});
+
+Deno.test({
+  name: "update: entry_group_templates with temporary id inserts new row",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock, calls } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+      selectEntryGroupTemplatesRoute(["egt_existing"]),
+      updateEntryGroupTemplateRoute(),
+      insertEntryGroupTemplatesRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update",
+          party_id: TEST_PARTY_ID,
+          entry_group_templates: [
+            {
+              id: "egt_existing",
+              label: "기존 그룹",
+              gender: "male",
+              birth_year_min: 1990,
+              birth_year_max: 2000,
+              required_verification_ids: [],
+            },
+            {
+              id: "eg_temp_1",
+              label: "신규 그룹",
+              gender: "female",
+              birth_year_min: 1995,
+              birth_year_max: 2005,
+              required_verification_ids: [],
+            },
+          ],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+      });
+    });
+
+    const entryGroupUpdates = calls.filter(
+      (c) =>
+        c.url.includes("/rest/v1/entry_group_templates") &&
+        c.method === "PATCH",
+    );
+    const entryGroupInserts = calls.filter(
+      (c) =>
+        c.url.includes("/rest/v1/entry_group_templates") && c.method === "POST",
+    );
+
+    assertEquals(entryGroupUpdates.length, 1);
+    assertEquals(entryGroupInserts.length, 1);
     assertEquals(
       JSON.parse(entryGroupInserts[0].body ?? "[]"),
       [
@@ -1670,6 +1850,553 @@ Deno.test({
           (c) => c.url.includes("/rest/v1/parties") && c.method === "PATCH",
         );
         assertEquals(partyPatches.length, 0);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create_location: inserts partner-owned location",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      insertLocationRoute("loc-new"),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create_location",
+          partner_id: TEST_PARTNER_ID,
+          location: {
+            name: "새 장소",
+            address: "서울시 강남구",
+            address_detail: "2층",
+          },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.location_id, "loc-new");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_location: updates permitted location",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectLocationRoute(),
+      permRoute(),
+      updateLocationRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_location",
+          location_id: TEST_LOCATION_ID,
+          location: {
+            address_detail: "3층",
+            directions_guide: "3번 출구",
+          },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create_ticket_template: inserts permitted party template",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+      insertSingleTicketTemplateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create_ticket_template",
+          ticket_template: {
+            party_id: TEST_PARTY_ID,
+            name: "일반 티켓",
+            price: 30000,
+            quantity: 20,
+          },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.ticket_template_id, "ticket-template-001");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_ticket_template: updates permitted party template",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectTicketTemplateByIdRoute(),
+      selectPartyRoute(),
+      permRoute(),
+      updateTicketTemplateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_ticket_template",
+          ticket_template_id: "ticket-template-001",
+          ticket_template: {
+            name: "수정 티켓",
+            price: 25000,
+            quantity: 20,
+          },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "delete_ticket_template: deletes permitted party template",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectTicketTemplateByIdRoute(),
+      selectPartyRoute(),
+      permRoute(),
+      deleteTicketTemplateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "delete_ticket_template",
+          ticket_template_id: "ticket-template-001",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create_location: rejects invalid payloads before DB write",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        let req = authenticatedJsonRequest("http://localhost", {
+          action: "create_location",
+          location: { name: "장소", address: "주소" },
+        });
+        let res = await handler(req);
+        assertEquals(res.status, 400);
+
+        req = authenticatedJsonRequest("http://localhost", {
+          action: "create_location",
+          partner_id: TEST_PARTNER_ID,
+          location: "invalid",
+        });
+        res = await handler(req);
+        assertEquals(res.status, 400);
+
+        req = authenticatedJsonRequest("http://localhost", {
+          action: "create_location",
+          partner_id: TEST_PARTNER_ID,
+          location: { address: "주소" },
+        });
+        res = await handler(req);
+        assertEquals(res.status, 400);
+
+        req = authenticatedJsonRequest("http://localhost", {
+          action: "create_location",
+          partner_id: TEST_PARTNER_ID,
+          location: { name: "장소" },
+        });
+        res = await handler(req);
+        assertEquals(res.status, 400);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create_location: returns 500 when insert fails",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      insertLocationErrorRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create_location",
+          partner_id: TEST_PARTNER_ID,
+          location: { name: "장소", address: "주소" },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_location: rejects invalid payloads before DB write",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        let req = authenticatedJsonRequest("http://localhost", {
+          action: "update_location",
+          location: { address_detail: "3층" },
+        });
+        let res = await handler(req);
+        assertEquals(res.status, 400);
+
+        req = authenticatedJsonRequest("http://localhost", {
+          action: "update_location",
+          location_id: TEST_LOCATION_ID,
+          location: null,
+        });
+        res = await handler(req);
+        assertEquals(res.status, 400);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_location: handles load/not-found/no-fields/update errors",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    await withEnv(ENV, async () => {
+      let fetchMock = createFetchMock([
+        authRoute(),
+        selectLocationErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_location",
+          location_id: TEST_LOCATION_ID,
+          location: { address_detail: "3층" },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 500);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectLocationNotFoundRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_location",
+          location_id: TEST_LOCATION_ID,
+          location: { address_detail: "3층" },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 404);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectLocationRoute(),
+        permRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_location",
+          location_id: TEST_LOCATION_ID,
+          location: {},
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectLocationRoute(),
+        permRoute(),
+        updateLocationErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_location",
+          location_id: TEST_LOCATION_ID,
+          location: { address_detail: "3층" },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "ticket_template: rejects invalid create/update/delete payloads",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        let req = authenticatedJsonRequest("http://localhost", {
+          action: "create_ticket_template",
+          ticket_template: null,
+        });
+        let res = await handler(req);
+        assertEquals(res.status, 400);
+
+        req = authenticatedJsonRequest("http://localhost", {
+          action: "create_ticket_template",
+          ticket_template: { name: "티켓", quantity: 1 },
+        });
+        res = await handler(req);
+        assertEquals(res.status, 400);
+
+        req = authenticatedJsonRequest("http://localhost", {
+          action: "update_ticket_template",
+          ticket_template: { name: "티켓", quantity: 1 },
+        });
+        res = await handler(req);
+        assertEquals(res.status, 400);
+
+        req = authenticatedJsonRequest("http://localhost", {
+          action: "update_ticket_template",
+          ticket_template_id: "ticket-template-001",
+          ticket_template: [],
+        });
+        res = await handler(req);
+        assertEquals(res.status, 400);
+
+        req = authenticatedJsonRequest("http://localhost", {
+          action: "delete_ticket_template",
+        });
+        res = await handler(req);
+        assertEquals(res.status, 400);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create_ticket_template: handles validation and insert errors",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    await withEnv(ENV, async () => {
+      let fetchMock = createFetchMock([
+        authRoute(),
+        selectPartyRoute(),
+        permRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create_ticket_template",
+          ticket_template: {
+            party_id: TEST_PARTY_ID,
+            name: "",
+            quantity: 1,
+          },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectPartyRoute(),
+        permRoute(),
+        insertSingleTicketTemplateErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create_ticket_template",
+          ticket_template: {
+            party_id: TEST_PARTY_ID,
+            name: "일반 티켓",
+            quantity: 1,
+          },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "update_ticket_template: handles load/not-found/validation/update errors",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    await withEnv(ENV, async () => {
+      let fetchMock = createFetchMock([
+        authRoute(),
+        selectTicketTemplateErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_ticket_template",
+          ticket_template_id: "ticket-template-001",
+          ticket_template: { name: "티켓", quantity: 1 },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 500);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectTicketTemplateNotFoundRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_ticket_template",
+          ticket_template_id: "ticket-template-001",
+          ticket_template: { name: "티켓", quantity: 1 },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 404);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectTicketTemplateByIdRoute(),
+        selectPartyRoute(),
+        permRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_ticket_template",
+          ticket_template_id: "ticket-template-001",
+          ticket_template: { name: "티켓", quantity: -1 },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectTicketTemplateByIdRoute(),
+        selectPartyRoute(),
+        permRoute(),
+        updateTicketTemplateErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_ticket_template",
+          ticket_template_id: "ticket-template-001",
+          ticket_template: { name: "티켓", quantity: 1 },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "delete_ticket_template: handles load/not-found/delete errors",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    await withEnv(ENV, async () => {
+      let fetchMock = createFetchMock([
+        authRoute(),
+        selectTicketTemplateErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "delete_ticket_template",
+          ticket_template_id: "ticket-template-001",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 500);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectTicketTemplateNotFoundRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "delete_ticket_template",
+          ticket_template_id: "ticket-template-001",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 404);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute(),
+        selectTicketTemplateByIdRoute(),
+        selectPartyRoute(),
+        permRoute(),
+        deleteTicketTemplateErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "delete_ticket_template",
+          ticket_template_id: "ticket-template-001",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 500);
       });
     });
   },

--- a/supabase/functions/partner-register/index.ts
+++ b/supabase/functions/partner-register/index.ts
@@ -1,12 +1,12 @@
 // partner-register — Partner application (save draft, submit, update)
 // Issue #311: RLS write strategy 전환
 
-import {
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
+import {
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
 import {
   requireNonEmpty,
   validateBizNumber,
@@ -45,11 +45,18 @@ const CLEARABLE_FIELDS: ReadonlySet<string> = new Set([
   "profile_image_path",
 ]);
 
-export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+const REVIEW_STATUSES = ["approved", "needs_correction", "rejected"] as const;
+
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
   const { supabase } = ctx;
-  if (ctx.auth.type !== "user") return errorResponse("Unexpected auth type", 500);
+  if (ctx.auth.type !== "user") {
+    return errorResponse("Unexpected auth type", 500);
+  }
   const userId = ctx.auth.userId;
 
   const result = await parseAction(req);
@@ -232,7 +239,7 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
         return errorResponse("Failed to verify uploaded files", 500);
       }
 
-      if (!fileData.some((file) => file.name === filename)) {
+      if (!fileData.some((file: { name: string }) => file.name === filename)) {
         errors.push({ field, message });
       }
     }
@@ -329,7 +336,83 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
     return successResponse({ success: true, application_id: applicationId });
   }
 
+  // ─── review ───
+  if (action === "review") {
+    const applicationId = body.application_id;
+    if (typeof applicationId !== "string" || !applicationId) {
+      return errorResponse("Missing application_id", 400);
+    }
+
+    const status = body.status;
+    if (
+      typeof status !== "string" ||
+      !REVIEW_STATUSES.includes(status as typeof REVIEW_STATUSES[number])
+    ) {
+      return errorResponse(
+        `Invalid status. Must be one of: ${REVIEW_STATUSES.join(", ")}`,
+        400,
+      );
+    }
+
+    const adminComment = typeof body.admin_comment === "string"
+      ? body.admin_comment
+      : null;
+
+    const adminCheck = await requireSuperAdmin(supabase, userId);
+    if (adminCheck instanceof Response) return adminCheck;
+
+    const { data: app, error: fetchError } = await supabase
+      .from("partner_applications")
+      .select("id, status")
+      .eq("id", applicationId)
+      .maybeSingle();
+
+    if (fetchError) return errorResponse("Failed to load application", 500);
+    if (!app) return errorResponse("Application not found", 404);
+    if (app.status !== "pending") {
+      return errorResponse(
+        `Application cannot be reviewed in status '${app.status}'`,
+        400,
+      );
+    }
+
+    const { error: updateError } = await supabase
+      .from("partner_applications")
+      .update({
+        status,
+        admin_comment: adminComment,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", applicationId)
+      .eq("status", "pending");
+
+    if (updateError) {
+      return errorResponse(
+        `Failed to review application: ${updateError.message}`,
+        500,
+      );
+    }
+
+    return successResponse({ success: true, application_id: applicationId });
+  }
+
   return errorResponse(`Unknown action: ${action}`, 400);
 };
 
 minglitEdgeFunction(handler);
+
+async function requireSuperAdmin(
+  supabase: EFContext["supabase"],
+  userId: string,
+): Promise<true | Response> {
+  const { data, error } = await supabase
+    .from("app_roles")
+    .select("role")
+    .eq("user_id", userId)
+    .eq("role", "super_admin")
+    .maybeSingle();
+
+  if (error) return errorResponse("Failed to verify admin role", 500);
+  if (!data) return errorResponse("Forbidden: super_admin required", 403);
+  return true;
+}

--- a/supabase/functions/partner-register/partner_register_test.ts
+++ b/supabase/functions/partner-register/partner_register_test.ts
@@ -3,11 +3,11 @@ import {
   authenticatedJsonRequest,
   captureServeHandler,
   createFetchMock,
+  type FetchRoute,
   jsonResponse,
   readJson,
   withEnv,
   withMockedFetch,
-  type FetchRoute,
 } from "../_test_utils/mock_http.ts";
 
 const TEST_USER_ID = "user-applicant-001";
@@ -54,8 +54,18 @@ function authFailRoute(): FetchRoute {
   };
 }
 
+function superAdminRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/app_roles") && req.method === "GET",
+    handler: () => jsonResponse({ role: "super_admin" }),
+  };
+}
+
 // SELECT route for fetching application
-function selectAppRoute(app: Record<string, unknown> | null = VALID_APP): FetchRoute {
+function selectAppRoute(
+  app: Record<string, unknown> | null = VALID_APP,
+): FetchRoute {
   return {
     matcher: (req) =>
       req.url.includes("/rest/v1/partner_applications") &&
@@ -69,7 +79,8 @@ function selectAppRoute(app: Record<string, unknown> | null = VALID_APP): FetchR
 function insertRoute(id = TEST_APP_ID): FetchRoute {
   return {
     matcher: (req) =>
-      req.url.includes("/rest/v1/partner_applications") && req.method === "POST",
+      req.url.includes("/rest/v1/partner_applications") &&
+      req.method === "POST",
     handler: () => jsonResponse({ id }),
   };
 }
@@ -77,7 +88,8 @@ function insertRoute(id = TEST_APP_ID): FetchRoute {
 function insertErrorRoute(): FetchRoute {
   return {
     matcher: (req) =>
-      req.url.includes("/rest/v1/partner_applications") && req.method === "POST",
+      req.url.includes("/rest/v1/partner_applications") &&
+      req.method === "POST",
     handler: () => jsonResponse({ message: "insert error" }, { status: 500 }),
   };
 }
@@ -86,7 +98,8 @@ function insertErrorRoute(): FetchRoute {
 function updateRoute(): FetchRoute {
   return {
     matcher: (req) =>
-      req.url.includes("/rest/v1/partner_applications") && req.method === "PATCH",
+      req.url.includes("/rest/v1/partner_applications") &&
+      req.method === "PATCH",
     handler: () => new Response(null, { status: 200 }),
   };
 }
@@ -94,7 +107,8 @@ function updateRoute(): FetchRoute {
 function updateErrorRoute(): FetchRoute {
   return {
     matcher: (req) =>
-      req.url.includes("/rest/v1/partner_applications") && req.method === "PATCH",
+      req.url.includes("/rest/v1/partner_applications") &&
+      req.method === "PATCH",
     handler: () => jsonResponse({ message: "update error" }, { status: 500 }),
   };
 }
@@ -103,14 +117,20 @@ function updateErrorRoute(): FetchRoute {
 // Returns matching file names based on the search query parameter
 function storageListRoute(hasFiles = true): FetchRoute {
   return {
-    matcher: (req) => req.url.includes("/storage/v1/object/list/partner-proofs"),
+    matcher: (req) =>
+      req.url.includes("/storage/v1/object/list/partner-proofs"),
     handler: (req) => {
       if (!hasFiles) return jsonResponse([]);
       // Extract search param from body or URL to return matching filename
       const url = new URL(req.url);
-      const prefix = url.pathname.replace("/storage/v1/object/list/partner-proofs/", "");
+      const prefix = url.pathname.replace(
+        "/storage/v1/object/list/partner-proofs/",
+        "",
+      );
       // Return a generic file that matches any search
-      return jsonResponse([{ name: "biz_reg_123.pdf" }, { name: "bankbook_123.pdf" }]);
+      return jsonResponse([{ name: "biz_reg_123.pdf" }, {
+        name: "bankbook_123.pdf",
+      }]);
     },
   };
 }
@@ -119,7 +139,9 @@ function storageListRoute(hasFiles = true): FetchRoute {
 Deno.test({
   name: "handles OPTIONS preflight request",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([]);
 
     await withEnv(ENV, async () => {
@@ -137,7 +159,9 @@ Deno.test({
 Deno.test({
   name: "returns 401 without authorization",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authFailRoute()]);
 
     await withEnv(ENV, async () => {
@@ -158,7 +182,9 @@ Deno.test({
 Deno.test({
   name: "returns 400 for missing action",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -168,7 +194,7 @@ Deno.test({
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing or invalid \"action\" field");
+        assertEquals(body.error, 'Missing or invalid "action" field');
       });
     });
   },
@@ -178,7 +204,9 @@ Deno.test({
 Deno.test({
   name: "returns 400 for unknown action",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -202,7 +230,9 @@ Deno.test({
 Deno.test({
   name: "save_draft: new insert returns application_id",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       insertRoute("new-app-id"),
@@ -229,10 +259,16 @@ Deno.test({
 Deno.test({
   name: "save_draft: existing update returns application_id",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
-      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "draft" }),
+      selectAppRoute({
+        id: TEST_APP_ID,
+        user_id: TEST_USER_ID,
+        status: "draft",
+      }),
       updateRoute(),
     ]);
 
@@ -258,14 +294,17 @@ Deno.test({
 Deno.test({
   name: "save_draft: current_step is persisted",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     let insertBody: string | null = null;
 
     const { fetchMock } = createFetchMock([
       authRoute(),
       {
         matcher: (req) =>
-          req.url.includes("/rest/v1/partner_applications") && req.method === "POST",
+          req.url.includes("/rest/v1/partner_applications") &&
+          req.method === "POST",
         handler: async (req) => {
           insertBody = await req.clone().text();
           return jsonResponse({ id: "new-id" });
@@ -294,10 +333,16 @@ Deno.test({
 Deno.test({
   name: "save_draft: returns 403 for other user's draft",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
-      selectAppRoute({ id: TEST_APP_ID, user_id: OTHER_USER_ID, status: "draft" }),
+      selectAppRoute({
+        id: TEST_APP_ID,
+        user_id: OTHER_USER_ID,
+        status: "draft",
+      }),
     ]);
 
     await withEnv(ENV, async () => {
@@ -319,10 +364,16 @@ Deno.test({
 Deno.test({
   name: "save_draft: returns 400 when application is pending",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
-      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "pending" }),
+      selectAppRoute({
+        id: TEST_APP_ID,
+        user_id: TEST_USER_ID,
+        status: "pending",
+      }),
     ]);
 
     await withEnv(ENV, async () => {
@@ -336,7 +387,10 @@ Deno.test({
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Application cannot be updated in current status");
+        assertEquals(
+          body.error,
+          "Application cannot be updated in current status",
+        );
       });
     });
   },
@@ -346,7 +400,9 @@ Deno.test({
 Deno.test({
   name: "save_draft: returns 500 when insert fails",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       insertErrorRoute(),
@@ -374,7 +430,9 @@ Deno.test({
 Deno.test({
   name: "submit: draft → pending with valid data",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     // Use valid biz_number with correct checksum: 1208100083
     const validApp = { ...VALID_APP, biz_number: "1208100088" };
     const { fetchMock } = createFetchMock([
@@ -404,7 +462,9 @@ Deno.test({
 Deno.test({
   name: "submit: returns 400 with validation details for missing fields",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const incompleteApp = {
       id: TEST_APP_ID,
       user_id: TEST_USER_ID,
@@ -456,7 +516,9 @@ Deno.test({
 Deno.test({
   name: "submit: returns 400 for invalid biz_number format",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const badBizApp = { ...VALID_APP, biz_number: "123" };
     const { fetchMock } = createFetchMock([
       authRoute(),
@@ -475,7 +537,9 @@ Deno.test({
         assertEquals(res.status, 400);
         const body = await readJson(res);
         assertEquals(body.error, "validation_failed");
-        const bizErr = body.details.find((d: { field: string }) => d.field === "biz_number");
+        const bizErr = body.details.find((d: { field: string }) =>
+          d.field === "biz_number"
+        );
         assertEquals(bizErr !== undefined, true);
       });
     });
@@ -486,8 +550,14 @@ Deno.test({
 Deno.test({
   name: "submit: returns 400 for invalid email format",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const badEmailApp = { ...VALID_APP, biz_number: "1208100088", contact_email: "not-an-email" };
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const badEmailApp = {
+      ...VALID_APP,
+      biz_number: "1208100088",
+      contact_email: "not-an-email",
+    };
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectAppRoute(badEmailApp),
@@ -505,7 +575,9 @@ Deno.test({
         assertEquals(res.status, 400);
         const body = await readJson(res);
         assertEquals(body.error, "validation_failed");
-        const emailErr = body.details.find((d: { field: string }) => d.field === "contact_email");
+        const emailErr = body.details.find((d: { field: string }) =>
+          d.field === "contact_email"
+        );
         assertEquals(emailErr !== undefined, true);
       });
     });
@@ -516,7 +588,9 @@ Deno.test({
 Deno.test({
   name: "submit: returns 400 when storage file not found",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const validApp = { ...VALID_APP, biz_number: "1208100088" };
     const { fetchMock } = createFetchMock([
       authRoute(),
@@ -544,7 +618,9 @@ Deno.test({
 Deno.test({
   name: "submit: returns 403 for file path with other user's prefix",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const hackedApp = {
       ...VALID_APP,
       biz_number: "1208100088",
@@ -575,14 +651,18 @@ Deno.test({
 Deno.test({
   name: "submit: returns 500 when storage list fails",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const validApp = { ...VALID_APP, biz_number: "1208100088" };
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectAppRoute(validApp),
       {
-        matcher: (req) => req.url.includes("/storage/v1/object/list/partner-proofs"),
-        handler: () => jsonResponse({ message: "storage error" }, { status: 500 }),
+        matcher: (req) =>
+          req.url.includes("/storage/v1/object/list/partner-proofs"),
+        handler: () =>
+          jsonResponse({ message: "storage error" }, { status: 500 }),
       },
     ]);
 
@@ -606,7 +686,9 @@ Deno.test({
 Deno.test({
   name: "submit: returns 400 when already pending",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const pendingApp = { ...VALID_APP, status: "pending" };
     const { fetchMock } = createFetchMock([
       authRoute(),
@@ -623,7 +705,10 @@ Deno.test({
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Application cannot be submitted in current status");
+        assertEquals(
+          body.error,
+          "Application cannot be submitted in current status",
+        );
       });
     });
   },
@@ -633,8 +718,14 @@ Deno.test({
 Deno.test({
   name: "submit: needs_correction → pending transition success",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const correctionApp = { ...VALID_APP, status: "needs_correction", biz_number: "1208100088" };
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const correctionApp = {
+      ...VALID_APP,
+      status: "needs_correction",
+      biz_number: "1208100088",
+    };
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectAppRoute(correctionApp),
@@ -662,7 +753,9 @@ Deno.test({
 Deno.test({
   name: "submit: returns 400 for missing application_id",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -684,7 +777,9 @@ Deno.test({
 Deno.test({
   name: "submit: returns 403 for other user's application",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const otherApp = { ...VALID_APP, user_id: OTHER_USER_ID };
     const { fetchMock } = createFetchMock([
       authRoute(),
@@ -713,10 +808,16 @@ Deno.test({
 Deno.test({
   name: "update: draft status allows update",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
-      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "draft" }),
+      selectAppRoute({
+        id: TEST_APP_ID,
+        user_id: TEST_USER_ID,
+        status: "draft",
+      }),
       updateRoute(),
     ]);
 
@@ -742,10 +843,16 @@ Deno.test({
 Deno.test({
   name: "update: needs_correction status allows update",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
-      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "needs_correction" }),
+      selectAppRoute({
+        id: TEST_APP_ID,
+        user_id: TEST_USER_ID,
+        status: "needs_correction",
+      }),
       updateRoute(),
     ]);
 
@@ -770,10 +877,16 @@ Deno.test({
 Deno.test({
   name: "update: returns 400 when status is pending",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
-      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "pending" }),
+      selectAppRoute({
+        id: TEST_APP_ID,
+        user_id: TEST_USER_ID,
+        status: "pending",
+      }),
     ]);
 
     await withEnv(ENV, async () => {
@@ -787,7 +900,10 @@ Deno.test({
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Application cannot be updated in current status");
+        assertEquals(
+          body.error,
+          "Application cannot be updated in current status",
+        );
       });
     });
   },
@@ -797,10 +913,16 @@ Deno.test({
 Deno.test({
   name: "update: returns 403 for other user's application",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
-      selectAppRoute({ id: TEST_APP_ID, user_id: OTHER_USER_ID, status: "draft" }),
+      selectAppRoute({
+        id: TEST_APP_ID,
+        user_id: OTHER_USER_ID,
+        status: "draft",
+      }),
     ]);
 
     await withEnv(ENV, async () => {
@@ -822,7 +944,9 @@ Deno.test({
 Deno.test({
   name: "update: returns 400 for missing application_id",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -845,10 +969,16 @@ Deno.test({
 Deno.test({
   name: "update: returns 400 when no valid fields in data",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
-      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "draft" }),
+      selectAppRoute({
+        id: TEST_APP_ID,
+        user_id: TEST_USER_ID,
+        status: "draft",
+      }),
     ]);
 
     await withEnv(ENV, async () => {
@@ -870,16 +1000,20 @@ Deno.test({
 
 // ─── save_draft: non-clearable null omitted, clearable null preserved ───
 Deno.test({
-  name: "save_draft: non-clearable null is omitted, clearable null is preserved in payload",
+  name:
+    "save_draft: non-clearable null is omitted, clearable null is preserved in payload",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     let insertBody: string | null = null;
 
     const { fetchMock } = createFetchMock([
       authRoute(),
       {
         matcher: (req) =>
-          req.url.includes("/rest/v1/partner_applications") && req.method === "POST",
+          req.url.includes("/rest/v1/partner_applications") &&
+          req.method === "POST",
         handler: async (req) => {
           insertBody = await req.clone().text();
           return jsonResponse({ id: "new-id" });
@@ -893,10 +1027,10 @@ Deno.test({
           authenticatedJsonRequest("http://localhost", {
             action: "save_draft",
             data: {
-              brand_name: null,         // non-clearable → omit
-              biz_type: null,           // non-clearable → omit
-              introduction: null,       // clearable → preserve as null
-              tax_email: null,          // clearable → preserve as null
+              brand_name: null, // non-clearable → omit
+              biz_type: null, // non-clearable → omit
+              introduction: null, // clearable → preserve as null
+              tax_email: null, // clearable → preserve as null
               profile_image_path: null, // clearable → preserve as null
               current_step: 1,
             },
@@ -916,17 +1050,25 @@ Deno.test({
 
 // ─── update: non-clearable null omitted, clearable null preserved ───
 Deno.test({
-  name: "update: non-clearable null is omitted, clearable null is preserved in payload",
+  name:
+    "update: non-clearable null is omitted, clearable null is preserved in payload",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     let patchBody: string | null = null;
 
     const { fetchMock } = createFetchMock([
       authRoute(),
-      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "needs_correction" }),
+      selectAppRoute({
+        id: TEST_APP_ID,
+        user_id: TEST_USER_ID,
+        status: "needs_correction",
+      }),
       {
         matcher: (req) =>
-          req.url.includes("/rest/v1/partner_applications") && req.method === "PATCH",
+          req.url.includes("/rest/v1/partner_applications") &&
+          req.method === "PATCH",
         handler: async (req) => {
           patchBody = await req.clone().text();
           return new Response(null, { status: 200 });
@@ -941,10 +1083,10 @@ Deno.test({
             action: "update",
             application_id: TEST_APP_ID,
             data: {
-              brand_name: null,         // non-clearable → omit
-              biz_type: null,           // non-clearable → omit
-              introduction: null,       // clearable → preserve as null
-              tax_email: null,          // clearable → preserve as null
+              brand_name: null, // non-clearable → omit
+              biz_type: null, // non-clearable → omit
+              introduction: null, // clearable → preserve as null
+              tax_email: null, // clearable → preserve as null
               profile_image_path: null, // clearable → preserve as null
             },
           }),
@@ -965,15 +1107,22 @@ Deno.test({
 Deno.test({
   name: "update: only whitelisted fields are sent to DB",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     let patchBody: string | null = null;
 
     const { fetchMock } = createFetchMock([
       authRoute(),
-      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "draft" }),
+      selectAppRoute({
+        id: TEST_APP_ID,
+        user_id: TEST_USER_ID,
+        status: "draft",
+      }),
       {
         matcher: (req) =>
-          req.url.includes("/rest/v1/partner_applications") && req.method === "PATCH",
+          req.url.includes("/rest/v1/partner_applications") &&
+          req.method === "PATCH",
         handler: async (req) => {
           patchBody = await req.clone().text();
           return new Response(null, { status: 200 });
@@ -1001,6 +1150,117 @@ Deno.test({
         assertEquals(parsed.status, undefined);
         assertEquals(parsed.user_id, undefined);
         assertEquals(parsed.id, undefined);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "review: super_admin can approve pending application",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute("admin-user-001"),
+      superAdminRoute(),
+      selectAppRoute({ id: TEST_APP_ID, status: "pending" }),
+      updateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            application_id: TEST_APP_ID,
+            status: "approved",
+            admin_comment: "ok",
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.application_id, TEST_APP_ID);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "review: rejects invalid requests and non-reviewable applications",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    await withEnv(ENV, async () => {
+      let fetchMock = createFetchMock([authRoute("admin-user-001")]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        let res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            status: "approved",
+          }),
+        );
+        assertEquals(res.status, 400);
+
+        res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            application_id: TEST_APP_ID,
+            status: "draft",
+          }),
+        );
+        assertEquals(res.status, 400);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute("admin-user-001"),
+        superAdminRoute(),
+        selectAppRoute(null),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            application_id: TEST_APP_ID,
+            status: "approved",
+          }),
+        );
+        assertEquals(res.status, 404);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute("admin-user-001"),
+        superAdminRoute(),
+        selectAppRoute({ id: TEST_APP_ID, status: "approved" }),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            application_id: TEST_APP_ID,
+            status: "rejected",
+          }),
+        );
+        assertEquals(res.status, 400);
+      });
+
+      fetchMock = createFetchMock([
+        authRoute("admin-user-001"),
+        superAdminRoute(),
+        selectAppRoute({ id: TEST_APP_ID, status: "pending" }),
+        updateErrorRoute(),
+      ]).fetchMock;
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            application_id: TEST_APP_ID,
+            status: "needs_correction",
+          }),
+        );
+        assertEquals(res.status, 500);
       });
     });
   },


### PR DESCRIPTION
## Summary
- Route remaining `minglit_kit` repository writes through Edge Functions instead of direct Supabase table writes.
- Extend partner/event/register Edge Functions for locations, ticket templates, direct event children, ticket create, and partner application review.
- Update RLS strict docs to mark Phase 2 complete and point Phase 3 GRANT revoke work at #2991.

## Verification
- `deno check --config supabase/functions/deno.json supabase/functions/partner-manage-event/index.ts supabase/functions/partner-manage-party/index.ts supabase/functions/partner-register/index.ts supabase/functions/partner-manage-event/partner_manage_event_test.ts supabase/functions/partner-manage-party/partner_manage_party_test.ts supabase/functions/partner-register/partner_register_test.ts`
- `deno test --allow-env --allow-read --config supabase/functions/deno.json supabase/functions/partner-manage-event/partner_manage_event_test.ts supabase/functions/partner-manage-party/partner_manage_party_test.ts supabase/functions/partner-register/partner_register_test.ts supabase/functions/partner-manage-party/_handlers/update_test.ts`
- `flutter test test/src/data/repositories/event_repository_commands_test.dart test/src/data/repositories/location_repository_test.dart test/src/data/repositories/partner_application_repository_test.dart test/src/data/repositories/party_repository_test.dart test/src/data/repositories/settlement_repository_test.dart test/src/data/repositories/ticket_repository_test.dart test/src/data/repositories/verification_command_repository_test.dart`
- `rg -n "\.(insert|update|upsert|delete)\s*\(" shared/packages/minglit_kit/lib/src/data/repositories --glob '*.dart'` -> 0 results

## Notes
- `flutter analyze` still exits non-zero due existing repo-wide info diagnostics; the introduced warning in `partner_application_repository.dart` was fixed before push.

Closes #2990
Refs #2396
Refs #2393
Refs #2991