### PR TITLE
ci: move post-merge follow-up to dev-staging

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -18,7 +18,7 @@
 | `sync-` | repo 에 자동 commit/push 가 실패함 (dev-staging push 또는 merge 기반) | `sync-graphify`, `sync-mds-mockups`, `sync-pr-branches`, `sync-test-coverage` |
 | `set-` | GitHub status/metadata 를 쓰는 수동·자동 API entrypoint 실패 | `set-dev-soak-status`, `set-rc-soak-status` |
 | `triage-` | 이슈 생성·슬래시 명령 (commit 없음) | `triage-mds-issue`, `triage-slash` |
-| `post-merge` | dev push 직후 follow-up 자동화의 단일 entry point (5 reusable orchestrator) | `post-merge` |
+| `post-merge` | dev-staging push 직후 일반 PR flow follow-up 자동화의 단일 entry point | `post-merge` |
 | `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
 | `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy`, `shared-ios-deploy`, `shared-vercel-deploy`, `shared-set-commit-status`, `shared-soak-gate`, `shared-promo-tag`, `shared-pr-source-guard` |
 | branch-strategy stage name | branch-strategy 문서의 stage entry workflow | `dev-staging-pr-gate`, `dev-staging-dev-cut-gate`, `dev-staging-dev-cut`, `dev-pr-gate`, `dev-rc-cut-gate`, `dev-rc-cut`, `rc-pr-gate`, `rc-main-cut-gate`, `rc-main-cut`, `main-pr-gate` |
@@ -68,7 +68,7 @@
 - `pr-setup-` vs `pr-review-setup-` vs `sync-` vs `triage-` 의 기준:
   - `pr-setup-` = PR push 마다 PR 브랜치를 mutate (#2627 이후 인스턴스 없음 — auto-format 은 `pr-gate` 의 `format-check` 잡으로 대체)
   - `pr-review-setup-` = PR 의 "리뷰 준비 단계" 자동화 (auto-merge enable, `needs-review` 라벨 부여)
-  - `sync-` = dev push 또는 merge 기반으로 repo 에 commit 을 자동 push
+  - `sync-` = dev-staging push 또는 merge 기반으로 repo 에 commit 을 자동 push
   - `triage-` = 이슈 생성·슬래시 명령 (commit 없음, PR 외 컨텍스트에서도 동작)
 
 ## 관련

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,7 +1,6 @@
-# Post-merge orchestrator — single push:dev entry point for follow-up automation that
-# previously lived in separate workflows (sync-pr-branches, triage-mds-issue,
-# sync-mds-mockups, sync-test-coverage). Only non-branch-mutating jobs stay attached
-# to push:dev; generated artifacts/reports must not auto-commit to dev/rc/main.
+# Post-merge orchestrator — single push:dev-staging entry point for follow-up
+# automation attached to normal PR flow. dev is promotion-only; deploy and health
+# workflows stay attached directly to push:dev.
 #
 # sync-graphify (independent schedule) and sync-version (pull_request: closed) are
 # deliberately NOT consolidated — different trigger semantics.
@@ -10,7 +9,7 @@ name: post-merge
 
 on:
   push:
-    branches: [dev]
+    branches: [dev-staging]
   workflow_dispatch:
 
 # Union of permissions needed across all called reusables; each reusable still declares
@@ -40,9 +39,11 @@ jobs:
               - 'apps/mds/docs/src/lib/components.ts'
               - 'apps/mds/docs/src/components/specs/**'
 
-  # No paths gate: previously fired on every push:dev regardless of files.
+  # No paths gate: keep dev-staging auto-merge PRs current after dev-staging moves.
   sync-pr-branches:
     uses: ./.github/workflows/sync-pr-branches.yml
+    with:
+      base_ref: dev-staging
     secrets: inherit
 
   # Push-event-only: reusable consumes github.event.before for diff computation, which

--- a/.github/workflows/sync-mds-mockups.yml
+++ b/.github/workflows/sync-mds-mockups.yml
@@ -1,6 +1,6 @@
 name: sync-mds-mockups
 
-# Invoked by post-merge.yml on push to dev (paths filter applied at caller level).
+# Legacy workflow_call/manual reusable; not invoked by current post-merge.
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/sync-pr-branches.yml
+++ b/.github/workflows/sync-pr-branches.yml
@@ -1,9 +1,21 @@
 name: sync-pr-branches
 
-# Invoked by post-merge.yml on push to dev. workflow_dispatch retained for manual reruns.
+# Invoked by post-merge.yml on push to dev-staging. workflow_dispatch retained for manual reruns.
 on:
   workflow_call:
+    inputs:
+      base_ref:
+        description: PR base branch to scan for auto-merge branch updates.
+        required: false
+        type: string
+        default: dev-staging
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: PR base branch to scan for auto-merge branch updates.
+        required: false
+        type: string
+        default: dev-staging
 
 # Fix #1972: permissions moved to job level (minimum necessary scope)
 # Workflow-level permissions removed to avoid granting write access to all jobs.
@@ -11,7 +23,7 @@ on:
 # Fix #2634: cancel-in-progress causes every run to be cancelled when dev merges happen in rapid succession.
 # update-branch is idempotent — duplicate runs are safe; cancellation is harmful.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ inputs.base_ref || 'dev-staging' }}
   cancel-in-progress: false
 
 jobs:
@@ -30,20 +42,22 @@ jobs:
           # created with conclusion=action_required and never execute). PAT-authed
           # pushes count as real-user events and trigger downstream CI normally.
           GH_TOKEN: ${{ secrets.GH_PAT_VERSION_BUMP }}
+          BASE_REF: ${{ inputs.base_ref }}
         run: |
           REPO="${{ github.repository }}"
+          BASE_REF="${BASE_REF:-dev-staging}"
           # Fix #1972: cap on update *attempts* (not enumeration) so every PR's
           # mergeStateStatus is visible. PRs beyond the cap are handled next push.
           MAX_UPDATES=20
           UPDATE_COUNT=0
 
-          echo "Checking open PRs with auto-merge enabled..."
+          echo "Checking open PRs with auto-merge enabled for base ${BASE_REF}..."
 
           while IFS= read -r PR_NUM; do
             [ -z "$PR_NUM" ] && continue
 
             if [ "$UPDATE_COUNT" -ge "$MAX_UPDATES" ]; then
-              echo "⚠️  WARNING: reached update cap of $MAX_UPDATES — remaining PRs handled on next dev push"
+              echo "⚠️  WARNING: reached update cap of $MAX_UPDATES — remaining PRs handled on next ${BASE_REF} push"
               break
             fi
 
@@ -59,6 +73,6 @@ jobs:
             else
               echo "PR #$PR_NUM is $MERGE_STATE — skipping"
             fi
-          done < <(gh pr list --repo "$REPO" --base dev --state open --limit 100 \
+          done < <(gh pr list --repo "$REPO" --base "$BASE_REF" --state open --limit 100 \
             --json number,autoMergeRequest \
             --jq '.[] | select(.autoMergeRequest != null) | .number')

--- a/.github/workflows/sync-test-coverage.yml
+++ b/.github/workflows/sync-test-coverage.yml
@@ -5,7 +5,7 @@ name: sync-test-coverage
 #
 # 매트릭스로 변경된 프로젝트만 측정해서 noise 줄임. 변경 없으면 commit skip.
 
-# Invoked by post-merge.yml on push to dev (paths filter applied at caller level).
+# Legacy workflow_call/manual reusable; not invoked by current post-merge.
 # Internal matrix still re-filters per-project via the nested `changes` job, so the outer
 # caller-level filter is intentionally coarse (any flutter file → call this workflow).
 on:

--- a/.github/workflows/triage-mds-issue.yml
+++ b/.github/workflows/triage-mds-issue.yml
@@ -1,6 +1,6 @@
 name: triage-mds-issue
 
-# Invoked by post-merge.yml on push to dev (paths filter applied at caller level).
+# Invoked by post-merge.yml on push to dev-staging (paths filter applied at caller level).
 # Relies on github.event.before/head_commit; only safe under push context — caller gates with
 # `if: github.event_name == 'push'` so workflow_dispatch on the caller does not call this.
 on:

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -9,7 +9,7 @@
                               │
                               └─daily dev-staging-dev-cut merge-commit snapshot PR──▶ dev
                                                               │
-                                                              ├─▶ dev-rc-cut-gate (post-merge 자동)
+                                                              ├─▶ dev push health/deploy + daily dev-rc-cut-gate
                                                               │      │
                                                               │      ├─ pass: status dev-rc-cut-pass
                                                               │      │         │

--- a/docs/infra/branch-strategy/dev-staging-pipeline.md
+++ b/docs/infra/branch-strategy/dev-staging-pipeline.md
@@ -2,10 +2,11 @@
 
 AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 진입점. 일반 PR + auto-merge 로 처리하고, `dev-staging-pr-gate` 가 가벼운 검증을 담당한다. source version bump 와 `v*-dev-staging` tag 는 PR 머지마다 만들지 않고, 하루 1회 `dev-staging-dev-cut` 이 promote 할 snapshot 에만 만든다.
 
-## 두 가지 workflow
+## 세 가지 workflow
 
 1. **`dev-staging-pr-gate`** — PR 머지 전
-2. **`dev-staging-dev-cut`** — daily cut 시점 (direct version bump commit + tag + dev promotion PR)
+2. **`post-merge`** — PR 머지 후 dev-staging follow-up (auto-merge PR branch update + MDS triage)
+3. **`dev-staging-dev-cut`** — daily cut 시점 (direct version bump commit + tag + dev promotion PR)
 
 ## PR + Auto-Merge
 
@@ -31,10 +32,10 @@ AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 �
 - 운영 복잡도를 낮추고 기존 GitHub auto-merge 흐름을 재사용한다
 - 필요해지면 `dev-staging` 에만 merge queue 를 후속 도입한다
 
-### 결정해야 할 것
+### 운영 기준
 
-- branch update 자동화 방식 (`gh api update-branch` vs 기존 sync-pr-branches 재사용)
-- merge queue 도입 기준 (동시 PR 수, conflict 빈도, stale 재실행 비용)
+- branch update 자동화는 `post-merge` 가 `sync-pr-branches` 를 `base_ref=dev-staging` 으로 호출한다.
+- merge queue 도입 기준은 동시 PR 수, conflict 빈도, stale 재실행 비용을 보고 별도 판단한다.
 
 ## `dev-staging-pr-gate`
 

--- a/docs/infra/branch-strategy/specs/execution-plan.md
+++ b/docs/infra/branch-strategy/specs/execution-plan.md
@@ -10,12 +10,12 @@
 |----------|------|------------------|
 | **Deploy** | `dev-deploy`, `rc-deploy`, `main-deploy`, `deploy-android-{user,partner}`, `deploy-ios-{user,partner}`, `deploy-dev-seed`, `shared-android-deploy` | branch-level deploy entrypoint + reusable/domain deploy jobs |
 | **PR / Review** | `pr-gate`, `pr-review-setup`, `doc-freshness` | spec 의 pr-gate-core 의 base — 추출·일반화 대상 |
-| **Post-merge** | `post-merge` (dev push orchestrator), `sync-pr-branches`, `sync-test-coverage`, `sync-mds-mockups`, `sync-graphify` | dev push follow-up 자동화. branch-mutating generated report sync 는 dev/rc/main 에 붙이지 않는다 |
+| **Post-merge** | `post-merge` (dev-staging push orchestrator), `sync-pr-branches`, `triage-mds-issue` | 일반 PR flow follow-up 자동화. dev 는 promotion-only 이므로 deploy/health workflow 만 push 에 직접 붙인다 |
 | **Reusable** | `shared-android-deploy`, `shared-cuj-integration`, `shared-notify` | spec 의 reusable 패턴 — 추가 reusable extract 시 참고 |
 | **Monitor** | `monitor-allure`, `monitor-cuj-coverage`, `monitor-db-invariants`, `monitor-deno-coverage`, `monitor-event-flow-*`, `monitor-mds-render-coverage`, `monitor-patrol-e2e` | 본 release pipeline 과 orthogonal — 유지 |
 | **Triage** | `triage-mds-issue`, `triage-slash` | 동상 — 유지 |
 
-> `post-merge.yml` 주석에 *"single push:dev entry point for follow-up automation that previously lived in 5 separate workflows"* — 이미 orchestrator 패턴이 도입돼있음. 우리 spec 도 비슷한 방향 (`*-post-merge-sync` entry workflow 가 reusable 호출).
+> `post-merge.yml` 은 `dev-staging` push 직후 일반 PR flow follow-up 을 묶는 orchestrator 다. dev push 는 promotion 결과의 deploy/health signal 에만 사용한다.
 
 ## Existing → Spec mapping
 


### PR DESCRIPTION
## Summary

- Move `post-merge` from `push: dev` to `push: dev-staging` because `dev` is promotion-only.
- Parameterize `sync-pr-branches` with `base_ref` and call it with `dev-staging`.
- Update MDS triage and branch-strategy docs to treat post-merge as dev-staging PR-flow follow-up.

## Contract

`dev` keeps promotion/deploy/health workflows only. General PR-flow follow-up now belongs to `dev-staging`:

- auto-merge PR branch update: `sync-pr-branches(base_ref=dev-staging)`
- MDS changed-file detection: `changes`
- MDS impact issue creation: `triage-mds-issue`

No linked issue: requested branch strategy workflow cleanup.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/post-merge.yml .github/workflows/sync-pr-branches.yml .github/workflows/triage-mds-issue.yml .github/workflows/sync-test-coverage.yml .github/workflows/sync-mds-mockups.yml`
- read-only `gh pr list --base dev-staging` check for the new `sync-pr-branches` target

Note: `actionlint` is not installed in the local environment.
