### PR TITLE
fix(ci): disable Flutter SPM for iOS deploy

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -11,7 +11,7 @@
 | [`run-partner-cuj.sh`](./run-partner-cuj.sh) | `apps/app_partner/integration_test/cuj/` CUJ 실행. 모든 CUJ 파일을 실행한 뒤 실패 목록 aggregate | `shared-cuj-integration` (app-name=partner 일 때), `monitor-dev-cuj` |
 | [`check-bluedoc-freshness.sh`](./check-bluedoc-freshness.sh) | PR 에서 새/삭제 파일에 대해 가장 가까운 ancestor BLUEDOC.md 갱신 강제. 통과: 이정표 표 갱신 또는 BLUEDOC 의 `_Reviewed_` 날짜 bump. + 모든 BLUEDOC.md 의 Reviewed 형식 검증 | `pr-gate.check-bluedoc-freshness` (required check) |
 | [`check-pr-issue-reference.sh`](./check-pr-issue-reference.sh) | dev-staging PR 본문에 이슈 종료 의도(`Closes/Fixes/Resolves`) 또는 명시적 비종료 사유(`Refs` + 이유 / `No linked issue`)가 있는지 검사 | `pr-gate.static-checks` |
-| [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | `ios-deploy` action 의 브랜치 분기(`main` vs `non-main`) 회귀 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
+| [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | iOS deploy 브랜치·timeout·heartbeat·Flutter SPM off 계약 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
 | [`check-android-deploy-workflow-contract.py`](./check-android-deploy-workflow-contract.py) | Android deploy release archive token 계약 + merge promotion 뒤 snapshot metadata 탐색 회귀 검증 | `pr-gate.static-checks` |
 | [`check-dev-soak-workflow-contract.py`](./check-dev-soak-workflow-contract.py) | dev event-flow cron install + `monitor-dev-cuj` + `dev-rc-cut-gate` + `shared-soak-gate` 판정 계약 검증 | `pr-gate.static-checks` |
 | [`check-dev-cut-workflow-contract.py`](./check-dev-cut-workflow-contract.py) | promotion cut workflow 의 full-history checkout, merge auto-merge mode, `shared-notify` repo 컨텍스트 계약 검증 | `pr-gate.static-checks` |

--- a/.github/scripts/check-ios-deploy-branch-conditions.sh
+++ b/.github/scripts/check-ios-deploy-branch-conditions.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 ACTION_FILE=".github/actions/ios-deploy/action.yml"
 WORKFLOW_FILE=".github/workflows/shared-ios-deploy.yml"
+APP_PUBSPECS=(
+  "apps/app_user/pubspec.yaml"
+  "apps/app_partner/pubspec.yaml"
+)
 
 require_file() {
   local file="$1"
@@ -14,11 +18,45 @@ require_file() {
 
 require_file "$ACTION_FILE"
 require_file "$WORKFLOW_FILE"
+for pubspec in "${APP_PUBSPECS[@]}"; do
+  require_file "$pubspec"
+done
 
 count_matches() {
   local pattern="$1"
   local file="$2"
   (grep -nE "$pattern" "$file" || true) | wc -l | tr -d ' '
+}
+
+assert_flutter_spm_disabled() {
+  local pubspec="$1"
+  if ! awk '
+    /^flutter:[[:space:]]*$/ {
+      in_flutter = 1
+      in_config = 0
+      next
+    }
+    in_flutter && /^[^[:space:]#][^:]*:/ {
+      in_flutter = 0
+      in_config = 0
+    }
+    in_flutter && /^[[:space:]]{2}config:[[:space:]]*$/ {
+      in_config = 1
+      next
+    }
+    in_config && /^[[:space:]]{2}[^[:space:]#][^:]*:/ {
+      in_config = 0
+    }
+    in_config && /^[[:space:]]{4}enable-swift-package-manager:[[:space:]]*false([[:space:]]*(#.*)?)?$/ {
+      found = 1
+    }
+    END {
+      exit found ? 0 : 1
+    }
+  ' "$pubspec"; then
+    echo "ERROR: $pubspec must set flutter.config.enable-swift-package-manager: false for CocoaPods-based iOS deploy"
+    exit 1
+  fi
 }
 
 # Regression guard: dev-staging (and any non-main branch) must go through
@@ -82,4 +120,8 @@ if (( direct_build_invocation_count > 0 )); then
   exit 1
 fi
 
-echo "OK: iOS deploy workflow contract validated (branch, timeout, heartbeat, exit-code)"
+for pubspec in "${APP_PUBSPECS[@]}"; do
+  assert_flutter_spm_disabled "$pubspec"
+done
+
+echo "OK: iOS deploy workflow contract validated (branch, timeout, heartbeat, exit-code, SPM disabled)"

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -96,6 +96,8 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
+  config:
+    enable-swift-package-manager: false
   generate: true
 
   # The following line ensures that the Material Icons font is

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -96,6 +96,8 @@ dev_dependencies:
 
 # For information on the generic Dart part of this file, see the
 flutter:
+  config:
+    enable-swift-package-manager: false
   generate: true
 
   # The following line ensures that the Material Icons font is


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## What
- Disable Flutter Swift Package Manager integration in both Flutter app pubspecs so iOS deploy stays on the existing CocoaPods path.
- Extend `check-ios-deploy-branch-conditions.sh` to guard the SPM-off contract for both apps.
- Update `.github/scripts/BLUEDOC.md` to reflect the expanded contract check.

## Why
Refs #3016. The failing `dev-deploy` run 26870302971 had Web/Android success, while both iOS deploy jobs hung during `flutter build ipa` at `Adding Swift Package Manager integration...` until job timeout/cancellation. Previous dev-deploy run 26754986127 showed the same iOS-only cancellation pattern.

Non-closing reason: do not close #3016 from this PR merge. The issue should stay open until this reaches `dev` and a subsequent dev-deploy confirms both iOS jobs pass.

Flutter docs document project-level SPM disable via `flutter.config.enable-swift-package-manager: false`: https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers

## Verification
- `bash .github/scripts/check-ios-deploy-branch-conditions.sh`
- `flutter pub get` in `apps/app_user`
- `flutter pub get` in `apps/app_partner`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- `git diff --check`

## Residual Risk
- Local environment is Linux with Flutter 3.41.9, so I could not run the macOS `flutter build ipa` path directly. The regression target is the GitHub macOS deploy runner using Flutter stable 3.44.x.
