### PR TITLE
fix(security): guard client service-role exposure

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -179,6 +179,7 @@ jobs:
       app_user: ${{ steps.filter.outputs.app_user }}
       app_partner: ${{ steps.filter.outputs.app_partner }}
       minglit_kit: ${{ steps.filter.outputs.minglit_kit }}
+      minglit_lints: ${{ steps.filter.outputs.minglit_lints }}
       ios_connectivity_plus_cap: ${{ steps.filter.outputs.ios_connectivity_plus_cap }}
       demo_android: ${{ steps.filter.outputs.demo_android }}
       mds_core: ${{ steps.filter.outputs.mds_core }}
@@ -218,6 +219,10 @@ jobs:
           minglit_kit:
             - 'shared/packages/minglit_kit/**'
             - 'shared/packages/**'
+          minglit_lints:
+            - 'shared/packages/minglit_lints/**'
+            - 'pubspec.yaml'
+            - 'pubspec.lock'
           ios_connectivity_plus_cap:
             - 'pubspec.yaml'
             - 'pubspec.lock'
@@ -308,6 +313,33 @@ jobs:
         run: flutter pub get
       - name: Guard iOS connectivity_plus cap
         run: bash .github/scripts/check-ios-connectivity-plus-cap.sh
+
+  test-minglit-lints:
+    name: test-minglit-lints
+    needs: changes
+    if: ${{ needs.changes.outputs.minglit_lints == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
+          cache: true
+      - name: Cache pub packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-minglit-lints-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Test minglit_lints
+        run: dart test shared/packages/minglit_lints
 
   # App CI (User + Partner)
   test-flutter-apps:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -619,6 +619,8 @@ jobs:
           flutter build apk \
             --flavor dev \
             --release \
+            --obfuscate \
+            --split-debug-info=build/symbols/dev \
             --build-number=${{ github.run_number }} \
             --dart-define=SUPABASE_URL="$SUPABASE_DEV_URL" \
             --dart-define=SUPABASE_PUBLISHABLE_KEY="$SUPABASE_DEV_PUBLISHABLE_KEY" \
@@ -637,6 +639,8 @@ jobs:
           flutter build appbundle \
             --flavor dev \
             --release \
+            --obfuscate \
+            --split-debug-info=build/symbols/dev \
             --build-number=${{ github.run_number }} \
             --dart-define=SUPABASE_URL="$SUPABASE_DEV_URL" \
             --dart-define=SUPABASE_PUBLISHABLE_KEY="$SUPABASE_DEV_PUBLISHABLE_KEY" \

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -418,11 +418,11 @@ jobs:
       - name: Custom lint (minglit_kit)
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         run: dart run custom_lint
-        working-directory: shared/packages/minglit_kit
+        working-directory: .
       - name: Custom lint
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' && matrix.app != 'mds_core' }}
         run: dart run custom_lint
-        working-directory: ${{ matrix.directory }}
+        working-directory: .
       - name: Test
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         run: dart run test_reporter -- flutter test --coverage --exclude-tags golden --file-reporter=json:test-results.json

--- a/.github/workflows/shared-android-deploy.yml
+++ b/.github/workflows/shared-android-deploy.yml
@@ -166,11 +166,50 @@ jobs:
 
       - name: Build APK (Dev)
         if: inputs.deploy-stage == 'dev'
-        run: flutter build apk --flavor dev --release --build-name=${{ needs.version.outputs.version_name }} --build-number=${{ needs.version.outputs.build_number }} --dart-define=APP_VERSION=${{ needs.version.outputs.version_name }} --dart-define=APP_CHANNEL=dev --dart-define=SOURCE_BRANCH=dev --dart-define=GIT_SHA=${{ needs.version.outputs.source_sha }} --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_DEV_URL }} --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }} --dart-define=SENTRY_DSN=${{ secrets.SENTRY_DSN_FLUTTER }} --dart-define=ENVIRONMENT=development --dart-define=JUSO_CONFIRM_KEY=${{ secrets.JUSO_CONFIRM_KEY }}
+        run: |
+          flutter build apk \
+            --flavor dev \
+            --release \
+            --obfuscate \
+            --split-debug-info=build/symbols/dev \
+            --build-name=${{ needs.version.outputs.version_name }} \
+            --build-number=${{ needs.version.outputs.build_number }} \
+            --dart-define=APP_VERSION=${{ needs.version.outputs.version_name }} \
+            --dart-define=APP_CHANNEL=dev \
+            --dart-define=SOURCE_BRANCH=dev \
+            --dart-define=GIT_SHA=${{ needs.version.outputs.source_sha }} \
+            --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_DEV_URL }} \
+            --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }} \
+            --dart-define=SENTRY_DSN=${{ secrets.SENTRY_DSN_FLUTTER }} \
+            --dart-define=ENVIRONMENT=development \
+            --dart-define=JUSO_CONFIRM_KEY=${{ secrets.JUSO_CONFIRM_KEY }}
 
       - name: Build AAB (Main)
         if: inputs.deploy-stage == 'main'
