### PR TITLE
docs(mds): refine partner home checkin ctas

### DIFF
--- a/apps/mds/docs/public/specs/BLUEDOC.md
+++ b/apps/mds/docs/public/specs/BLUEDOC.md
@@ -40,4 +40,4 @@ MDS 화면 spec 의 **source HTML + 자동 산출물 디렉터리**. Flutter 화
 - [`../../src/lib/flow-data.ts`](../../src/lib/flow-data.ts) — route/spec 매핑
 
 ---
-_Reviewed: 2026-06-03 17:18_
+_Reviewed: 2026-06-03 17:27_

--- a/apps/mds/docs/public/specs/BLUEDOC.md
+++ b/apps/mds/docs/public/specs/BLUEDOC.md
@@ -40,4 +40,4 @@ MDS 화면 spec 의 **source HTML + 자동 산출물 디렉터리**. Flutter 화
 - [`../../src/lib/flow-data.ts`](../../src/lib/flow-data.ts) — route/spec 매핑
 
 ---
-_Reviewed: 2026-06-03 17:04 KST_
+_Reviewed: 2026-06-03 17:04_

--- a/apps/mds/docs/public/specs/BLUEDOC.md
+++ b/apps/mds/docs/public/specs/BLUEDOC.md
@@ -40,4 +40,4 @@ MDS 화면 spec 의 **source HTML + 자동 산출물 디렉터리**. Flutter 화
 - [`../../src/lib/flow-data.ts`](../../src/lib/flow-data.ts) — route/spec 매핑
 
 ---
-_Reviewed: 2026-06-03 17:04_
+_Reviewed: 2026-06-03 17:18_

--- a/apps/mds/docs/public/specs/BLUEDOC.md
+++ b/apps/mds/docs/public/specs/BLUEDOC.md
@@ -40,4 +40,4 @@ MDS 화면 spec 의 **source HTML + 자동 산출물 디렉터리**. Flutter 화
 - [`../../src/lib/flow-data.ts`](../../src/lib/flow-data.ts) — route/spec 매핑
 
 ---
-_Reviewed: 2026-06-03 16:10_
+_Reviewed: 2026-06-03 17:04 KST_

