### PR TITLE
docs(mds): align checkin tab route contract

### DIFF
--- a/apps/mds/docs/public/specs/BLUEDOC.md
+++ b/apps/mds/docs/public/specs/BLUEDOC.md
@@ -40,4 +40,4 @@ MDS 화면 spec 의 **source HTML + 자동 산출물 디렉터리**. Flutter 화
 - [`../../src/lib/flow-data.ts`](../../src/lib/flow-data.ts) — route/spec 매핑
 
 ---
-_Reviewed: 2026-06-03 15:25_
+_Reviewed: 2026-06-03 16:10_

--- a/apps/mds/docs/public/specs/checkin_placeholder_page/index.html
+++ b/apps/mds/docs/public/specs/checkin_placeholder_page/index.html
@@ -2,11 +2,11 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
-<title>Spec — CheckinPlaceholderPage (app_partner · CheckinTabRoute)</title>
+<title>Spec — CheckinTabRoute (app_partner · route resolver)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
 /* ============================================================
-   CheckinPlaceholderPage-specific atoms.
+   CheckinTabRoute-specific atoms.
    Partner brand override — page is in app_partner.
    ============================================================ */
 .viewport {
@@ -208,44 +208,44 @@ body.dark-mode .viewport {
 <div class="page">
 
 <header>
-  <h1>체크인 진입</h1>
+  <h1>체크인 탭 라우팅</h1>
 </header>
 
 <section class="doc">
   <h2>Overview</h2>
   <table class="ref">
     <tbody>
-      <tr><th style="width: 140px;">Status</th><td><strong>✅ 디자인완료</strong></td></tr>
+      <tr><th style="width: 140px;">Status</th><td><strong>✅ 라우팅 계약완료</strong> <em style="color: var(--color-text-secondary);">— visible screen은 OngoingEventListPage로 수렴</em></td></tr>
       <tr><th>App</th><td><code>app_partner</code></td></tr>
       <tr><th>Category</th><td>checkin (탭)</td></tr>
-      <tr><th>Route / Surface</th><td><code>CheckinPlaceholderPage</code> — Bottom nav 체크인 탭 직접 자식 (route라기보다 IndexedStack child)</td></tr>
-      <tr><th>Path</th><td><em>—</em> (탭 자식 · URL 없음, parent shell이 <code>/partner/home</code>)</td></tr>
+      <tr><th>Route / Surface</th><td><code>CheckinTabRoute</code> / <code>CheckinPlaceholderPage</code> — Bottom nav 체크인 탭의 route resolver</td></tr>
+      <tr><th>Path</th><td><code>/checkin</code> — parent shell의 하단 nav 체크인 탭</td></tr>
       <tr>
         <th>Hierarchy</th>
         <td>
           <strong>Parent</strong>: <a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a> shell의 BottomNavBar 체크인 탭<br>
-          <strong>Children</strong>: <code>QRScannerScreen</code> (탐색 시작점 · 별도 화면)
+          <strong>Children</strong>: <a href="/specs/ongoing_event_list_page/index.html"><code>OngoingEventListPage</code></a> (오늘 이벤트 1개 또는 선택 완료) · Empty state (0개) · Event selector (2개 이상)
         </td>
       </tr>
       <tr>
         <th>Purpose</th>
         <td>
-          파트너가 체크인 탭을 누르는 순간 오늘 진행 예정 이벤트 수에 따라 자동으로 다른 화면을 보여준다 — 이벤트가 없으면 안내, 1개면 즉시 스캐너, 2개 이상이면 선택 목록.
-          단순 진입 마찰을 줄여 가장 흔한 1-event 케이스에서 별도 선택 없이 바로 스캔 가능.
+          파트너가 체크인 탭을 누르는 순간 오늘 운영 가능한 이벤트 수에 따라 적절한 운영 화면으로 보낸다.
+          이 route 자체는 독립 운영 화면이 아니며, 이벤트가 있으면 <code>OngoingEventListPage</code>가 참가자 명단 · QR mode · 수동 체크인을 모두 담당한다.
         </td>
       </tr>
       <tr>
         <th>User journey</th>
         <td>
           <strong>Entry points</strong>: 파트너 홈의 하단 체크인 탭 진입.<br>
-          <strong>Exit points</strong>: 이벤트 1개일 땐 곧장 다크 테마 스캐너 화면으로 진입. 2개 이상일 땐 카드 선택 후 스캐너로 이동. 이벤트가 없으면 다른 탭으로만 이탈.
+          <strong>Exit points</strong>: 이벤트 1개일 땐 해당 이벤트의 <code>OngoingEventListPage</code>로 바로 진입. 2개 이상일 땐 이벤트 선택 후 <code>OngoingEventListPage</code>로 이동. 이벤트가 없으면 빈 안내만 노출하고 다른 탭으로 이탈.
         </td>
       </tr>
       <tr>
         <th>Background</th>
         <td>
-          파트너가 운영일에 체크인 탭을 누를 때 가장 잦은 시나리오는 "오늘 1 이벤트". 매번 선택 화면을 거치게 하면 마찰이 커서 1개일 때는 자동으로 스캐너에 진입.
-          "오늘"의 기준은 시작 3시간 전부터 종료 1시간 후까지의 윈도우.
+          PartnerHome LIVE/진행 임박 카드에서도 여러 이벤트 운영이 가능하므로, 체크인 탭은 별도 dashboard를 새로 만들지 않는다.
+          1개 이벤트는 운영 dashboard로 직행하고, 2개 이상일 때만 event selector가 잠깐 개입한다. "오늘"의 기준은 시작 3시간 전부터 종료 1시간 후까지의 윈도우.
         </td>
       </tr>
       <tr><th>Frequency</th><td>운영일에 매 진입마다 (체크인 시작/중간 중)</td></tr>
@@ -260,6 +260,12 @@ body.dark-mode .viewport {
       <tr><th style="width: 110px;">Date</th><th style="width: 80px;">Version</th><th style="width: 120px;">Author</th><th>Changes</th></tr>
     </thead>
     <tbody>
+      <tr>
+        <td>2026-06-03</td>
+        <td>1.1</td>
+        <td>codex</td>
+        <td>#2999: CheckinPlaceholderPage를 visible screen이 아닌 CheckinTabRoute resolver 계약으로 재정의. 1-event QR scanner 직행을 deprecated하고 OngoingEventListPage를 canonical 운영 화면으로 지정. 2+ events는 selector 후 OngoingEventListPage로 수렴.</td>
+      </tr>
       <tr>
         <td>2026-05-01</td>
         <td>1.0</td>
@@ -281,13 +287,13 @@ body.dark-mode .viewport {
   <div class="perspective__header">
     <span class="glyph">🧱</span>
     <h2>Layout</h2>
-    <span class="lede">파트너 정보를 불러오고 오늘 예정 이벤트 수(0 / 1 / 2+)에 따라 화면이 갈린다. state별 레이아웃이 완전히 다름.</span>
+    <span class="lede">파트너 정보를 불러오고 오늘 운영 가능한 이벤트 수(0 / 1 / 2+)에 따라 route destination이 갈린다. visible operation surface는 OngoingEventListPage다.</span>
   </div>
 
   <section class="doc">
     <h2>Blueprint &amp; tree</h2>
     <p class="intro">
-      모든 state는 simpleAppBar('체크인') + body. body 형태가 state별로 갈림 — Empty(중앙 정렬 컬럼) / Selection(상단 헤더 + ListView) / 1-event는 자체 화면 push라 본 페이지 잔영 없음.
+      이 route는 resolver다. 0-event만 빈 안내를 직접 보여주고, 1-event/2+ 선택 완료는 OngoingEventListPage로 이동한다. 기존 QRScannerScreen 직행 구현은 legacy로만 남긴다.
     </p>
 
     <div class="layout-grid">
@@ -308,9 +314,9 @@ body.dark-mode .viewport {
    ├─ 로딩  → 중앙 스피너
    ├─ 에러  → 중앙 평문 텍스트
    └─ 결과 (오늘 이벤트 수에 따라)
-      · 1개  → 다크 테마 스캐너 화면이 본 화면을 대체
+      · 1개  → OngoingEventListPage(eventId) 직접 진입
       · 0개  → 빈 안내 화면 (중앙 정렬)
-      · 2+개 → 선택 리스트 화면 (헤더 + 카드)</div>
+      · 2+개 → 이벤트 선택 → OngoingEventListPage(eventId)</div>
     </div>
   </section>
 
@@ -398,7 +404,7 @@ body.dark-mode .viewport {
   <div class="perspective__header">
     <span class="glyph">🎨</span>
     <h2>States</h2>
-    <span class="lede">5종 — 파트너/이벤트 데이터 로딩 단계 + 오늘 이벤트 수에 따른 3-way 분기. baseline은 Selection (2+events) — 가장 정보 풍부한 케이스.</span>
+    <span class="lede">5종 — 파트너/이벤트 데이터 로딩 단계 + 오늘 이벤트 수에 따른 3-way 분기. baseline은 Selection (2+events) — selector 후 운영 dashboard로 이동한다.</span>
   </div>
 
   <section class="doc">
@@ -408,8 +414,8 @@ body.dark-mode .viewport {
         <tr><th style="width: 220px;">State</th><th style="width: 100px;">Tag</th><th style="width: 220px;">조건 (요약)</th><th>Key visual differentiator</th></tr>
       </thead>
       <tbody>
-        <tr><td><strong>Selection (2+ events)</strong> 🎯</td><td>baseline</td><td>오늘 예정 이벤트 2개 이상</td><td>상단 헤더 + 시간순 카드 리스트 · LIVE 배지 가능</td></tr>
-        <tr><td><strong>Direct scan (1 event)</strong></td><td>auto-route</td><td>오늘 예정 이벤트 1개</td><td>본 화면에 머무르지 않고 즉시 다크 테마 스캐너로 진입</td></tr>
+        <tr><td><strong>Selection (2+ events)</strong> 🎯</td><td>baseline</td><td>오늘 예정 이벤트 2개 이상</td><td>상단 헤더 + 시간순 카드 리스트 · 선택 후 OngoingEventListPage</td></tr>
+        <tr><td><strong>Direct dashboard (1 event)</strong></td><td>auto-route</td><td>오늘 예정 이벤트 1개</td><td>본 화면에 머무르지 않고 즉시 OngoingEventListPage로 진입</td></tr>
         <tr><td><strong>Empty (0 events)</strong></td><td>no events</td><td>오늘 예정 이벤트 없음</td><td>중앙 QR 아이콘 + 안내 문구 풀-페이지</td></tr>
         <tr><td><strong>Loading</strong></td><td>async</td><td>파트너/이벤트 데이터 로딩 중</td><td>중앙 스피너 단독</td></tr>
         <tr><td><strong>Error</strong></td><td>fail</td><td>데이터 로딩 실패</td><td>중앙 평문 에러 텍스트 (재시도 CTA 없음)</td></tr>
@@ -479,7 +485,7 @@ body.dark-mode .viewport {
           </tr>
           <tr>
             <td class="state-mini__aspect">사용자 액션</td>
-            <td>이벤트 카드 탭 → 다크 테마 스캐너 화면으로 진입.</td>
+            <td>이벤트 카드 탭 → 해당 이벤트의 <a href="/specs/ongoing_event_list_page/index.html"><code>OngoingEventListPage</code></a>로 진입.</td>
           </tr>
           <tr>
             <td class="state-mini__aspect">사용자 액션</td>
@@ -510,35 +516,38 @@ body.dark-mode .viewport {
         </tbody>
       </table>
 
-      <!-- Direct scan -->
+      <!-- Direct dashboard -->
       <table class="ref state-mini">
         <thead>
-          <tr><th colspan="3"><strong>Direct scan (1 event)</strong> <span class="tag">auto-route</span></th></tr>
+          <tr><th colspan="3"><strong>Direct dashboard (1 event)</strong> <span class="tag">auto-route</span></th></tr>
         </thead>
         <tbody>
           <tr>
             <td rowspan="6" class="state-mini__mock">
               <div class="viewport">
-                <div class="cp-scanner">
-                  <div class="cp-scanner__appbar">
+                <div class="cp-appbar">
+                  <div class="cp-appbar__back">
                     <svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg>
-                    한강 노을 와인 모임
                   </div>
-                  <div class="cp-scanner__viewport">
-                    <div class="cp-scanner__frame"></div>
-                    <div class="cp-scanner__hint">QR을 프레임 안에 맞춰주세요</div>
+                  <div class="cp-appbar__title">체크인</div>
+                </div>
+                <div class="cp-body">
+                  <div class="cp-empty">
+                    <div class="cp-empty__icon">→</div>
+                    <div class="cp-empty__title">참가자 체크인으로 이동</div>
+                    <div class="cp-empty__sub">오늘 이벤트 1개<br>운영 화면 자동 진입</div>
                   </div>
                 </div>
               </div>
             </td>
             <td class="state-mini__aspect">조건</td>
-            <td>오늘 예정 이벤트가 정확히 1개. 체크인 탭을 누르는 즉시 본 화면을 거치지 않고 스캐너 화면이 그 자리에 채워짐.</td>
+            <td>오늘 예정 이벤트가 정확히 1개. 체크인 탭을 누르는 즉시 본 화면을 거치지 않고 <a href="/specs/ongoing_event_list_page/index.html"><code>OngoingEventListPage</code></a>로 진입.</td>
           </tr>
-          <tr><td class="state-mini__aspect">사용자 액션</td><td>스캐너 화면 자체의 액션으로 위임 (별도 spec).</td></tr>
-          <tr><td class="state-mini__aspect">에지케이스</td><td>스캐너는 시스템이 라이트 모드여도 항상 다크 테마로 노출 (카메라 화면에서 가독성 유지).</td></tr>
-          <tr><td class="state-mini__aspect">컴포넌트</td><td>↔ 체크인 AppBar가 사라지고 스캐너 화면이 자체 AppBar와 함께 본 화면을 대체.</td></tr>
-          <tr><td class="state-mini__aspect">토큰</td><td>↔ 라이트 컬러 스킴 → 다크 스킴 강제 (partner primary 시드).</td></tr>
-          <tr><td class="state-mini__aspect">노트</td><td>📝 본 페이지의 '체크인' AppBar는 이 분기에서 노출되지 않음 — 스캐너 화면이 자체 화면을 가짐. 사용자 입장에선 "탭하자마자 스캐너"라 본 페이지 잔영 없음.</td></tr>
+          <tr><td class="state-mini__aspect">사용자 액션</td><td>OngoingEventListPage의 QR mode / 검색 / row action sheet로 위임.</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>Flutter 현 구현은 QRScannerScreen 직행이지만, MDS TO-BE에서는 scanner를 inline QR mode로 흡수한다.</td></tr>
+          <tr><td class="state-mini__aspect">컴포넌트</td><td>+ <code>OngoingEventListPage</code> sticky counter · inline QR scanner · participant row action sheet.</td></tr>
+          <tr><td class="state-mini__aspect">토큰</td><td>+ operation dashboard tokens follow OngoingEventListPage; standalone dark scanner theme is deprecated.</td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📝 본 페이지의 '체크인' AppBar는 이 분기에서 노출되지 않음. 사용자는 바로 "참가자 체크인" 운영 화면을 본다.</td></tr>
         </tbody>
       </table>
 
@@ -651,10 +660,10 @@ body.dark-mode .viewport {
     <table class="ref">
       <thead><tr><th style="width: 220px;">사용자 액션</th><th>화면에 보이는 결과</th></tr></thead>
       <tbody>
-        <tr><td>체크인 탭 진입</td><td>데이터를 다시 조회 → 로딩 → 결과/에러/빈 상태 중 하나로 분기.</td></tr>
+        <tr><td>체크인 탭 진입</td><td>데이터를 다시 조회 → 0개 empty / 1개 OngoingEventListPage / 2+ selector로 분기.</td></tr>
         <tr><td>다른 탭으로 이탈</td><td>잠시 캐시가 유지되어 짧은 시간 내 재진입 시 빠르게 복원.</td></tr>
         <tr><td>OS 뒤로가기 (Android)</td><td>본 화면은 탭의 자식이라 무시됨 — 앱 종료 또는 셸 이전 화면으로.</td></tr>
-        <tr><td>스캐너에서 뒤로가기</td><td>본 페이지로 복귀. 1-event 자동 진입 케이스에서는 이때 본 페이지를 처음 보게 됨.</td></tr>
+        <tr><td>OngoingEventListPage에서 뒤로가기</td><td>하단 체크인 탭 상태로 복귀. 1-event 자동 진입 케이스에서는 필요 시 resolver가 다시 같은 이벤트로 보낸다.</td></tr>
       </tbody>
     </table>
   </section>
@@ -664,7 +673,7 @@ body.dark-mode .viewport {
     <table class="ref" style="margin-bottom: 16px;">
       <thead><tr><th style="width: 200px;">Token</th><th style="width: 80px;">Value</th><th>Use case</th></tr></thead>
       <tbody>
-        <tr><td><code>MinglitAnimation.fast</code></td><td>200ms</td><td>스캐너 화면 진입 (1-event 자동)</td></tr>
+        <tr><td><code>MinglitAnimation.fast</code></td><td>200ms</td><td>OngoingEventListPage 진입 (1-event 자동)</td></tr>
         <tr><td><code>MinglitAnimation.medium</code></td><td>350ms</td><td>로딩 ↔ 결과 크로스페이드</td></tr>
       </tbody>
     </table>
@@ -672,7 +681,7 @@ body.dark-mode .viewport {
       <thead><tr><th style="width: 220px;">Transition</th><th style="width: 140px;">Duration (token)</th><th>Curve / notes</th></tr></thead>
       <tbody>
         <tr><td>탭 진입 → 로딩 → 결과</td><td><code>medium</code> (350ms)</td><td>크로스페이드 전환</td></tr>
-        <tr><td>1-event 자동 → 스캐너</td><td><code>fast</code> (200ms)</td><td>Material slide push</td></tr>
+        <tr><td>1-event 자동 → OngoingEventListPage</td><td><code>fast</code> (200ms)</td><td>Material slide push 또는 shell child replace</td></tr>
         <tr><td>카드 리플 (Selection)</td><td><code>micro</code> (100ms)</td><td>Material 기본 ripple</td></tr>
       </tbody>
     </table>
@@ -683,7 +692,7 @@ body.dark-mode .viewport {
     <ul class="notes">
       <li><strong>네트워크 끊김</strong> — 이벤트 조회 실패 → "이벤트를 불러올 수 없습니다" 평문 텍스트. 재시도 버튼 없음 (디자인 부채).</li>
       <li><strong>오늘 윈도우 경계</strong> — 시작 3시간 전부터 종료 1시간 후까지. 자정 이후도 같은 "오늘"로 잡힐 수 있음.</li>
-      <li><strong>다크 모드</strong> — 본 페이지는 라이트/다크 자동. 단, 1-event 분기로 진입한 스캐너 화면은 항상 다크.</li>
+      <li><strong>다크 모드</strong> — 본 페이지는 라이트/다크 자동. QR scanner 단독 다크 화면은 deprecated; OngoingEventListPage의 inline QR panel만 forced dark.</li>
       <li><strong>접근성</strong> — 빈 상태/에러 메시지는 자동으로 읽힘. 큰 아이콘은 장식용으로 처리 권장 (현재 미적용).</li>
     </ul>
   </section>
@@ -701,11 +710,12 @@ body.dark-mode .viewport {
     <table class="ref">
       <thead><tr><th style="width: 200px;">항목</th><th>Path / Reference</th></tr></thead>
       <tbody>
-        <tr><td><strong>Widget class</strong></td><td><code>CheckinPlaceholderPage</code> (ConsumerWidget)</td></tr>
+        <tr><td><strong>Widget class</strong></td><td><code>CheckinPlaceholderPage</code> (ConsumerWidget · route resolver)</td></tr>
         <tr><td><strong>File path</strong></td><td><a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/features/checkin/checkin_placeholder_page.dart"><code>apps/app_partner/lib/src/features/checkin/checkin_placeholder_page.dart</code></a></td></tr>
         <tr><td><strong>Provider</strong></td><td><code>currentPartnerInfoProvider</code> · <code>todayEventsProvider(partnerId)</code> (FutureProvider.family.autoDispose)</td></tr>
-        <tr><td><strong>Internal widgets</strong></td><td><code>_CheckinEntryPage</code> · <code>_ScannerWrapper</code> · <code>_CheckinSelectionPage</code></td></tr>
-        <tr><td><strong>Route</strong></td><td><em>—</em> (BottomNav 탭 자식 — IndexedStack child of partner shell)</td></tr>
+        <tr><td><strong>Internal widgets</strong></td><td><code>_CheckinEntryPage</code> · <code>_ScannerWrapper</code> (legacy) · <code>_CheckinSelectionPage</code></td></tr>
+        <tr><td><strong>Route</strong></td><td><code>/checkin</code> — BottomNav 탭 자식 / CheckinTabRoute</td></tr>
+        <tr><td><strong>Implementation note</strong></td><td>현 Flutter는 1-event에서 <code>QRScannerScreen</code> 직행. #2999 MDS 계약은 이를 deprecated하고 <code>OngoingEventListPage</code> 진입으로 교체하는 TO-BE를 정의한다.</td></tr>
       </tbody>
     </table>
   </section>
@@ -715,7 +725,8 @@ body.dark-mode .viewport {
     <table class="ref">
       <thead><tr><th style="width: 240px;">Spec</th><th>Relation</th></tr></thead>
       <tbody>
-        <tr><td><a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a></td><td>Sibling — BottomNav 같은 shell의 다른 탭.</td></tr>
+        <tr><td><a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a></td><td>Parent shell — 하단 nav 체크인 탭과 LIVE 카드 "참가자 체크인" CTA.</td></tr>
+        <tr><td><a href="/specs/ongoing_event_list_page/index.html"><code>OngoingEventListPage</code></a></td><td>Canonical destination — 참가자 명단 · QR mode · 수동 체크인 · 워크인 / 노쇼 운영.</td></tr>
         <tr><td><a href="/specs/event_check_in_screen/index.html"><code>EventCheckInScreen</code></a></td><td>관련 — 사용자측 체크인 화면 (역할 반대).</td></tr>
         <tr><td><a href="/specs/event_checked_in_screen/index.html"><code>EventCheckedInScreen</code></a></td><td>관련 — 체크인 완료 후 사용자 화면.</td></tr>
       </tbody>

--- a/apps/mds/docs/public/specs/ongoing_event_list_page/index.html
+++ b/apps/mds/docs/public/specs/ongoing_event_list_page/index.html
@@ -2,7 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
-<title>Spec — OngoingEventListPage (app_partner · spec-only)</title>
+<title>Spec — OngoingEventListPage (app_partner · participant check-in dashboard)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
 /* ============================================================
@@ -540,15 +540,15 @@ body.dark-mode .viewport {
   <h2>Overview</h2>
   <table class="ref">
     <tbody>
-      <tr><th style="width: 140px;">Status</th><td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— spec v0.1 · Flutter route / implementation TBD</em></td></tr>
+      <tr><th style="width: 140px;">Status</th><td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— canonical destination for "참가자 체크인" · Flutter route / implementation TBD</em></td></tr>
       <tr><th>App</th><td><code>app_partner</code></td></tr>
       <tr><th>Category</th><td>event operation · check-in · live dashboard</td></tr>
-      <tr><th>Route / Surface</th><td><code>OngoingEventListPage</code> · spec-only surface (route 미구현)</td></tr>
+      <tr><th>Route / Surface</th><td><code>OngoingEventListPage</code> · participant check-in / live operation dashboard</td></tr>
       <tr><th>Path</th><td><code>TBD</code> · 권장: <code>/events/:eventId/ongoing</code> 또는 <code>/events/:eventId/live</code></td></tr>
       <tr>
         <th>Hierarchy</th>
         <td>
-          <strong>Parent</strong>: <a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a> LIVE/진행 임박 카드 · <a href="/specs/partner_event_detail_page/index.html"><code>PartnerEventDetailPage</code></a> 참가 현황.<br>
+          <strong>Parent</strong>: <a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a> LIVE/D-0 진행 임박 카드 "참가자 체크인" CTA · <a href="/specs/checkin_placeholder_page/index.html"><code>CheckinTabRoute</code></a> 1-event direct / 2+ selector · <a href="/specs/partner_event_detail_page/index.html"><code>PartnerEventDetailPage</code></a> 참가 현황.<br>
           <strong>Children</strong>: row action bottom sheet · inline QR scanner 영역 (별도 route 없음).
         </td>
       </tr>
@@ -558,7 +558,7 @@ body.dark-mode .viewport {
       </tr>
       <tr>
         <th>User journey</th>
-        <td><strong>Entry points</strong>: PartnerHomePage LIVE/진행 임박 카드의 "참가자 명단" CTA · PartnerEventDetailPage 참가 현황 · Checkin tab의 오늘 이벤트 선택.<br><strong>Exit points</strong>: 뒤로 가기 → parent route · row action sheet dismiss · 종료 후 read-only 회고에서 EventApplicationListPage/Settlement flow로 이동 가능.</td>
+        <td><strong>Entry points</strong>: PartnerHomePage LIVE/D-0 진행 임박 카드의 "참가자 체크인" CTA · PartnerEventDetailPage 참가 현황 · CheckinTabRoute의 1-event direct / 2+ event selector.<br><strong>Exit points</strong>: 뒤로 가기 → parent route · row action sheet dismiss · 종료 후 read-only 회고에서 EventApplicationListPage/Settlement flow로 이동 가능.</td>
       </tr>
       <tr><th>Background</th><td>기존 참가 신청 리스트는 심사/결제 상태 관리에 최적화되어 있다. 실제 이벤트 운영 시간에는 체크인 완료율, 미도착자 탐색, QR 스캔, 수동 체크인/노쇼/메모가 더 중요하므로 별도 운영 모드가 필요하다.</td></tr>
       <tr><th>Frequency</th><td>이벤트 당일 집중 사용. 시작 2시간 전부터 종료 후 24시간까지 접근 가능하고, 이후에는 read-only history surface로만 연결한다.</td></tr>
@@ -570,8 +570,9 @@ body.dark-mode .viewport {
   <h2>History</h2>
   <table class="ref">
     <thead><tr><th style="width: 110px;">Date</th><th style="width: 80px;">Version</th><th style="width: 120px;">Author</th><th>Changes</th></tr></thead>
-    <tbody>
-      <tr><td>2026-06-03</td><td>0.1</td><td>codex</td><td>Initial MDS spec for #2220. Defines 5 operational states, sticky LIVE counter, inline QR split, participant row action sheet, wakelock indicator, and route/implementation TBD boundaries.</td></tr>
+	    <tbody>
+	      <tr><td>2026-06-03</td><td>0.2</td><td>codex</td><td>#2999: PartnerHome의 "QR 코드 체크인" + "참가자 명단" dual CTA를 "참가자 체크인" single CTA로 수렴. CheckinTabRoute 1-event direct / 2+ selector의 canonical destination으로 지정.</td></tr>
+	      <tr><td>2026-06-03</td><td>0.1</td><td>codex</td><td>Initial MDS spec for #2220. Defines 5 operational states, sticky LIVE counter, inline QR split, participant row action sheet, wakelock indicator, and route/implementation TBD boundaries.</td></tr>
     </tbody>
   </table>
 </section>
@@ -862,7 +863,7 @@ body.dark-mode .viewport {
         <tr><td><strong>File path</strong></td><td><code>TBD</code> · recommended <code>apps/app_partner/lib/src/features/party/event/ongoing/ongoing_event_list_page.dart</code></td></tr>
         <tr><td><strong>Controller / Provider</strong></td><td><code>TBD</code> · event roster stream + check-in mutation controller</td></tr>
         <tr><td><strong>Route</strong></td><td><code>TBD</code> · recommended <code>OngoingEventListRoute(eventId)</code> · path <code>/events/:eventId/ongoing</code></td></tr>
-        <tr><td><strong>Issue</strong></td><td><a href="https://github.com/Mark-Yun/minglit/issues/2220">#2220 — OngoingEventListPage spec</a></td></tr>
+        <tr><td><strong>Issue</strong></td><td><a href="https://github.com/Mark-Yun/minglit/issues/2220">#2220 — OngoingEventListPage spec</a> · <a href="https://github.com/Mark-Yun/minglit/issues/2999">#2999 — CheckinTabRoute contract</a></td></tr>
       </tbody>
     </table>
   </section>
@@ -872,7 +873,8 @@ body.dark-mode .viewport {
     <table class="ref">
       <thead><tr><th style="width: 280px;">Spec</th><th>Relation</th></tr></thead>
       <tbody>
-        <tr><td><a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a></td><td>Primary future entry: LIVE / 진행 임박 card "참가자 명단" CTA.</td></tr>
+        <tr><td><a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a></td><td>Primary entry: LIVE / D-0 진행 임박 card "참가자 체크인" CTA.</td></tr>
+        <tr><td><a href="/specs/checkin_placeholder_page/index.html"><code>CheckinTabRoute</code></a></td><td>Bottom nav resolver: 1 event direct, 2+ events after event selection.</td></tr>
         <tr><td><a href="/specs/partner_event_detail_page/index.html"><code>PartnerEventDetailPage</code></a></td><td>Parent event context; 참가 현황 section can deep link here when event is within operation window.</td></tr>
         <tr><td><a href="/specs/event_application_list_page/index.html"><code>EventApplicationListPage</code></a></td><td>Sibling roster/history list focused on application/payment/review status, not live operation.</td></tr>
         <tr><td><a href="/specs/checkin_placeholder_page/index.html"><code>CheckinPlaceholderPage</code></a></td><td>Bottom-nav check-in entry surface; can route here when exactly one live/upcoming event is selected.</td></tr>

--- a/apps/mds/docs/public/specs/partner_home_page/index.html
+++ b/apps/mds/docs/public/specs/partner_home_page/index.html
@@ -1334,7 +1334,7 @@ body.dark-mode .viewport {
                         </div>
                         <button class="ph-card__cta">
                           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-                          참가자 명단
+	                          참가자 체크인
                         </button>
                       </div>
                     </div>
@@ -1583,7 +1583,7 @@ body.dark-mode .viewport {
                         </div>
                         <button class="ph-card__cta">
                           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-                          참가자 명단
+                          참가자 체크인
                         </button>
                       </div>
                     </div>
@@ -2365,7 +2365,7 @@ body.dark-mode .viewport {
         <tr>
           <td>4</td>
           <td><strong>진행 임박</strong></td>
-          <td>이벤트 detail 카드 (D-day chip + capacity bar 3-layer + 명단 CTA)</td>
+          <td>이벤트 detail 카드 (D-day chip + capacity bar 3-layer + 참가자 체크인 CTA)</td>
           <td>🟠 secondary</td>
           <td>T-7 이내 이벤트 (승인 대기는 별도 섹션, 여기엔 처리 완료된 이벤트만)</td>
         </tr>
@@ -2505,7 +2505,7 @@ body.dark-mode .viewport {
     <h2>카드별 명세 — ② 진행 중 카드 · 단계별 변형</h2>
     <p class="intro">
       "진행 중" 섹션의 카드는 이벤트 당일(D-0) 새벽부터 종료까지 같은 슬롯에서 단계별로 모습이 바뀐다.
-      <strong>체크인은 이벤트 시작 2시간 전부터 활성</strong> — 그 전엔 QR CTA 비활성, 명단만 접근 가능.
+      <strong>체크인은 이벤트 시작 2시간 전부터 활성</strong> — 홈 CTA는 항상 <code>참가자 체크인</code> 하나이며, 그 전엔 OngoingEventListPage 내부 QR mode만 비활성이고 명단/공지 준비는 가능.
       LIVE 진입 후엔 chip이 빨간색 펄스로 변경되고 진행 바가 체크인/참가/정원 3-layer로 시각화됨.
     </p>
     <table class="ref">
@@ -2544,8 +2544,8 @@ body.dark-mode .viewport {
           <td>
             오늘 진행 예정이지만 아직 체크인 시작 전.<br>
             · D-day chip: warning yellow "오늘 19:30"<br>
-            · QR CTA <strong>비활성</strong> (회색 + not-allowed cursor)<br>
-            · 명단 CTA outlined로 활성<br>
+            · CTA는 <strong>"참가자 체크인"</strong> single primary — OngoingEventListPage pre_start로 진입<br>
+            · 내부 QR mode는 disabled, 명단 조회 / 공지 준비만 가능<br>
             · 체크인 시작 시간 inline note (warning 톤)<br>
             · 시간이 가까워지면 "체크인 N분 후" 카운트다운으로 변경 가능
           </td>
@@ -2588,7 +2588,8 @@ body.dark-mode .viewport {
             체크인 윈도우 열림.<br>
             · D-day chip: primary "체크인 가능" (보라)<br>
             · 진행 바 노출 시작 — 페이드(참가) 영역만 visible<br>
-            · QR CTA <strong>활성</strong> (primary 보라)<br>
+            · CTA는 <strong>"참가자 체크인"</strong> single primary<br>
+            · OngoingEventListPage 내부 QR mode 활성 — 기본은 명단+요약, 운영자가 QR mode를 켤 수 있음<br>
             · 첫 참가자가 도착하기 시작하는 단계
           </td>
         </tr>
@@ -2630,7 +2631,8 @@ body.dark-mode .viewport {
             이벤트 시작 후 체크인 진행 중.<br>
             · D-day chip: <strong>error red "LIVE · N분"</strong> + 펄스 도트<br>
             · 진행 바 3-layer (체크인 solid + 참가 fade + 정원 트랙) 모두 visible<br>
-            · 듀얼 CTA: QR primary + 명단 outlined<br>
+            · CTA는 <strong>"참가자 체크인"</strong> single primary — OngoingEventListPage live 상태로 진입<br>
+            · QR / 수동 체크인 / 노쇼 처리는 OngoingEventListPage 내부 action으로 분기<br>
             · 시간 경과는 chip의 분(min)으로 실시간 표시
           </td>
         </tr>
@@ -2673,8 +2675,8 @@ body.dark-mode .viewport {
             모든 참가자 체크인 완료 (체크인 = 참가). 정원이 미달인 채로 출석 100%인 케이스.<br>
             · 진행 바: solid가 페이드 영역을 완전히 덮음 → 페이드 사라짐<br>
             · <strong>"체크인 완료!" success note</strong> 추가 (success 톤 — 초록)<br>
-            · QR CTA는 <strong>disabled 상태로 유지</strong> (회색) — 노출은 하되 더 받을 사람 없음을 시각화<br>
-            · 명단 CTA는 outlined로 활성 (워크인 / 노트 / 사진 업로드 등)
+            · CTA는 <strong>"참가자 체크인"</strong> single primary 유지 — 운영 기록 / 워크인 / 노트 확인 가능<br>
+            · OngoingEventListPage 내부 QR mode는 collapsed 또는 disabled로 표시
           </td>
         </tr>
         <tr>
@@ -2716,8 +2718,8 @@ body.dark-mode .viewport {
             정원 = 참가 = 체크인 동일. 트랙(미판매석) 사라짐.<br>
             · 진행 바 100% 채워짐<br>
             · <strong>"정원 만석! 체크인 완료 ✨" success note</strong> (가장 축하 톤)<br>
-            · QR CTA disabled (회색)<br>
-            · 명단 CTA outlined<br>
+            · CTA는 <strong>"참가자 체크인"</strong> single primary 유지<br>
+            · OngoingEventListPage 내부 QR mode는 collapsed 또는 disabled, 운영 마무리 action 중심<br>
             · 운영 마무리 / 후기 정리 단계로 자연 진입
           </td>
         </tr>
@@ -2820,7 +2822,7 @@ body.dark-mode .viewport {
        ============================================================ -->
   <section class="doc">
     <h2>카드별 명세 — ④ 진행 임박 카드 (Detail + capacity bar)</h2>
-    <p class="intro">T-7 이내 이벤트. capacity bar (확정/심사대기/정원 3-layer) + 명단 CTA 강조.</p>
+    <p class="intro">T-7 이내 이벤트. capacity bar (확정/심사대기/정원 3-layer) + 참가자 체크인 CTA 강조. QR mode는 OngoingEventListPage 내부에서 시간 조건에 따라 활성화한다.</p>
     <table class="ref">
       <thead><tr><th style="width: 360px;">Mockup</th><th>명세</th></tr></thead>
       <tbody>
@@ -2857,7 +2859,7 @@ body.dark-mode .viewport {
                     <div class="ph-card__detail-tag">브런치</div>
                     <div class="ph-card__detail-tag">강남</div>
                   </div>
-                  <button class="ph-card__cta">참가자 명단</button>
+                  <button class="ph-card__cta">참가자 체크인</button>
                 </div>
               </div>
             </div>
@@ -2869,14 +2871,14 @@ body.dark-mode .viewport {
             · capacity bar (3-layer): 확정 solid primary + 심사대기 0.35 fade + 정원 트랙<br>
             · legend (3 dots + 라벨): 확정 / 심사 대기 / 정원<br>
             · tags (회색 칩): 카테고리 / 지역<br>
-            · primary CTA "참가자 명단"<br><br>
+            · primary CTA "참가자 체크인"<br><br>
             <strong>D-day chip 색</strong>: D-1~7 = primary purple (soon)<br><br>
             <strong>Variants</strong>:<br>
             · D-3 일반 케이스 (mockup)<br>
             · 정원 만석: capacity bar 100% + chip 라벨 "마감"<br>
             · D-1: chip "D-1" 같은 색 + meta 강조<br>
             · 심사 대기 0: 페이드 영역 0% (해당 이벤트는 다 처리됨)<br><br>
-            <strong>Tap 액션</strong>: 카드 영역 → 이벤트 상세 / "참가자 명단" CTA → 명단 화면
+            <strong>Tap 액션</strong>: 카드 영역 → 이벤트 상세 / "참가자 체크인" CTA → OngoingEventListPage (D-3/D-1은 pre_start/readiness, T-2부터 QR mode 가능)
           </td>
         </tr>
       </tbody>

--- a/apps/mds/docs/public/specs/partner_home_page/index.html
+++ b/apps/mds/docs/public/specs/partner_home_page/index.html
@@ -966,9 +966,15 @@ body.dark-mode .viewport {
         <th>Changes</th>
       </tr>
     </thead>
-    <tbody>
-      <tr>
-        <td>2026-05-05</td>
+	    <tbody>
+	      <tr>
+	        <td>2026-06-03</td>
+	        <td>2.1</td>
+	        <td>codex</td>
+	        <td>#2999: LIVE/진행 임박 카드의 <code>QR 코드 체크인</code> + <code>참가자 명단</code> dual CTA를 <code>참가자 체크인</code> single CTA로 수렴. CTA destination은 OngoingEventListPage이며 QR은 inline mode로 처리.</td>
+	      </tr>
+	      <tr>
+	        <td>2026-05-05</td>
         <td>2.0</td>
         <td>mark-yun</td>
         <td>
@@ -1248,14 +1254,10 @@ body.dark-mode .viewport {
                                                         <span><span class="ph-card__live-progress-legend ph-card__live-progress-legend--total"></span>정원 20</span>
                           </div>
                         </div>
-                        <button class="ph-card__cta">
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="7" y="7" width="3" height="3"/><rect x="14" y="7" width="3" height="3"/><rect x="7" y="14" width="3" height="3"/><path d="M3 7V5a2 2 0 0 1 2-2h2"/><path d="M17 3h2a2 2 0 0 1 2 2v2"/><path d="M21 17v2a2 2 0 0 1-2 2h-2"/><path d="M7 21H5a2 2 0 0 1-2-2v-2"/><line x1="14" y1="14" x2="14" y2="14.01"/><line x1="17" y1="14" x2="17" y2="14.01"/><line x1="14" y1="17" x2="14" y2="17.01"/><line x1="17" y1="17" x2="17" y2="17.01"/></svg>
-                          QR 코드 체크인
-                        </button>
-                        <button class="ph-card__cta ph-card__cta--outlined">
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-                          참가자 명단
-                        </button>
+	                        <button class="ph-card__cta">
+	                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="7" y="7" width="3" height="3"/><rect x="14" y="7" width="3" height="3"/><rect x="7" y="14" width="3" height="3"/><path d="M3 7V5a2 2 0 0 1 2-2h2"/><path d="M17 3h2a2 2 0 0 1 2 2v2"/><path d="M21 17v2a2 2 0 0 1-2 2h-2"/><path d="M7 21H5a2 2 0 0 1-2-2v-2"/><line x1="14" y1="14" x2="14" y2="14.01"/><line x1="17" y1="14" x2="17" y2="14.01"/><line x1="14" y1="17" x2="14" y2="17.01"/><line x1="17" y1="17" x2="17" y2="17.01"/></svg>
+	                          참가자 체크인
+	                        </button>
                       </div>
                     </div>
                   </div>
@@ -1539,14 +1541,10 @@ body.dark-mode .viewport {
                             <span><span class="ph-card__live-progress-legend ph-card__live-progress-legend--total"></span>정원 20</span>
                           </div>
                         </div>
-                        <button class="ph-card__cta">
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="7" y="7" width="3" height="3"/><rect x="14" y="7" width="3" height="3"/><rect x="7" y="14" width="3" height="3"/><path d="M3 7V5a2 2 0 0 1 2-2h2"/><path d="M17 3h2a2 2 0 0 1 2 2v2"/><path d="M21 17v2a2 2 0 0 1-2 2h-2"/><path d="M7 21H5a2 2 0 0 1-2-2v-2"/><line x1="14" y1="14" x2="14" y2="14.01"/><line x1="17" y1="14" x2="17" y2="14.01"/><line x1="14" y1="17" x2="14" y2="17.01"/><line x1="17" y1="17" x2="17" y2="17.01"/></svg>
-                          QR 코드 체크인
-                        </button>
-                        <button class="ph-card__cta ph-card__cta--outlined">
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-                          참가자 명단
-                        </button>
+	                        <button class="ph-card__cta">
+	                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="7" y="7" width="3" height="3"/><rect x="14" y="7" width="3" height="3"/><rect x="7" y="14" width="3" height="3"/><path d="M3 7V5a2 2 0 0 1 2-2h2"/><path d="M17 3h2a2 2 0 0 1 2 2v2"/><path d="M21 17v2a2 2 0 0 1-2 2h-2"/><path d="M7 21H5a2 2 0 0 1-2-2v-2"/><line x1="14" y1="14" x2="14" y2="14.01"/><line x1="17" y1="14" x2="17" y2="14.01"/><line x1="14" y1="17" x2="14" y2="17.01"/><line x1="17" y1="17" x2="17" y2="17.01"/></svg>
+	                          참가자 체크인
+	                        </button>
                       </div>
                     </div>
                   </div>
@@ -1642,10 +1640,9 @@ body.dark-mode .viewport {
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>
           <td>
-            ① <strong>"QR 코드 체크인"</strong> (primary) → QR 스캐너 화면. 빠른 체크인 흐름.<br>
-            ② <strong>"참가자 명단"</strong> (outlined) → 명단 화면 (수동 체크인 / 워크인 / 노쇼 / 전화 등 운영 액션).<br>
-            ③ 진행 중 카드 영역 탭 → 이벤트 상세.<br>
-            ④ 다른 섹션 동작은 baseline과 동일 (진행 임박 카드 명단 CTA 등).
+	            ① <strong>"참가자 체크인"</strong> (primary) → <a href="/specs/ongoing_event_list_page/index.html"><code>OngoingEventListPage</code></a>. QR mode / 참가자 명단 / 수동 체크인을 한 화면에서 처리.<br>
+	            ② 진행 중 카드 영역 탭 → 이벤트 상세.<br>
+	            ③ 다른 섹션 동작은 baseline과 동일.
           </td>
         </tr>
         <tr>
@@ -1654,15 +1651,15 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td class="state-mini__aspect">컴포넌트</td>
-          <td>+ 🟣✨ 진행 중 섹션 (보라 블링크 도트 + ⓘ 도움말).<br>+ LIVE 카드 (detail style · 빨간 LIVE chip 펄스 + 3-layer 진행 바[체크인 solid + 참가 faded + 정원 트랙] + dual CTA: <code>QR 코드 체크인</code> primary + <code>참가자 명단</code> outlined).<br>− baseline의 이벤트 참가 승인 대기 섹션은 진행 중 동안 비어있음 (신청 차단).<br>+ 진행 임박 섹션은 그대로 (다음 이벤트가 D-7 이내라면).</td>
+	          <td>+ 🟣✨ 진행 중 섹션 (보라 블링크 도트 + ⓘ 도움말).<br>+ LIVE 카드 (detail style · 빨간 LIVE chip 펄스 + 3-layer 진행 바[체크인 solid + 참가 faded + 정원 트랙] + single CTA: <code>참가자 체크인</code> primary).<br>− baseline의 이벤트 참가 승인 대기 섹션은 진행 중 동안 비어있음 (신청 차단).<br>+ 진행 임박 섹션은 그대로 (다음 이벤트가 D-7 이내라면).</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">토큰</td>
-          <td>+ <code>color-error</code> (LIVE chip 배경 + 펄스 도트), <code>color-primary</code> (진행 중 섹션 도트 블링크 + QR CTA), <code>color-success</code> (진행 바 체크인 solid + 참가 fade)<br>· LIVE chip 펄스 (1.4s ease-in-out, opacity 1↔0.3).</td>
+	          <td>+ <code>color-error</code> (LIVE chip 배경 + 펄스 도트), <code>color-primary</code> (진행 중 섹션 도트 블링크 + 참가자 체크인 CTA), <code>color-success</code> (진행 바 체크인 solid + 참가 fade)<br>· LIVE chip 펄스 (1.4s ease-in-out, opacity 1↔0.3).</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">노트</td>
-          <td>📝 LIVE는 운영 현황 바로 다음 (피드 최상단). dual CTA로 QR 빠른 진입 + 명단 manual ops 두 진입점 분리. 체크인 진행 단계별 시각은 "진행 중 카드 · 진행 단계별 변형" 7단계 참고.</td>
+	          <td>📝 LIVE는 운영 현황 바로 다음 (피드 최상단). QR 빠른 진입과 명단 manual ops를 한 CTA로 합치고, 실제 분기는 OngoingEventListPage 내부 QR mode가 담당한다. 체크인 진행 단계별 시각은 "진행 중 카드 · 진행 단계별 변형" 7단계 참고.</td>
         </tr>
       </tbody>
     </table>
@@ -2354,7 +2351,7 @@ body.dark-mode .viewport {
         <tr>
           <td>2</td>
           <td><strong>진행 중</strong></td>
-          <td>이벤트 detail 카드 (LIVE chip + dual CTA QR/명단) 또는 사전 체크인 대기 카드</td>
+          <td>이벤트 detail 카드 (LIVE chip + single CTA 참가자 체크인) 또는 사전 체크인 대기 카드</td>
           <td>🟣 primary blink</td>
           <td>이벤트 당일(D-0) 또는 LIVE 진행 중인 이벤트 1+</td>
         </tr>
@@ -2539,8 +2536,7 @@ body.dark-mode .viewport {
                   </div>
                   <div class="ph-card__detail-meta">강남 와인러버스 · 체크인 17:30부터</div>
                   <div class="ph-card__cta-note">체크인은 17:30부터 가능해요</div>
-                  <button class="ph-card__cta ph-card__cta--disabled">QR 코드 체크인</button>
-                  <button class="ph-card__cta ph-card__cta--outlined">참가자 명단</button>
+                  <button class="ph-card__cta">참가자 체크인</button>
                 </div>
               </div>
             </div>
@@ -2583,8 +2579,7 @@ body.dark-mode .viewport {
                       <span><span class="ph-card__live-progress-legend ph-card__live-progress-legend--total"></span>정원 20</span>
                     </div>
                   </div>
-                  <button class="ph-card__cta">QR 코드 체크인</button>
-                  <button class="ph-card__cta ph-card__cta--outlined">참가자 명단</button>
+                  <button class="ph-card__cta">참가자 체크인</button>
                 </div>
               </div>
             </div>
@@ -2626,8 +2621,7 @@ body.dark-mode .viewport {
                       <span><span class="ph-card__live-progress-legend ph-card__live-progress-legend--total"></span>정원 20</span>
                     </div>
                   </div>
-                  <button class="ph-card__cta">QR 코드 체크인</button>
-                  <button class="ph-card__cta ph-card__cta--outlined">참가자 명단</button>
+                  <button class="ph-card__cta">참가자 체크인</button>
                 </div>
               </div>
             </div>
@@ -2670,8 +2664,7 @@ body.dark-mode .viewport {
                     </div>
                   </div>
                   <div class="ph-card__cta-note ph-card__cta-note--success">체크인 완료! 모든 참가자 도착했어요 ✓</div>
-                  <button class="ph-card__cta ph-card__cta--disabled">QR 코드 체크인</button>
-                  <button class="ph-card__cta ph-card__cta--outlined">참가자 명단</button>
+                  <button class="ph-card__cta">참가자 체크인</button>
                 </div>
               </div>
             </div>
@@ -2714,8 +2707,7 @@ body.dark-mode .viewport {
                     </div>
                   </div>
                   <div class="ph-card__cta-note ph-card__cta-note--success">정원 만석! 체크인 완료 ✨</div>
-                  <button class="ph-card__cta ph-card__cta--disabled">QR 코드 체크인</button>
-                  <button class="ph-card__cta ph-card__cta--outlined">참가자 명단</button>
+                  <button class="ph-card__cta">참가자 체크인</button>
                 </div>
               </div>
             </div>
@@ -2761,7 +2753,7 @@ body.dark-mode .viewport {
             · 회색 체크 아이콘 + "이벤트명 · 종료" 타이틀<br>
             · sub: 결과 요약 (참석 / 매출 / 출석률)<br>
             · 카드 탭 → 이벤트 상세 (다음 회차 만들기 / 후기 / 사진 / 명단 등 모든 액션)<br>
-            · QR / 진행 바 / dual CTA 모두 제거 — chip 형태로 가벼움 유지<br>
+            · QR / 진행 바 / 참가자 체크인 CTA 모두 제거 — chip 형태로 가벼움 유지<br>
             · 종료 후 24시간 동안 홈에 남고, 그 후 자동 소멸 (정산 탭에서 계속 추적)
           </td>
         </tr>
@@ -3429,16 +3421,10 @@ body.dark-mode .viewport {
           <td>guide 메인 거치지 않고 해당 토픽 modal sheet push</td>
         </tr>
         <tr>
-          <td>진행 중 카드 — "QR 코드 체크인" CTA</td>
-          <td>QR 스캐너 화면</td>
-          <td>📝 TBD</td>
-          <td>체크인 탭의 sub-screen 또는 별도</td>
-        </tr>
-        <tr>
-          <td>진행 중 / 진행 임박 카드 — "참가자 명단" CTA</td>
+          <td>진행 중 / D-0 진행 임박 카드 — "참가자 체크인" CTA</td>
           <td><a href="/specs/ongoing_event_list_page/index.html"><code>OngoingEventListPage</code></a></td>
           <td>✅</td>
-          <td>QR inline split / 워크인 / 노쇼 / 전화 액션 모두 여기서 (#2220)</td>
+          <td>QR inline mode / 참가자 명단 / 수동 체크인 / 워크인 / 노쇼 / 전화 액션 모두 여기서 (#2220, #2999)</td>
         </tr>
         <tr>
           <td>진행 중 / 모집 중 / 진행 임박 카드 영역 탭</td>
@@ -3490,9 +3476,9 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td>하단 nav — 체크인</td>
-          <td>체크인 탭 (LIVE 운영 dashboard)</td>
-          <td>📝 TBD</td>
-          <td>진행 중 이벤트 있을 때 dashboard로 변신 — 별도 PR로 강화 예정</td>
+          <td><a href="/specs/checkin_placeholder_page/index.html"><code>CheckinTabRoute</code></a></td>
+          <td>✅</td>
+          <td>0개 empty · 1개 OngoingEventListPage direct · 2+ selector 후 OngoingEventListPage (#2999)</td>
         </tr>
         <tr>
           <td>하단 nav — 정산</td>

--- a/apps/mds/docs/src/lib/flow-data.ts
+++ b/apps/mds/docs/src/lib/flow-data.ts
@@ -402,7 +402,7 @@ const ROUTE_DESIGN_OVERRIDES: Record<string, string> = {
   // PartnerGuideRoute → template-driven guide hub. Default rule yields
   // 'partner_guide_page', but the single reusable spec is partner_guide.
   'partner-PartnerGuideRoute':        '/specs/partner_guide/index.html',
-  // CheckinRoute → CheckinPlaceholderPage. Default rule yields 'checkin_page'.
+  // CheckinRoute → CheckinTabRoute resolver spec. Default rule yields 'checkin_page'.
   'partner-CheckinRoute':            '/specs/checkin_placeholder_page/index.html',
   // ApplicationDetailRoute (partner) → PartnerApplicationDetailPage (admin-side
   // partner application review). Distinct from EventApplicationDetailRoute.


### PR DESCRIPTION
## Summary

- Reframe `CheckinPlaceholderPage` as the `CheckinTabRoute` route resolver rather than a standalone visible screen.
- Collapse PartnerHome LIVE/D-0 check-in CTAs into a single `참가자 체크인` CTA.
- Mark `OngoingEventListPage` as the canonical participant check-in dashboard for PartnerHome and CheckinTabRoute.

## Contract

- 0 active events: `CheckinTabRoute` shows empty guidance.
- 1 active event: route directly to `OngoingEventListPage(eventId)`.
- 2+ active events: select event, then route to `OngoingEventListPage(eventId)`.
- QR scanning is handled as inline QR mode inside `OngoingEventListPage`, not as a separate PartnerHome CTA.

## Verification

- `npm run lint --workspace=apps/mds/docs`
- `npm run build --workspace=apps/mds/docs`
- `git diff --check`
- Local HTTP smoke via Node fetch:
  - `200 /specs/checkin_placeholder_page/index.html`
  - `200 /specs/partner_home_page/index.html`
  - `200 /specs/ongoing_event_list_page/index.html`

Refs #2222
Closes #2999