-        run: flutter build appbundle --flavor prod --release --build-name=${{ needs.version.outputs.version_name }} --build-number=${{ needs.version.outputs.build_number }} --dart-define=APP_VERSION=${{ needs.version.outputs.version_name }} --dart-define=APP_CHANNEL=main --dart-define=SOURCE_BRANCH=main --dart-define=GIT_SHA=${{ needs.version.outputs.source_sha }} --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_MAIN_URL }} --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_MAIN_PUBLISHABLE_KEY }} --dart-define=SENTRY_DSN=${{ secrets.SENTRY_DSN_FLUTTER }} --dart-define=ENVIRONMENT=production --dart-define=JUSO_CONFIRM_KEY=${{ secrets.JUSO_CONFIRM_KEY }}
+        run: |
+          flutter build appbundle \
+            --flavor prod \
+            --release \
+            --obfuscate \
+            --split-debug-info=build/symbols/main \
+            --build-name=${{ needs.version.outputs.version_name }} \
+            --build-number=${{ needs.version.outputs.build_number }} \
+            --dart-define=APP_VERSION=${{ needs.version.outputs.version_name }} \
+            --dart-define=APP_CHANNEL=main \
+            --dart-define=SOURCE_BRANCH=main \
+            --dart-define=GIT_SHA=${{ needs.version.outputs.source_sha }} \
+            --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_MAIN_URL }} \
+            --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_MAIN_PUBLISHABLE_KEY }} \
+            --dart-define=SENTRY_DSN=${{ secrets.SENTRY_DSN_FLUTTER }} \
+            --dart-define=ENVIRONMENT=production \
+            --dart-define=JUSO_CONFIRM_KEY=${{ secrets.JUSO_CONFIRM_KEY }}
+
+      - name: Upload obfuscation symbols
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-${{ inputs.app-name }}-${{ inputs.deploy-stage }}-symbols-${{ needs.version.outputs.version_name }}
+          path: ${{ inputs.app-directory }}/build/symbols
+          if-no-files-found: warn
 
       - name: Generate release bot token
         id: release-bot

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,3 +10,18 @@ analyzer:
 linter:
   rules:
     public_member_api_docs: false
+
+custom_lint:
+  rules:
+    # Security rules run from the workspace root because custom_lint 0.8.1 does
+    # not discover Dart workspace package roots from package subdirectories.
+    - no_service_role_in_client: true
+    - no_supabase_writes_outside_ef: true
+    # Existing noisy UI/demo migration rules stay package-local until their
+    # tracked cleanup work is complete.
+    - use_minglit_async_value_widget: false
+    - use_minglit_progress_indicator: false
+    - minglit_no_hardcoded_text_style: false
+    - minglit_no_hardcoded_colors: false
+    - no_hardcoded_padding: false
+    - minglit_no_direct_supabase_instance: true

--- a/apps/architecture.md
+++ b/apps/architecture.md
@@ -77,6 +77,20 @@ UI (ref.watch, AsyncValue 패턴으로 loading/error 처리)
 Coordinator (routing or state 변경)
 ```
 
+### 3.1 Optimistic UI Authority
+
+Optimistic UI is allowed only as a temporary local projection of an Edge
+Function request. The EF response is the authoritative state:
+
+- On success, reconcile local state to the EF response payload, not to the
+  original optimistic payload.
+- On failure, restore the previous state and surface a `MinglitUserException`
+  or `MinglitSystemException` through the standard feedback path.
+- If the EF returns a canonical status, timestamp, capacity decision, payment
+  state, or permission result, overwrite speculative client state with it.
+- Direct Supabase writes remain forbidden; optimistic controllers must call a
+  Repository method that invokes an EF or a documented read-only query.
+
 ## 4. Provider Organization
 
 | Provider 타입 | 위치 |
@@ -121,6 +135,29 @@ Riverpod 패턴: `AsyncValueMinglitX<T>.showMinglitError(context)` / `guardMingl
 | Configuration | `url_config.dart`, `iamport_config.dart` |
 | Location | `location_service.dart` |
 | Utility | `age_util`, `refund_calculator`, `ticket_crypto` 등 도메인 특화 |
+
+## 7. Release Build Protection
+
+Flutter release artifacts must not carry elevated Supabase credentials. Client
+builds may receive only publishable/public keys such as
+`SUPABASE_PUBLISHABLE_KEY`; service-role JWTs, `sb_secret_...`, and
+`SUPABASE_*_SECRET_KEY` values are server-only.
+
+Android release builds use Dart obfuscation and split debug info:
+
+```bash
+flutter build apk --release --obfuscate --split-debug-info=build/symbols/<stage>
+flutter build appbundle --release --obfuscate --split-debug-info=build/symbols/<stage>
+```
+
+CI enforcement:
+
+- `.github/workflows/pr-gate.yml` builds release APK/AAB for artifact secret
+  scanning with obfuscation enabled.
+- `.github/workflows/shared-android-deploy.yml` builds deploy artifacts with
+  obfuscation and uploads `build/symbols` as a workflow artifact.
+- `.github/scripts/scan-build-artifact-secrets.py` remains the binary/source
+  safety net for `service_role` JWT and `sb_secret_...` leakage.
 
 ## 관련
 

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -413,6 +413,7 @@ Flutter 앱(publishable key = anon/authenticated role)은 **READ 전용**이다.
 | 계층 | 수단 | 상태 |
 |------|------|------|
 | IDE | `no_supabase_writes_outside_ef` custom_lint 룰 | ✅ 운영 중 (`shared/packages/minglit_lints/`) |
+| IDE | `no_service_role_in_client` custom_lint 룰 | ✅ 운영 중 (`shared/packages/minglit_lints/`) |
 | CI | `dart run custom_lint` PR-gate 스텝 | ✅ 운영 중 (`.github/workflows/pr-gate.yml`) |
 | DB | `REVOKE INSERT/UPDATE/DELETE/TRUNCATE FROM anon, authenticated` + write RLS policy gate + write-capable SECURITY DEFINER RPC EXECUTE gate | ✅ 구현 완료 (`20260603215321_rls_strict_revoke_publishable_writes.sql`, `107_rls_strict_publishable_write_lockdown_test.sql`) |
 