--- a/apps/mds/docs/public/specs/ongoing_event_list_page/index.html
+++ b/apps/mds/docs/public/specs/ongoing_event_list_page/index.html
@@ -540,7 +540,7 @@ body.dark-mode .viewport {
   <h2>Overview</h2>
   <table class="ref">
     <tbody>
-      <tr><th style="width: 140px;">Status</th><td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— canonical destination for "참가자 체크인" · Flutter route / implementation TBD</em></td></tr>
+      <tr><th style="width: 140px;">Status</th><td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— canonical destination for PartnerHome "참가자 리스트" pre-start entry + "참가자 체크인" active entry · Flutter route / implementation TBD</em></td></tr>
       <tr><th>App</th><td><code>app_partner</code></td></tr>
       <tr><th>Category</th><td>event operation · check-in · live dashboard</td></tr>
       <tr><th>Route / Surface</th><td><code>OngoingEventListPage</code> · participant check-in / live operation dashboard</td></tr>
@@ -548,7 +548,7 @@ body.dark-mode .viewport {
       <tr>
         <th>Hierarchy</th>
         <td>
-          <strong>Parent</strong>: <a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a> LIVE/D-0 진행 임박 카드 "참가자 체크인" CTA · <a href="/specs/checkin_placeholder_page/index.html"><code>CheckinTabRoute</code></a> 1-event direct / 2+ selector · <a href="/specs/partner_event_detail_page/index.html"><code>PartnerEventDetailPage</code></a> 참가 현황.<br>
+          <strong>Parent</strong>: <a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a> 진행 임박/D-0 체크인 대기 카드 "참가자 리스트" outline CTA · T-2 이후 체크인 가능/LIVE 카드 "참가자 체크인" primary CTA · <a href="/specs/checkin_placeholder_page/index.html"><code>CheckinTabRoute</code></a> 1-event direct / 2+ selector · <a href="/specs/partner_event_detail_page/index.html"><code>PartnerEventDetailPage</code></a> 참가 현황.<br>
           <strong>Children</strong>: row action bottom sheet · inline QR scanner 영역 (별도 route 없음).
         </td>
       </tr>
@@ -558,7 +558,7 @@ body.dark-mode .viewport {
       </tr>
       <tr>
         <th>User journey</th>
-        <td><strong>Entry points</strong>: PartnerHomePage LIVE/D-0 진행 임박 카드의 "참가자 체크인" CTA · PartnerEventDetailPage 참가 현황 · CheckinTabRoute의 1-event direct / 2+ event selector.<br><strong>Exit points</strong>: 뒤로 가기 → parent route · row action sheet dismiss · 종료 후 read-only 회고에서 EventApplicationListPage/Settlement flow로 이동 가능.</td>
+        <td><strong>Entry points</strong>: PartnerHomePage 진행 임박/D-0 체크인 대기 카드의 "참가자 리스트" outline CTA(pre_start/readiness list mode) · PartnerHomePage T-2 이후 체크인 가능/LIVE 카드의 "참가자 체크인" primary CTA(checkin_ready/live mode) · PartnerEventDetailPage 참가 현황 · CheckinTabRoute의 1-event direct / 2+ event selector.<br><strong>Exit points</strong>: 뒤로 가기 → parent route · row action sheet dismiss · 종료 후 read-only 회고에서 EventApplicationListPage/Settlement flow로 이동 가능.</td>
       </tr>
       <tr><th>Background</th><td>기존 참가 신청 리스트는 심사/결제 상태 관리에 최적화되어 있다. 실제 이벤트 운영 시간에는 체크인 완료율, 미도착자 탐색, QR 스캔, 수동 체크인/노쇼/메모가 더 중요하므로 별도 운영 모드가 필요하다.</td></tr>
       <tr><th>Frequency</th><td>이벤트 당일 집중 사용. 시작 2시간 전부터 종료 후 24시간까지 접근 가능하고, 이후에는 read-only history surface로만 연결한다.</td></tr>
@@ -570,9 +570,10 @@ body.dark-mode .viewport {
   <h2>History</h2>
   <table class="ref">
     <thead><tr><th style="width: 110px;">Date</th><th style="width: 80px;">Version</th><th style="width: 120px;">Author</th><th>Changes</th></tr></thead>
-	    <tbody>
-	      <tr><td>2026-06-03</td><td>0.2</td><td>codex</td><td>#2999: PartnerHome의 "QR 코드 체크인" + "참가자 명단" dual CTA를 "참가자 체크인" single CTA로 수렴. CheckinTabRoute 1-event direct / 2+ selector의 canonical destination으로 지정.</td></tr>
-	      <tr><td>2026-06-03</td><td>0.1</td><td>codex</td><td>Initial MDS spec for #2220. Defines 5 operational states, sticky LIVE counter, inline QR split, participant row action sheet, wakelock indicator, and route/implementation TBD boundaries.</td></tr>
+    <tbody>
+      <tr><td>2026-06-03</td><td>0.3</td><td>codex</td><td>PartnerHome CTA contract sync: 진행 임박/D-0 체크인 대기는 "참가자 리스트" outline으로 pre_start/readiness list mode에 진입하고, T-2 이후 체크인 가능/LIVE는 "참가자 체크인" primary로 checkin_ready/live mode에 진입.</td></tr>
+      <tr><td>2026-06-03</td><td>0.2</td><td>codex</td><td>#2999: PartnerHome의 "QR 코드 체크인" + "참가자 명단" dual CTA를 "참가자 체크인" single CTA로 수렴. CheckinTabRoute 1-event direct / 2+ selector의 canonical destination으로 지정.</td></tr>
+      <tr><td>2026-06-03</td><td>0.1</td><td>codex</td><td>Initial MDS spec for #2220. Defines 5 operational states, sticky LIVE counter, inline QR split, participant row action sheet, wakelock indicator, and route/implementation TBD boundaries.</td></tr>
     </tbody>
   </table>
 </section>
@@ -873,7 +874,7 @@ body.dark-mode .viewport {
     <table class="ref">
       <thead><tr><th style="width: 280px;">Spec</th><th>Relation</th></tr></thead>
       <tbody>
-        <tr><td><a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a></td><td>Primary entry: LIVE / D-0 진행 임박 card "참가자 체크인" CTA.</td></tr>
+        <tr><td><a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a></td><td>Primary entries: 진행 임박/D-0 체크인 대기 card "참가자 리스트" outline CTA → pre_start/readiness list mode · T-2 이후 체크인 가능/LIVE card "참가자 체크인" primary CTA → checkin_ready/live mode.</td></tr>
         <tr><td><a href="/specs/checkin_placeholder_page/index.html"><code>CheckinTabRoute</code></a></td><td>Bottom nav resolver: 1 event direct, 2+ events after event selection.</td></tr>
         <tr><td><a href="/specs/partner_event_detail_page/index.html"><code>PartnerEventDetailPage</code></a></td><td>Parent event context; 참가 현황 section can deep link here when event is within operation window.</td></tr>
         <tr><td><a href="/specs/event_application_list_page/index.html"><code>EventApplicationListPage</code></a></td><td>Sibling roster/history list focused on application/payment/review status, not live operation.</td></tr>

--- a/apps/mds/docs/public/specs/ongoing_event_list_page/index.html
+++ b/apps/mds/docs/public/specs/ongoing_event_list_page/index.html
@@ -542,7 +542,7 @@ body.dark-mode .viewport {
     <tbody>
       <tr><th style="width: 140px;">Status</th><td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— canonical destination for PartnerHome "참가자 리스트" pre-start entry + "참가자 체크인" active entry · Flutter route / implementation TBD</em></td></tr>
       <tr><th>App</th><td><code>app_partner</code></td></tr>
-      <tr><th>Category</th><td>event operation · check-in · live dashboard</td></tr>
+      <tr><th>Category</th><td>event operation · participant list · check-in · live dashboard</td></tr>
       <tr><th>Route / Surface</th><td><code>OngoingEventListPage</code> · participant check-in / live operation dashboard</td></tr>
       <tr><th>Path</th><td><code>TBD</code> · 권장: <code>/events/:eventId/ongoing</code> 또는 <code>/events/:eventId/live</code></td></tr>
       <tr>
@@ -554,14 +554,14 @@ body.dark-mode .viewport {
       </tr>
       <tr>
         <th>Purpose</th>
-        <td>이벤트 당일 파트너가 참가자 명단과 체크인 상태를 한 화면에서 운영하는 LIVE dashboard. 상단 sticky 카운터와 QR 모드, 검색/필터, 명단 row action sheet를 결합해 운영 중 시선 이동과 오작동을 줄인다.</td>
+        <td>진행 임박부터 이벤트 당일까지 파트너가 참가자 명단과 체크인 상태를 한 화면에서 운영하는 roster/live dashboard. T-7~T-2 pre_start/readiness list mode에서는 명단 확인과 공지 준비를 지원하고, T-2 이후에는 상단 sticky 카운터와 QR 모드, 검색/필터, 명단 row action sheet를 결합해 운영 중 시선 이동과 오작동을 줄인다.</td>
       </tr>
       <tr>
         <th>User journey</th>
         <td><strong>Entry points</strong>: PartnerHomePage 진행 임박/D-0 체크인 대기 카드의 "참가자 리스트" outline CTA(pre_start/readiness list mode) · PartnerHomePage T-2 이후 체크인 가능/LIVE 카드의 "참가자 체크인" primary CTA(checkin_ready/live mode) · PartnerEventDetailPage 참가 현황 · CheckinTabRoute의 1-event direct / 2+ event selector.<br><strong>Exit points</strong>: 뒤로 가기 → parent route · row action sheet dismiss · 종료 후 read-only 회고에서 EventApplicationListPage/Settlement flow로 이동 가능.</td>
       </tr>
       <tr><th>Background</th><td>기존 참가 신청 리스트는 심사/결제 상태 관리에 최적화되어 있다. 실제 이벤트 운영 시간에는 체크인 완료율, 미도착자 탐색, QR 스캔, 수동 체크인/노쇼/메모가 더 중요하므로 별도 운영 모드가 필요하다.</td></tr>
-      <tr><th>Frequency</th><td>이벤트 당일 집중 사용. 시작 2시간 전부터 종료 후 24시간까지 접근 가능하고, 이후에는 read-only history surface로만 연결한다.</td></tr>
+      <tr><th>Frequency</th><td>진행 임박(T-7 이내)부터 종료 후 24시간까지 접근 가능. T-7~T-2는 pre_start/readiness list mode로 QR/check-in action을 비활성화하고, T-2 이후부터 checkin_ready/live operation mode로 QR/수동 체크인을 활성화한다. 종료 후 24시간 이후에는 read-only history surface로만 연결한다.</td></tr>
     </tbody>
   </table>
 </section>
@@ -571,7 +571,7 @@ body.dark-mode .viewport {
   <table class="ref">
     <thead><tr><th style="width: 110px;">Date</th><th style="width: 80px;">Version</th><th style="width: 120px;">Author</th><th>Changes</th></tr></thead>
     <tbody>
-      <tr><td>2026-06-03</td><td>0.3</td><td>codex</td><td>PartnerHome CTA contract sync: 진행 임박/D-0 체크인 대기는 "참가자 리스트" outline으로 pre_start/readiness list mode에 진입하고, T-2 이후 체크인 가능/LIVE는 "참가자 체크인" primary로 checkin_ready/live mode에 진입.</td></tr>
+      <tr><td>2026-06-03</td><td>0.3</td><td>codex</td><td>PartnerHome CTA contract sync: 진행 임박/D-0 체크인 대기는 "참가자 리스트" outline으로 T-7~T-2 pre_start/readiness list mode에 진입하고, T-2 이후 체크인 가능/LIVE는 "참가자 체크인" primary로 checkin_ready/live mode에 진입.</td></tr>
       <tr><td>2026-06-03</td><td>0.2</td><td>codex</td><td>#2999: PartnerHome의 "QR 코드 체크인" + "참가자 명단" dual CTA를 "참가자 체크인" single CTA로 수렴. CheckinTabRoute 1-event direct / 2+ selector의 canonical destination으로 지정.</td></tr>
       <tr><td>2026-06-03</td><td>0.1</td><td>codex</td><td>Initial MDS spec for #2220. Defines 5 operational states, sticky LIVE counter, inline QR split, participant row action sheet, wakelock indicator, and route/implementation TBD boundaries.</td></tr>
     </tbody>
@@ -651,7 +651,7 @@ body.dark-mode .viewport {
     <table class="ref">
       <thead><tr><th style="width: 180px;">State</th><th style="width: 120px;">Tag</th><th>Condition</th><th>Key visual differentiator</th></tr></thead>
       <tbody>
-        <tr><td>시작 전</td><td><code>pre_start</code></td><td>이벤트 시작 2시간보다 이전</td><td>QR toggle disabled · 준비 안내 strip</td></tr>
+        <tr><td>시작 전</td><td><code>pre_start</code></td><td>T-7 이내 ~ T-2h</td><td>QR toggle disabled · roster/readiness list · 준비 안내 strip</td></tr>
         <tr><td>체크인 가능</td><td><code>checkin_ready</code></td><td>T-2h ~ start time</td><td>QR toggle enabled · "이제 체크인 받을 수 있어요" strip</td></tr>
         <tr><td>LIVE 진행 중</td><td><code>live</code></td><td>start time ~ end time</td><td>LIVE pulse · wakelock indicator · inline scanner split</td></tr>
         <tr><td>체크인 완료</td><td><code>all_checked_in</code></td><td>paid participant all checked-in before/while live</td><td>100% success progress · scanner collapsed · success empty card</td></tr>

--- a/apps/mds/docs/public/specs/partner_home_page/index.html
+++ b/apps/mds/docs/public/specs/partner_home_page/index.html
@@ -966,15 +966,21 @@ body.dark-mode .viewport {
         <th>Changes</th>
       </tr>
     </thead>
-	    <tbody>
-	      <tr>
-	        <td>2026-06-03</td>
-	        <td>2.1</td>
-	        <td>codex</td>
-	        <td>#2999: LIVE/진행 임박 카드의 <code>QR 코드 체크인</code> + <code>참가자 명단</code> dual CTA를 <code>참가자 체크인</code> single CTA로 수렴. CTA destination은 OngoingEventListPage이며 QR은 inline mode로 처리.</td>
-	      </tr>
-	      <tr>
-	        <td>2026-05-05</td>
+    <tbody>
+      <tr>
+        <td>2026-06-03</td>
+        <td>2.2</td>
+        <td>codex</td>
+        <td>진행 임박 및 D-0 체크인 대기 카드는 active check-in 전 단계로 분리. CTA를 <code>참가자 체크인</code> primary에서 <code>참가자 리스트</code> outline으로 낮추고, T-2 이후 진행 중/체크인 가능 카드만 primary <code>참가자 체크인</code> CTA를 사용하도록 정리.</td>
+      </tr>
+      <tr>
+        <td>2026-06-03</td>
+        <td>2.1</td>
+        <td>codex</td>
+        <td>#2999: LIVE/진행 임박 카드의 <code>QR 코드 체크인</code> + <code>참가자 명단</code> dual CTA를 <code>참가자 체크인</code> single CTA로 수렴. CTA destination은 OngoingEventListPage이며 QR은 inline mode로 처리.</td>
+      </tr>
+      <tr>
+        <td>2026-05-05</td>
         <td>2.0</td>
         <td>mark-yun</td>
         <td>
@@ -1332,9 +1338,9 @@ body.dark-mode .viewport {
                           <div class="ph-card__detail-tag">브런치</div>
                           <div class="ph-card__detail-tag">강남</div>
                         </div>
-                        <button class="ph-card__cta">
+                        <button class="ph-card__cta ph-card__cta--outlined">
                           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-	                          참가자 체크인
+                          참가자 리스트
                         </button>
                       </div>
                     </div>
@@ -1581,9 +1587,9 @@ body.dark-mode .viewport {
                           <div class="ph-card__detail-tag">살사</div>
                           <div class="ph-card__detail-tag">강남</div>
                         </div>
-                        <button class="ph-card__cta">
+                        <button class="ph-card__cta ph-card__cta--outlined">
                           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-                          참가자 체크인
+                          참가자 리스트
                         </button>
                       </div>
                     </div>
@@ -2351,7 +2357,7 @@ body.dark-mode .viewport {
         <tr>
           <td>2</td>
           <td><strong>진행 중</strong></td>
-          <td>이벤트 detail 카드 (LIVE chip + single CTA 참가자 체크인) 또는 사전 체크인 대기 카드</td>
+          <td>이벤트 detail 카드 (D-0 체크인 대기 = 참가자 리스트 outline / T-2 이후 = 참가자 체크인 primary / LIVE chip)</td>
           <td>🟣 primary blink</td>
           <td>이벤트 당일(D-0) 또는 LIVE 진행 중인 이벤트 1+</td>
         </tr>
@@ -2365,7 +2371,7 @@ body.dark-mode .viewport {
         <tr>
           <td>4</td>
           <td><strong>진행 임박</strong></td>
-          <td>이벤트 detail 카드 (D-day chip + capacity bar 3-layer + 참가자 체크인 CTA)</td>
+          <td>이벤트 detail 카드 (D-day chip + capacity bar 3-layer + 참가자 리스트 outline CTA)</td>
           <td>🟠 secondary</td>
           <td>T-7 이내 이벤트 (승인 대기는 별도 섹션, 여기엔 처리 완료된 이벤트만)</td>
         </tr>
@@ -2505,7 +2511,7 @@ body.dark-mode .viewport {
     <h2>카드별 명세 — ② 진행 중 카드 · 단계별 변형</h2>
     <p class="intro">
       "진행 중" 섹션의 카드는 이벤트 당일(D-0) 새벽부터 종료까지 같은 슬롯에서 단계별로 모습이 바뀐다.
-      <strong>체크인은 이벤트 시작 2시간 전부터 활성</strong> — 홈 CTA는 항상 <code>참가자 체크인</code> 하나이며, 그 전엔 OngoingEventListPage 내부 QR mode만 비활성이고 명단/공지 준비는 가능.
+      <strong>체크인은 이벤트 시작 2시간 전부터 활성</strong> — D-0 새벽~T-2에는 <code>참가자 리스트</code> outline으로 OngoingEventListPage pre_start/list mode에 진입하고, T-2 이후부터 <code>참가자 체크인</code> primary로 전환한다.
       LIVE 진입 후엔 chip이 빨간색 펄스로 변경되고 진행 바가 체크인/참가/정원 3-layer로 시각화됨.
     </p>
     <table class="ref">
@@ -2536,7 +2542,10 @@ body.dark-mode .viewport {
                   </div>
                   <div class="ph-card__detail-meta">강남 와인러버스 · 체크인 17:30부터</div>
                   <div class="ph-card__cta-note">체크인은 17:30부터 가능해요</div>
-                  <button class="ph-card__cta">참가자 체크인</button>
+                  <button class="ph-card__cta ph-card__cta--outlined">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+                    참가자 리스트
+                  </button>
                 </div>
               </div>
             </div>
@@ -2544,10 +2553,10 @@ body.dark-mode .viewport {
           <td>
             오늘 진행 예정이지만 아직 체크인 시작 전.<br>
             · D-day chip: warning yellow "오늘 19:30"<br>
-            · CTA는 <strong>"참가자 체크인"</strong> single primary — OngoingEventListPage pre_start로 진입<br>
+            · CTA는 <strong>"참가자 리스트"</strong> outline — OngoingEventListPage pre_start/list mode로 진입<br>
             · 내부 QR mode는 disabled, 명단 조회 / 공지 준비만 가능<br>
             · 체크인 시작 시간 inline note (warning 톤)<br>
-            · 시간이 가까워지면 "체크인 N분 후" 카운트다운으로 변경 가능
+            · T-2부터 "참가자 체크인" primary CTA로 전환
           </td>
         </tr>
         <tr>
@@ -2588,7 +2597,7 @@ body.dark-mode .viewport {
             체크인 윈도우 열림.<br>
             · D-day chip: primary "체크인 가능" (보라)<br>
             · 진행 바 노출 시작 — 페이드(참가) 영역만 visible<br>
-            · CTA는 <strong>"참가자 체크인"</strong> single primary<br>
+            · CTA는 <strong>"참가자 체크인"</strong> single primary — OngoingEventListPage checkin_ready 상태로 진입<br>
             · OngoingEventListPage 내부 QR mode 활성 — 기본은 명단+요약, 운영자가 QR mode를 켤 수 있음<br>
             · 첫 참가자가 도착하기 시작하는 단계
           </td>
@@ -2822,7 +2831,7 @@ body.dark-mode .viewport {
        ============================================================ -->
   <section class="doc">
     <h2>카드별 명세 — ④ 진행 임박 카드 (Detail + capacity bar)</h2>
-    <p class="intro">T-7 이내 이벤트. capacity bar (확정/심사대기/정원 3-layer) + 참가자 체크인 CTA 강조. QR mode는 OngoingEventListPage 내부에서 시간 조건에 따라 활성화한다.</p>
+    <p class="intro">T-7 이내 이벤트. capacity bar (확정/심사대기/정원 3-layer) + 참가자 리스트 outline CTA. 아직 active check-in 단계가 아니므로 액션 강도는 낮추고, OngoingEventListPage는 pre_start/readiness list mode로 열린다.</p>
     <table class="ref">
       <thead><tr><th style="width: 360px;">Mockup</th><th>명세</th></tr></thead>
       <tbody>
@@ -2859,7 +2868,7 @@ body.dark-mode .viewport {
                     <div class="ph-card__detail-tag">브런치</div>
                     <div class="ph-card__detail-tag">강남</div>
                   </div>
-                  <button class="ph-card__cta">참가자 체크인</button>
+                  <button class="ph-card__cta ph-card__cta--outlined">참가자 리스트</button>
                 </div>
               </div>
             </div>
@@ -2871,14 +2880,14 @@ body.dark-mode .viewport {
             · capacity bar (3-layer): 확정 solid primary + 심사대기 0.35 fade + 정원 트랙<br>
             · legend (3 dots + 라벨): 확정 / 심사 대기 / 정원<br>
             · tags (회색 칩): 카테고리 / 지역<br>
-            · primary CTA "참가자 체크인"<br><br>
+            · outline CTA "참가자 리스트"<br><br>
             <strong>D-day chip 색</strong>: D-1~7 = primary purple (soon)<br><br>
             <strong>Variants</strong>:<br>
             · D-3 일반 케이스 (mockup)<br>
             · 정원 만석: capacity bar 100% + chip 라벨 "마감"<br>
             · D-1: chip "D-1" 같은 색 + meta 강조<br>
             · 심사 대기 0: 페이드 영역 0% (해당 이벤트는 다 처리됨)<br><br>
-            <strong>Tap 액션</strong>: 카드 영역 → 이벤트 상세 / "참가자 체크인" CTA → OngoingEventListPage (D-3/D-1은 pre_start/readiness, T-2부터 QR mode 가능)
+            <strong>Tap 액션</strong>: 카드 영역 → 이벤트 상세 / "참가자 리스트" CTA → OngoingEventListPage pre_start/readiness list mode (QR mode는 D-0/T-2부터 활성)
           </td>
         </tr>
       </tbody>
@@ -3423,10 +3432,22 @@ body.dark-mode .viewport {
           <td>guide 메인 거치지 않고 해당 토픽 modal sheet push</td>
         </tr>
         <tr>
-          <td>진행 중 / D-0 진행 임박 카드 — "참가자 체크인" CTA</td>
+          <td>진행 중 / D-0 체크인 대기 카드 — "참가자 리스트" CTA</td>
           <td><a href="/specs/ongoing_event_list_page/index.html"><code>OngoingEventListPage</code></a></td>
           <td>✅</td>
-          <td>QR inline mode / 참가자 명단 / 수동 체크인 / 워크인 / 노쇼 / 전화 액션 모두 여기서 (#2220, #2999)</td>
+          <td>outline CTA · pre_start/list mode · QR mode disabled, 명단/공지 준비 가능 (#2220, #2999)</td>
+        </tr>
+        <tr>
+          <td>진행 중 / T-2 이후 체크인 가능·LIVE 카드 — "참가자 체크인" CTA</td>
+          <td><a href="/specs/ongoing_event_list_page/index.html"><code>OngoingEventListPage</code></a></td>
+          <td>✅</td>
+          <td>primary CTA · QR inline mode / 참가자 명단 / 수동 체크인 / 워크인 / 노쇼 / 전화 액션 모두 여기서 (#2220, #2999)</td>
+        </tr>
+        <tr>
+          <td>진행 임박 카드 — "참가자 리스트" CTA</td>
+          <td><a href="/specs/ongoing_event_list_page/index.html"><code>OngoingEventListPage</code></a></td>
+          <td>✅</td>
+          <td>outline CTA · pre_start/readiness list mode · QR mode는 D-0/T-2부터 활성 (#2220, #2999)</td>
         </tr>
         <tr>
           <td>진행 중 / 모집 중 / 진행 임박 카드 영역 탭</td>


### PR DESCRIPTION
## Summary
- Split PartnerHome CTA intent by check-in availability.
- Use outline `참가자 리스트` for 진행 임박 and D-0 pre-checkin cards.
- Keep primary `참가자 체크인` for T-2+ checkin-ready/LIVE cards and document that it routes to `OngoingEventListPage`.
- Sync `OngoingEventListPage` entry/access contract: T-7~T-2 list/readiness mode, T-2+ active check-in/live mode.

## Verification
- `npm run lint --workspace=apps/mds/docs`
- `npm run build --workspace=apps/mds/docs`
- `curl -I http://127.0.0.1:3003/specs/partner_home_page/index.html`
- `curl -I http://127.0.0.1:3003/specs/ongoing_event_list_page/index.html`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`

Refs #2222 — follow-up tracker; not close because #2222 covers broader ongoing-event ops/UI work.
Refs #2999 — follow-up to the completed CTA route discussion; no close because #2999 is already closed.