@@ -427,6 +428,20 @@ Flutter 앱(publishable key = anon/authenticated role)은 **READ 전용**이다.
   supabase.from('legacy_table').insert(data);
   ```
   `reason:` 필드 필수. 이유 없는 억제 주석은 lint error.
+
+#### lint 룰: `no_service_role_in_client`
+
+- **위치**: `shared/packages/minglit_lints/lib/src/no_service_role_in_client_rule.dart`
+- **적용 범위**: `apps/app_user/lib`, `apps/app_partner/lib`, `shared/packages/minglit_kit/lib`
+- **차단 패턴**: `service_role` literal, `sb_secret_...`, `SUPABASE_SERVICE_ROLE_KEY`,
+  `SUPABASE_SECRET_KEYS`, `SUPABASE_*_SECRET_KEY`, `serviceRoleKey`/`sbSecret`
+  계열 identifier.
+- **허용 패턴**: `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_URL`,
+  `STATSIG_CLIENT_KEY`, `KAKAO_*`, `JUSO_CONFIRM_KEY` 같은 publishable/public
+  client config.
+- **서버 전용 예외**: Edge Functions, migrations, `.github/`, `docs/`, scripts,
+  tests 는 client Dart lint 범위 밖이다. Elevated key names may be documented
+  there intentionally.
 
 ---
 

--- a/shared/packages/minglit_kit/lib/src/features/dev/dev_config.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/dev_config.dart
@@ -1,24 +1,25 @@
-import 'package:supabase_flutter/supabase_flutter.dart';
-
 /// Configuration for Dev features.
 class DevConfig {
-  static SupabaseClient? _adminClient;
-
-  /// Initialize with Service Role Key (ONLY IN DEV MAIN).
-  static void init(String url, String serviceRoleKey) {
-    _adminClient = SupabaseClient(url, serviceRoleKey);
+  /// Legacy initializer kept only to avoid breaking stale dev imports.
+  ///
+  /// Flutter clients must not construct elevated Supabase clients. Dev/admin
+  /// operations should go through dev-only Edge Functions instead.
+  @Deprecated(
+    'Client admin Supabase access was removed. Use dev Edge Functions.',
+  )
+  static void init(String url, String elevatedCredential) {
+    throw UnsupportedError(
+      'Client admin Supabase access was removed. Use dev Edge Functions.',
+    );
   }
 
-  /// Get the admin client. Throws if not initialized.
-  static SupabaseClient get adminClient {
-    if (_adminClient == null) {
-      throw StateError(
-        'DevConfig not initialized. Call init() with Service Role Key.',
-      );
-    }
-    return _adminClient!;
+  /// Removed legacy admin client accessor.
+  static Never get adminClient {
+    throw StateError(
+      'Client admin Supabase access was removed. Use dev Edge Functions.',
+    );
   }
 
-  /// Whether the admin client has been initialized.
-  static bool get isInitialized => _adminClient != null;
+  /// Client admin access is no longer initialized in Flutter code.
+  static bool get isInitialized => false;
 }

--- a/shared/packages/minglit_lints/lib/minglit_lints.dart
+++ b/shared/packages/minglit_lints/lib/minglit_lints.dart
@@ -4,6 +4,7 @@ import 'package:minglit_lints/src/no_direct_supabase_instance.dart';
 import 'package:minglit_lints/src/no_hardcoded_colors_rule.dart';
 import 'package:minglit_lints/src/no_hardcoded_padding_rule.dart';
 import 'package:minglit_lints/src/no_hardcoded_text_style_rule.dart';
+import 'package:minglit_lints/src/no_service_role_in_client_rule.dart';
 import 'package:minglit_lints/src/no_supabase_writes_outside_ef_rule.dart';
 import 'package:minglit_lints/src/use_minglit_async_value_widget_rule.dart';
 import 'package:minglit_lints/src/use_minglit_progress_indicator_rule.dart';
@@ -20,6 +21,7 @@ class _MinglitLintsPlugin extends PluginBase {
         const UseMinglitAsyncValueWidgetRule(),
         const NoCrossFeatureImportsRule(),
         const NoSupabaseWritesOutsideEfRule(),
+        const NoServiceRoleInClientRule(),
         const NoDirectSupabaseInstanceRule(),
       ];
 }

--- a/shared/packages/minglit_lints/lib/src/no_service_role_in_client_rule.dart
+++ b/shared/packages/minglit_lints/lib/src/no_service_role_in_client_rule.dart
@@ -1,3 +1,4 @@
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
@@ -111,6 +112,20 @@ class NoServiceRoleInClientRule extends DartLintRule {
     CustomLintContext context,
   ) {
     if (!shouldLintPath(resolver.path)) return;
+
+    void reportDangerousToken(Token? token) {
+      if (token == null) return;
+      if (!isDangerousIdentifier(token.lexeme)) return;
+      reporter.atToken(token, _code);
+    }
+
+    context.registry.addVariableDeclaration((node) {
+      reportDangerousToken(node.name);
+    });
+
+    context.registry.addFormalParameter((node) {
+      reportDangerousToken(node.name);
+    });
 
     context.registry.addSimpleIdentifier((node) {
       if (!isDangerousIdentifier(node.name)) return;

--- a/shared/packages/minglit_lints/lib/src/no_service_role_in_client_rule.dart
+++ b/shared/packages/minglit_lints/lib/src/no_service_role_in_client_rule.dart
@@ -44,6 +44,14 @@ class NoServiceRoleInClientRule extends DartLintRule {
     'MOBILE_REDIRECT_SCHEME',
   };
 
+  static final _supabaseSecretEnvPattern = RegExp(
+    r'^SUPABASE_[A-Z0-9_]+_SECRET_KEY$',
+  );
+
+  static final _supabaseSecretIdentifierPattern = RegExp(
+    'supabase[a-z0-9]*secretkeys?',
+  );
+
   /// Returns true when [filePath] is a Flutter/client source location.
   ///
   /// Exposed as static for unit testing.
@@ -88,14 +96,14 @@ class NoServiceRoleInClientRule extends DartLintRule {
   static bool isDangerousIdentifier(String name) {
     final upper = name.toUpperCase();
     if (_dangerousEnvNames.contains(upper)) return true;
+    if (_supabaseSecretEnvPattern.hasMatch(upper)) return true;
 
     final compact = name.replaceAll(RegExp('[^A-Za-z0-9]'), '').toLowerCase();
 
     return compact == 'servicerole' ||
         compact.contains('servicerolekey') ||
         compact.contains('supabaseservicerole') ||
-        compact.contains('supabasesecretkey') ||
-        compact.contains('supabasesecretkeys') ||
+        _supabaseSecretIdentifierPattern.hasMatch(compact) ||
         compact.contains('sbsecret');
   }
 
@@ -107,6 +115,7 @@ class NoServiceRoleInClientRule extends DartLintRule {
     final upper = trimmed.toUpperCase();
     if (_safePublicEnvNames.contains(upper)) return false;
     if (_dangerousEnvNames.contains(upper)) return true;
+    if (_supabaseSecretEnvPattern.hasMatch(upper)) return true;
 
     final lower = trimmed.toLowerCase();
     return lower.contains('sb_secret_') || lower.contains('service_role');

--- a/shared/packages/minglit_lints/lib/src/no_service_role_in_client_rule.dart
+++ b/shared/packages/minglit_lints/lib/src/no_service_role_in_client_rule.dart
@@ -1,0 +1,129 @@
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// Flags Supabase elevated-key exposure in Flutter/client Dart code.
+///
+/// Client code may use publishable/public keys only. Service-role JWTs and
+/// `sb_secret_...` keys belong to Edge Functions, workflows, or server-only
+/// tooling.
+class NoServiceRoleInClientRule extends DartLintRule {
+  const NoServiceRoleInClientRule() : super(code: _code);
+
+  static const LintCode _code = LintCode(
+    name: 'no_service_role_in_client',
+    problemMessage:
+        'Service-role or Supabase secret-key material is forbidden in client '
+        'Dart code.',
+    correctionMessage:
+        'Keep elevated Supabase credentials in Edge Functions or CI/server '
+        'tooling. Client code may only use publishable/public keys.',
+  );
+
+  static const _dangerousEnvNames = {
+    'SUPABASE_SERVICE_ROLE_KEY',
+    'SUPABASE_SECRET_KEYS',
+    'SUPABASE_DEV_SECRET_KEY',
+    'SUPABASE_MAIN_SECRET_KEY',
+    'SERVICE_ROLE_KEY',
+    'SERVICE_ROLE_JWT',
+    'SB_SECRET_KEY',
+  };
+
+  static const _safePublicEnvNames = {
+    'SUPABASE_URL',
+    'SUPABASE_PUBLISHABLE_KEY',
+    'SUPABASE_ANON_KEY',
+    'SENTRY_DSN',
+    'STATSIG_CLIENT_KEY',
+    'GOOGLE_WEB_CLIENT_ID',
+    'KAKAO_LOCAL_REST_API_KEY',
+    'KAKAO_MAP_JAVASCRIPT_KEY',
+    'JUSO_CONFIRM_KEY',
+    'IAMPORT_USER_CODE',
+    'MOBILE_REDIRECT_SCHEME',
+  };
+
+  /// Returns true when [filePath] is a Flutter/client source location.
+  ///
+  /// Exposed as static for unit testing.
+  static bool isClientPath(String filePath) {
+    final path = _normalizePath(filePath);
+    return path.contains('apps/app_user/lib/') ||
+        path.contains('apps/app_partner/lib/') ||
+        path.contains('shared/packages/minglit_kit/lib/');
+  }
+
+  /// Returns true for paths where service-role terms can appear legitimately.
+  ///
+  /// Exposed as static for unit testing.
+  static bool isExemptPath(String filePath) {
+    final path = _normalizePath(filePath);
+    return path.contains('/test/') ||
+        path.contains('/integration_test/') ||
+        path.contains('/patrol_test/') ||
+        path.contains('supabase/functions/') ||
+        path.contains('supabase/migrations/') ||
+        path.contains('.github/') ||
+        path.contains('docs/') ||
+        path.contains('scripts/');
+  }
+
+  /// Returns true when this lint should run for [filePath].
+  ///
+  /// Exposed as static for unit testing.
+  static bool shouldLintPath(String filePath) =>
+      isClientPath(filePath) && !isExemptPath(filePath);
+
+  /// Returns true when [name] is a dangerous client identifier.
+  ///
+  /// Exposed as static for unit testing.
+  static bool isDangerousIdentifier(String name) {
+    final upper = name.toUpperCase();
+    if (_dangerousEnvNames.contains(upper)) return true;
+
+    final compact = name.replaceAll(RegExp('[^A-Za-z0-9]'), '').toLowerCase();
+
+    return compact == 'servicerole' ||
+        compact.contains('servicerolekey') ||
+        compact.contains('supabaseservicerole') ||
+        compact.contains('supabasesecretkey') ||
+        compact.contains('supabasesecretkeys') ||
+        compact.contains('sbsecret');
+  }
+
+  /// Returns true when [value] is a dangerous client string literal.
+  ///
+  /// Exposed as static for unit testing.
+  static bool isDangerousStringValue(String value) {
+    final trimmed = value.trim();
+    final upper = trimmed.toUpperCase();
+    if (_safePublicEnvNames.contains(upper)) return false;
+    if (_dangerousEnvNames.contains(upper)) return true;
+
+    final lower = trimmed.toLowerCase();
+    return lower.contains('sb_secret_') || lower.contains('service_role');
+  }
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    DiagnosticReporter reporter,
+    CustomLintContext context,
+  ) {
+    if (!shouldLintPath(resolver.path)) return;
+
+    context.registry.addSimpleIdentifier((node) {
+      if (!isDangerousIdentifier(node.name)) return;
+      reporter.atNode(node, _code);
+    });
+
+    context.registry.addSimpleStringLiteral((node) {
+      final value = node.value;
+      if (!isDangerousStringValue(value)) return;
+      reporter.atNode(node, _code);
+    });
+  }
+
+  static String _normalizePath(String filePath) =>
+      filePath.replaceAll(r'\', '/');
+}

--- a/shared/packages/minglit_lints/lib/src/no_service_role_in_client_rule.dart
+++ b/shared/packages/minglit_lints/lib/src/no_service_role_in_client_rule.dart
@@ -49,7 +49,11 @@ class NoServiceRoleInClientRule extends DartLintRule {
   /// Exposed as static for unit testing.
   static bool isClientPath(String filePath) {
     final path = _normalizePath(filePath);
-    return path.contains('apps/app_user/lib/') ||
+    return path.startsWith('lib/') ||
+        path.startsWith('package:app_user/') ||
+        path.startsWith('package:app_partner/') ||
+        path.startsWith('package:minglit_kit/') ||
+        path.contains('apps/app_user/lib/') ||
         path.contains('apps/app_partner/lib/') ||
         path.contains('shared/packages/minglit_kit/lib/');
   }
@@ -59,7 +63,10 @@ class NoServiceRoleInClientRule extends DartLintRule {
   /// Exposed as static for unit testing.
   static bool isExemptPath(String filePath) {
     final path = _normalizePath(filePath);
-    return path.contains('/test/') ||
+    return path.startsWith('test/') ||
+        path.startsWith('integration_test/') ||
+        path.startsWith('patrol_test/') ||
+        path.contains('/test/') ||
         path.contains('/integration_test/') ||
         path.contains('/patrol_test/') ||
         path.contains('supabase/functions/') ||

--- a/shared/packages/minglit_lints/test/no_service_role_in_client_test.dart
+++ b/shared/packages/minglit_lints/test/no_service_role_in_client_test.dart
@@ -1,3 +1,7 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
 import 'package:minglit_lints/src/no_service_role_in_client_rule.dart';
 import 'package:test/test.dart';
 
@@ -76,6 +80,15 @@ void main() {
       test('serviceRoleKey', () {
         expect(
           NoServiceRoleInClientRule.isDangerousIdentifier('serviceRoleKey'),
+          isTrue,
+        );
+      });
+
+      test('prefixed service role key identifier', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousIdentifier(
+            'reviewCodexServiceRoleKey',
+          ),
           isTrue,
         );
       });
@@ -205,4 +218,105 @@ void main() {
       });
     });
   });
+
+  group('NoServiceRoleInClientRule custom_lint integration', () {
+    test(
+      'dart run custom_lint flags app_user client fixtures',
+      () async {
+        final packageRoot = await _minglitLintsPackageRoot();
+        final tempRoot = await Directory.systemTemp.createTemp(
+          'minglit_lints_service_role_',
+        );
+        addTearDown(() {
+          if (tempRoot.existsSync()) {
+            tempRoot.deleteSync(recursive: true);
+          }
+        });
+
+        final appDir = Directory('${tempRoot.path}/apps/app_user');
+        await Directory('${appDir.path}/lib').create(recursive: true);
+
+        await File('${appDir.path}/pubspec.yaml').writeAsString('''
+name: app_user
+publish_to: none
+
+environment:
+  sdk: ">=3.6.0 <4.0.0"
+
+dev_dependencies:
+  custom_lint: 0.8.1
+  minglit_lints:
+    path: ${packageRoot.path.replaceAll(r'\', '/')}
+''');
+
+        await File('${appDir.path}/analysis_options.yaml').writeAsString('''
+analyzer:
+  plugins:
+    - custom_lint
+''');
+
+        await File('${appDir.path}/lib/main.dart').writeAsString('''
+const reviewCodexServiceRoleKey = 'x';
+const reviewCodexPublicKey =
+    String.fromEnvironment('SUPABASE_PUBLISHABLE_KEY');
+const reviewCodexLeak =
+    String.fromEnvironment('SUPABASE_SERVICE_ROLE_KEY');
+
+void acceptsSecret(String sbSecret) {}
+''');
+
+        final pubGet = await Process.run(
+          'dart',
+          ['pub', 'get'],
+          workingDirectory: appDir.path,
+        );
+        expect(
+          pubGet.exitCode,
+          0,
+          reason: 'dart pub get failed:\n${pubGet.stdout}\n${pubGet.stderr}',
+        );
+
+        final customLint = await Process.run(
+          'dart',
+          ['run', 'custom_lint', '--format=json'],
+          workingDirectory: appDir.path,
+        );
+        expect(
+          customLint.exitCode,
+          isNot(0),
+          reason: 'custom_lint should fail on service-role fixtures',
+        );
+
+        final output =
+            jsonDecode(customLint.stdout as String) as Map<String, dynamic>;
+        final diagnostics =
+            (output['diagnostics'] as List).cast<Map<String, dynamic>>();
+        final serviceRoleDiagnostics = diagnostics
+            .where(
+              (diagnostic) => diagnostic['code'] == 'no_service_role_in_client',
+            )
+            .toList();
+
+        expect(serviceRoleDiagnostics, hasLength(greaterThanOrEqualTo(3)));
+        expect(
+          serviceRoleDiagnostics.map((diagnostic) {
+            final location = diagnostic['location'] as Map;
+            return location['file'] as String;
+          }),
+          everyElement(endsWith('apps/app_user/lib/main.dart')),
+        );
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
+  });
+}
+
+Future<Directory> _minglitLintsPackageRoot() async {
+  final libUri = await Isolate.resolvePackageUri(
+    Uri.parse('package:minglit_lints/minglit_lints.dart'),
+  );
+  if (libUri == null) {
+    throw StateError('Unable to resolve package:minglit_lints');
+  }
+  return File.fromUri(libUri).parent.parent;
 }

--- a/shared/packages/minglit_lints/test/no_service_role_in_client_test.dart
+++ b/shared/packages/minglit_lints/test/no_service_role_in_client_test.dart
@@ -127,6 +127,24 @@ void main() {
         );
       });
 
+      test('SUPABASE_PROD_SECRET_KEY', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousIdentifier(
+            'SUPABASE_PROD_SECRET_KEY',
+          ),
+          isTrue,
+        );
+      });
+
+      test('supabaseProdSecretKey', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousIdentifier(
+            'supabaseProdSecretKey',
+          ),
+          isTrue,
+        );
+      });
+
       test('supabaseSecretKeys', () {
         expect(
           NoServiceRoleInClientRule.isDangerousIdentifier('supabaseSecretKeys'),
@@ -185,6 +203,15 @@ void main() {
         expect(
           NoServiceRoleInClientRule.isDangerousStringValue(
             'SUPABASE_DEV_SECRET_KEY',
+          ),
+          isTrue,
+        );
+      });
+
+      test('staged secret key env name', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousStringValue(
+            'SUPABASE_PROD_SECRET_KEY',
           ),
           isTrue,
         );
@@ -282,10 +309,13 @@ analyzer:
 
         await File('${appDir.path}/lib/main.dart').writeAsString('''
 const reviewCodexServiceRoleKey = 'x';
+const supabaseProdSecretKey = 'x';
 const reviewCodexPublicKey =
     String.fromEnvironment('SUPABASE_PUBLISHABLE_KEY');
 const reviewCodexLeak =
     String.fromEnvironment('SUPABASE_SERVICE_ROLE_KEY');
+const reviewCodexProdLeak =
+    String.fromEnvironment('SUPABASE_PROD_SECRET_KEY');
 
 void acceptsSecret(String sbSecret) {}
 ''');
@@ -322,7 +352,7 @@ void acceptsSecret(String sbSecret) {}
             )
             .toList();
 
-        expect(serviceRoleDiagnostics, hasLength(greaterThanOrEqualTo(3)));
+        expect(serviceRoleDiagnostics, hasLength(greaterThanOrEqualTo(5)));
         expect(
           serviceRoleDiagnostics.map((diagnostic) {
             final location = diagnostic['location'] as Map;

--- a/shared/packages/minglit_lints/test/no_service_role_in_client_test.dart
+++ b/shared/packages/minglit_lints/test/no_service_role_in_client_test.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:isolate';
 
 import 'package:minglit_lints/src/no_service_role_in_client_rule.dart';
 import 'package:test/test.dart';
@@ -367,11 +366,18 @@ void acceptsSecret(String sbSecret) {}
 }
 
 Future<Directory> _minglitLintsPackageRoot() async {
-  final libUri = await Isolate.resolvePackageUri(
-    Uri.parse('package:minglit_lints/minglit_lints.dart'),
-  );
-  if (libUri == null) {
-    throw StateError('Unable to resolve package:minglit_lints');
+  final candidates = [
+    Directory.current,
+    Directory('${Directory.current.path}/shared/packages/minglit_lints'),
+    File.fromUri(Platform.script).parent.parent,
+  ];
+
+  for (final candidate in candidates) {
+    final pubspec = File('${candidate.path}/pubspec.yaml');
+    if (!pubspec.existsSync()) continue;
+    if (!pubspec.readAsStringSync().contains('name: minglit_lints')) continue;
+    return candidate;
   }
-  return File.fromUri(libUri).parent.parent;
+
+  throw StateError('Unable to resolve minglit_lints package root');
 }

--- a/shared/packages/minglit_lints/test/no_service_role_in_client_test.dart
+++ b/shared/packages/minglit_lints/test/no_service_role_in_client_test.dart
@@ -1,0 +1,208 @@
+import 'package:minglit_lints/src/no_service_role_in_client_rule.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('NoServiceRoleInClientRule.shouldLintPath', () {
+    group('client lib paths: warning enabled', () {
+      test('app_user lib', () {
+        expect(
+          NoServiceRoleInClientRule.shouldLintPath(
+            '/repo/apps/app_user/lib/src/bootstrap/user_startup.dart',
+          ),
+          isTrue,
+        );
+      });
+
+      test('app_partner lib', () {
+        expect(
+          NoServiceRoleInClientRule.shouldLintPath(
+            '/repo/apps/app_partner/lib/src/bootstrap/partner_startup.dart',
+          ),
+          isTrue,
+        );
+      });
+
+      test('minglit_kit lib', () {
+        expect(
+          NoServiceRoleInClientRule.shouldLintPath(
+            '/repo/shared/packages/minglit_kit/lib/src/config/env_keystore.dart',
+          ),
+          isTrue,
+        );
+      });
+    });
+
+    group('server-only and non-client paths: warning disabled', () {
+      test('Edge Function', () {
+        expect(
+          NoServiceRoleInClientRule.shouldLintPath(
+            '/repo/supabase/functions/payment-verify/index.ts',
+          ),
+          isFalse,
+        );
+      });
+
+      test('migration SQL', () {
+        expect(
+          NoServiceRoleInClientRule.shouldLintPath(
+            '/repo/supabase/migrations/20260603000000_hardening.sql',
+          ),
+          isFalse,
+        );
+      });
+
+      test('docs mention secret names intentionally', () {
+        expect(
+          NoServiceRoleInClientRule.shouldLintPath(
+            '/repo/docs/architecture/edge-function-auth.md',
+          ),
+          isFalse,
+        );
+      });
+
+      test('app test file', () {
+        expect(
+          NoServiceRoleInClientRule.shouldLintPath(
+            '/repo/apps/app_user/test/src/config/env_keystore_test.dart',
+          ),
+          isFalse,
+        );
+      });
+    });
+  });
+
+  group('NoServiceRoleInClientRule.isDangerousIdentifier', () {
+    group('positive: elevated credential identifiers', () {
+      test('serviceRoleKey', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousIdentifier('serviceRoleKey'),
+          isTrue,
+        );
+      });
+
+      test('SUPABASE_SERVICE_ROLE_KEY', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousIdentifier(
+            'SUPABASE_SERVICE_ROLE_KEY',
+          ),
+          isTrue,
+        );
+      });
+
+      test('supabaseSecretKeys', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousIdentifier('supabaseSecretKeys'),
+          isTrue,
+        );
+      });
+
+      test('sbSecret', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousIdentifier('sbSecret'),
+          isTrue,
+        );
+      });
+    });
+
+    group('negative: public/client identifiers', () {
+      test('supabasePublishableKey', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousIdentifier(
+            'supabasePublishableKey',
+          ),
+          isFalse,
+        );
+      });
+
+      test('statsigClientKey', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousIdentifier('statsigClientKey'),
+          isFalse,
+        );
+      });
+
+      test('kakaoMapJavascriptKey', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousIdentifier(
+            'kakaoMapJavascriptKey',
+          ),
+          isFalse,
+        );
+      });
+    });
+  });
+
+  group('NoServiceRoleInClientRule.isDangerousStringValue', () {
+    group('positive: elevated credential string values', () {
+      test('service-role env name', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousStringValue(
+            'SUPABASE_SERVICE_ROLE_KEY',
+          ),
+          isTrue,
+        );
+      });
+
+      test('secret key env name', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousStringValue(
+            'SUPABASE_DEV_SECRET_KEY',
+          ),
+          isTrue,
+        );
+      });
+
+      test('sb_secret literal', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousStringValue(
+            'sb_secret_example123',
+          ),
+          isTrue,
+        );
+      });
+
+      test('role literal', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousStringValue('service_role'),
+          isTrue,
+        );
+      });
+    });
+
+    group('negative: safe public/client string values', () {
+      test('publishable key env name', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousStringValue(
+            'SUPABASE_PUBLISHABLE_KEY',
+          ),
+          isFalse,
+        );
+      });
+
+      test('Statsig client key env name', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousStringValue(
+            'STATSIG_CLIENT_KEY',
+          ),
+          isFalse,
+        );
+      });
+
+      test('Kakao map JavaScript key env name', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousStringValue(
+            'KAKAO_MAP_JAVASCRIPT_KEY',
+          ),
+          isFalse,
+        );
+      });
+
+      test('ordinary role text', () {
+        expect(
+          NoServiceRoleInClientRule.isDangerousStringValue('partner_role'),
+          isFalse,
+        );
+      });
+    });
+  });
+}

--- a/shared/packages/minglit_lints/test/no_service_role_in_client_test.dart
+++ b/shared/packages/minglit_lints/test/no_service_role_in_client_test.dart
@@ -34,6 +34,22 @@ void main() {
           isTrue,
         );
       });
+
+      test('package-local app lib path', () {
+        expect(
+          NoServiceRoleInClientRule.shouldLintPath('lib/main.dart'),
+          isTrue,
+        );
+      });
+
+      test('package URI app path', () {
+        expect(
+          NoServiceRoleInClientRule.shouldLintPath(
+            'package:app_user/main.dart',
+          ),
+          isTrue,
+        );
+      });
     });
 
     group('server-only and non-client paths: warning disabled', () {
@@ -68,6 +84,15 @@ void main() {
         expect(
           NoServiceRoleInClientRule.shouldLintPath(
             '/repo/apps/app_user/test/src/config/env_keystore_test.dart',
+          ),
+          isFalse,
+        );
+      });
+
+      test('package-local app test path', () {
+        expect(
+          NoServiceRoleInClientRule.shouldLintPath(
+            'test/src/config/env_keystore_test.dart',
           ),
           isFalse,
         );

--- a/shared/packages/minglit_lints/test/no_supabase_writes_outside_ef_test.dart
+++ b/shared/packages/minglit_lints/test/no_supabase_writes_outside_ef_test.dart
@@ -7,20 +7,86 @@ void main() {
   // ---------------------------------------------------------------------------
   group('NoSupabaseWritesOutsideEfRule.isWriteMethodName', () {
     group('positive: write method names', () {
-      test('insert', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('insert'), isTrue));
-      test('update', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('update'), isTrue));
-      test('delete', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('delete'), isTrue));
-      test('upsert', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('upsert'), isTrue));
+      test(
+        'insert',
+        () => expect(
+          NoSupabaseWritesOutsideEfRule.isWriteMethodName('insert'),
+          isTrue,
+        ),
+      );
+      test(
+        'update',
+        () => expect(
+          NoSupabaseWritesOutsideEfRule.isWriteMethodName('update'),
+          isTrue,
+        ),
+      );
+      test(
+        'delete',
+        () => expect(
+          NoSupabaseWritesOutsideEfRule.isWriteMethodName('delete'),
+          isTrue,
+        ),
+      );
+      test(
+        'upsert',
+        () => expect(
+          NoSupabaseWritesOutsideEfRule.isWriteMethodName('upsert'),
+          isTrue,
+        ),
+      );
     });
 
     group('negative: non-write method names', () {
-      test('select', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('select'), isFalse));
-      test('from', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('from'), isFalse));
-      test('invoke', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('invoke'), isFalse));
-      test('eq', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('eq'), isFalse));
-      test('filter', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('filter'), isFalse));
-      test('rpc', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('rpc'), isFalse));
-      test('empty string', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName(''), isFalse));
+      test(
+        'select',
+        () => expect(
+          NoSupabaseWritesOutsideEfRule.isWriteMethodName('select'),
+          isFalse,
+        ),
+      );
+      test(
+        'from',
+        () => expect(
+          NoSupabaseWritesOutsideEfRule.isWriteMethodName('from'),
+          isFalse,
+        ),
+      );
+      test(
+        'invoke',
+        () => expect(
+          NoSupabaseWritesOutsideEfRule.isWriteMethodName('invoke'),
+          isFalse,
+        ),
+      );
+      test(
+        'eq',
+        () => expect(
+          NoSupabaseWritesOutsideEfRule.isWriteMethodName('eq'),
+          isFalse,
+        ),
+      );
+      test(
+        'filter',
+        () => expect(
+          NoSupabaseWritesOutsideEfRule.isWriteMethodName('filter'),
+          isFalse,
+        ),
+      );
+      test(
+        'rpc',
+        () => expect(
+          NoSupabaseWritesOutsideEfRule.isWriteMethodName('rpc'),
+          isFalse,
+        ),
+      );
+      test(
+        'empty string',
+        () => expect(
+          NoSupabaseWritesOutsideEfRule.isWriteMethodName(''),
+          isFalse,
+        ),
+      );
     });
   });
 


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## Goal

Closes #2994.

Add early client-side guardrails for Supabase elevated key exposure, document the EF-authoritative optimistic UI contract, and wire practical Android release obfuscation policy into CI/deploy workflows.

## Changes

- Added `no_service_role_in_client` custom lint in `shared/packages/minglit_lints`.
  - Scopes enforcement to client Dart sources: `apps/app_user/lib`, `apps/app_partner/lib`, `shared/packages/minglit_kit/lib`, plus package-local and `package:` paths used by `custom_lint`.
  - Flags `service_role`, `sb_secret_...`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_SECRET_KEYS`, `SUPABASE_*_SECRET_KEY`, and related identifier forms such as `serviceRoleKey`, `sbSecret`, and `supabaseProdSecretKey`.
  - Keeps server-only/docs/test paths out of this client lint boundary.
- Runs client security custom lints from the workspace root in PR gate because `custom_lint 0.8.1` does not discover Dart workspace package roots reliably from package subdirectories.
- Added lint tests and an integration smoke test that builds a temporary app package under `apps/app_user`, runs `dart run custom_lint --format=json`, and verifies service-role/staged secret fixtures are diagnosed.
- Removed the client-side `DevConfig.adminClient` service-role Supabase client API from `minglit_kit`; the legacy shim now throws and points callers to dev Edge Functions.
- Documented optimistic UI authority in `apps/architecture.md`: optimistic state must reconcile to EF response, and direct Supabase writes remain forbidden.
- Documented the new client credential lint in `docs/architecture/backend.md`.
- Added `--obfuscate` and `--split-debug-info` to Android release artifact scan and shared Android deploy builds; shared deploy now uploads `build/symbols` as a workflow artifact.

## Verification

- `dart format shared/packages/minglit_lints/lib/minglit_lints.dart shared/packages/minglit_lints/lib/src/no_service_role_in_client_rule.dart shared/packages/minglit_lints/test/no_service_role_in_client_test.dart`
- `dart format shared/packages/minglit_lints/lib/src/no_service_role_in_client_rule.dart shared/packages/minglit_lints/test/no_supabase_writes_outside_ef_test.dart shared/packages/minglit_lints/test/no_service_role_in_client_test.dart`
- `dart format shared/packages/minglit_lints/lib/src/no_service_role_in_client_rule.dart shared/packages/minglit_lints/test/no_service_role_in_client_test.dart`
- `dart analyze shared/packages/minglit_lints`
- `dart test shared/packages/minglit_lints`
- `dart run custom_lint --format=json` from the workspace root
- YAML parse sanity check for `.github/workflows/pr-gate.yml` and `.github/workflows/shared-android-deploy.yml`
- `git diff --check`

## Residual Risk

- I did not run full Android release builds locally because they require signing secrets and CI-like Flutter/Gradle setup. The workflow syntax and command shape were checked locally.
- iOS obfuscation/symbol upload remains outside this PR because the current issue scope and existing shared workflow changes are Android-first; iOS deploy has separate signing/macOS constraints.
