### PR TITLE
fix(security): gate storage uploads behind signed flow

### DIFF
--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -382,15 +382,24 @@ protect_user_profile_fields() → trigger
 | event_applications | 4 | Self (read, create, update) + Partner staff read |
 | verification_submissions | 4 | Self + Partner staff (read, update) |
 | settlements | 1 | Admin + SETTLEMENT_VIEW |
-| storage.objects | 9 | Bucket-specific (verification-proofs, party-assets, partner-proofs) |
+| storage.objects | 6+ | Covered bucket read policies + public known-object serving; writes via signed upload EF |
 
 ### 5.3 Storage Buckets
 
-| Bucket | Public | Upload Policy | View Policy |
-|--------|--------|---------------|-------------|
-| `verification-proofs` | No | 본인 폴더만 | 본인 + 파일 접근 권한 + 파트너/관리자 |
-| `party-assets` | Yes | Authenticated | 전체 공개 |
-| `partner-proofs` | No | 본인 폴더만 | 본인 + 관리자 |
+| Bucket | Public | Upload Policy | View Policy | Hard Limit |
+|--------|--------|---------------|-------------|------------|
+| `verification-proofs` | No | `storage-upload` EF signed upload; user-id path prefix | 본인 + 파일 접근 권한 + 파트너/관리자 | 10MiB, image/PDF allowlist |
+| `party-assets` | Yes | `storage-upload` EF signed upload; partner-id path prefix + `PARTY_MANAGE` | 알려진 public object URL | 50MiB, image allowlist |
+| `partner-proofs` | No | `storage-upload` EF signed upload; user-id path prefix | 본인 + 관리자 | 10MiB, image/PDF allowlist |
+
+Covered product uploads use the `storage-upload` Edge Function:
+
+1. Client sends `{bucket, path_prefix, declared_size, mime, extension}` to `action=presign`.
+2. EF calls `reserve_storage_upload()` to enforce bucket policy, path scope, byte-rate, total quota, and active upload concurrency.
+3. EF returns Supabase `createSignedUploadUrl()` token; client uploads via `uploadBinaryToSignedUrl()`.
+4. Client calls `action=complete`; `complete_storage_upload()` reconciles declared vs actual metadata and closes `active_storage_uploads`.
+
+Direct authenticated `storage.objects INSERT` policies are removed for the three covered buckets. `bug-report-attachments` is intentionally separate QA/reporting infrastructure with its own 5MiB policy and retention lifecycle. TUS/resumable upload support is deferred; current covered flows are small image/document uploads under bucket hard limits.
 
 ### 5.4 Flutter Write Enforcement
 
@@ -436,7 +445,7 @@ Flutter 앱(publishable key = anon/authenticated role)은 **READ 전용**이다.
 | `on_application_approval` | event_applications | UPDATE/INSERT | approved/paid → event_participants 자동 발권 |
 | `on_application_rejected` | event_applications | UPDATE | 거절 시 pg_net으로 payment-cancel Edge Function 호출 |
 | `on_event_completed` | events | UPDATE | completed 시 settlement 자동 생성 |
-| `on_storage_object_created` | storage.objects | INSERT | minglit_files 메타데이터 동기화 |
+| `on_storage_object_created` | storage.objects | INSERT | minglit_files 메타데이터 동기화; signed upload 예약에서 owner_id 보정 |
 | `on_application_created` | event_applications | INSERT | 파트너 오너에게 file_access_grants 생성 |
 | `on_event_reschedule` | events | UPDATE (end_time) | file_access_grants 만료일 갱신 |
 
@@ -513,7 +522,7 @@ User B ──vote──> User A
 1. **Storage Layer**: Supabase Storage → `storage.objects` (RLS로 업로드/조회 제어)
 2. **Application Layer**: `minglit_files` + `file_access_grants` (세밀한 접근 권한)
 
-파일 업로드 시 `on_storage_object_created` 트리거가 `minglit_files`에 메타데이터를 동기화한다.
+파일 업로드 시 `on_storage_object_created` 트리거가 `minglit_files`에 메타데이터를 동기화한다. `storage-upload` signed upload 경로는 `active_storage_uploads` 예약을 사용해 Storage token 업로드의 소유자를 보정하고, complete 단계에서 실제 size를 reconcile한다.
 이벤트 신청 시 `on_application_created` 트리거가 파트너 오너에게 자동으로 `file_access_grants`를 생성하며, 이벤트 종료 후 30일에 만료된다.
 
 ---

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -389,7 +389,8 @@ protect_user_profile_fields() → trigger
 | Bucket | Public | Upload Policy | View Policy | Hard Limit |
 |--------|--------|---------------|-------------|------------|
 | `verification-proofs` | No | `storage-upload` EF signed upload; user-id path prefix | 본인 + 파일 접근 권한 + 파트너/관리자 | 10MiB, image/PDF allowlist |
-| `party-assets` | Yes | `storage-upload` EF signed upload; partner-id path prefix + `PARTY_MANAGE` | 알려진 public object URL | 50MiB, image allowlist |
+| `party-assets` | Yes | `storage-upload` EF publishes only after private staging reconcile; partner-id path prefix + `PARTY_MANAGE` | 알려진 public object URL | 50MiB, image allowlist |
+| `party-assets-pending` | No | `storage-upload` EF signed upload staging only | service_role only | 50MiB, image allowlist |
 | `partner-proofs` | No | `storage-upload` EF signed upload; user-id path prefix | 본인 + 관리자 | 10MiB, image/PDF allowlist |
 
 Covered product uploads use the `storage-upload` Edge Function:
@@ -397,7 +398,8 @@ Covered product uploads use the `storage-upload` Edge Function:
 1. Client sends `{bucket, path_prefix, declared_size, mime, extension}` to `action=presign`.
 2. EF calls `reserve_storage_upload()` to enforce bucket policy, path scope, byte-rate, total quota, and active upload concurrency.
 3. EF returns Supabase `createSignedUploadUrl()` token; client uploads via `uploadBinaryToSignedUrl()`.
-4. Client calls `action=complete`; `complete_storage_upload()` reconciles declared vs actual metadata and closes `active_storage_uploads`.
+4. Client calls `action=complete`; `complete_storage_upload()` reconciles declared vs actual metadata.
+5. Public buckets (`party-assets`) are uploaded to private staging first; EF publishes to the public bucket only after reconcile passes.
 
 Direct authenticated `storage.objects INSERT` policies are removed for the three covered buckets. `bug-report-attachments` is intentionally separate QA/reporting infrastructure with its own 5MiB policy and retention lifecycle. TUS/resumable upload support is deferred; current covered flows are small image/document uploads under bucket hard limits.
 
@@ -522,7 +524,7 @@ User B ──vote──> User A
 1. **Storage Layer**: Supabase Storage → `storage.objects` (RLS로 업로드/조회 제어)
 2. **Application Layer**: `minglit_files` + `file_access_grants` (세밀한 접근 권한)
 
-파일 업로드 시 `on_storage_object_created` 트리거가 `minglit_files`에 메타데이터를 동기화한다. `storage-upload` signed upload 경로는 `active_storage_uploads` 예약을 사용해 Storage token 업로드의 소유자를 보정하고, complete 단계에서 실제 size를 reconcile한다.
+파일 업로드 시 `on_storage_object_created` 트리거가 `minglit_files`에 메타데이터를 동기화한다. `storage-upload` signed upload 경로는 `active_storage_uploads` 예약을 사용해 Storage token 업로드의 소유자를 보정하고, complete 단계에서 실제 size를 reconcile한다. Public asset은 private staging object를 먼저 검증한 뒤 publish 단계에서만 `party-assets`와 `minglit_files`에 노출한다.
 이벤트 신청 시 `on_application_created` 트리거가 파트너 오너에게 자동으로 `file_access_grants`를 생성하며, 이벤트 종료 후 30일에 만료된다.
 
 ---

--- a/shared/packages/minglit_kit/lib/src/data/repositories/partner_application_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/partner_application_repository.dart
@@ -68,22 +68,25 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
 
   Future<String> _uploadFile(String userId, XFile file, String type) async {
     Log.d('_uploadFile called | type: $type, file: ${file.name}');
-    final extension = p.extension(file.name);
-    final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final path = '$userId/${type}_$timestamp$extension';
+    final extension = p.extension(file.name).isEmpty
+        ? '.jpg'
+        : p.extension(file.name);
     final rawBytes = await file.readAsBytes();
     // Fix #1230: GPS/EXIF 메타데이터 유출 방지 — 업로드 전 재인코딩으로 완전 제거
     final bytes = stripExifAndReencode(rawBytes, filename: file.name);
 
-    await supabaseClient.storage
-        .from('partner-proofs')
-        .uploadBinary(
-          path,
-          bytes,
-          fileOptions: FileOptions(contentType: file.mimeType),
+    final uploadedPath =
+        await StorageRepository(
+          supabase: supabaseClient,
+        ).uploadBytes(
+          bytes: bytes,
+          bucket: 'partner-proofs',
+          pathPrefix: userId,
+          contentType: file.mimeType ?? _contentTypeForExtension(extension),
+          extension: extension,
         );
-    Log.d('_uploadFile success | path: $path');
-    return path;
+    Log.d('_uploadFile success | path: $uploadedPath');
+    return uploadedPath;
   }
 
   /// Fetches the most recent application for the current user.
@@ -165,7 +168,7 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
           'action': 'review',
           'application_id': applicationId,
           'status': status,
-          if (adminComment != null) 'admin_comment': adminComment,
+          'admin_comment': ?adminComment,
         },
       );
       if (response.status != 200) {
@@ -399,5 +402,21 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
       return MinglitUserException(errorMsg, details: details);
     }
     return MinglitUserException(fallback);
+  }
+
+  String _contentTypeForExtension(String extension) {
+    switch (extension.toLowerCase()) {
+      case '.jpg':
+      case '.jpeg':
+        return 'image/jpeg';
+      case '.png':
+        return 'image/png';
+      case '.webp':
+        return 'image/webp';
+      case '.pdf':
+        return 'application/pdf';
+      default:
+        return 'application/octet-stream';
+    }
   }
 }

--- a/shared/packages/minglit_kit/lib/src/data/repositories/partner_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/partner_repository.dart
@@ -1,6 +1,7 @@
 import 'package:image_picker/image_picker.dart' show XFile;
 import 'package:minglit_kit/src/data/models/partner.dart';
 import 'package:minglit_kit/src/data/models/partner_application.dart';
+import 'package:minglit_kit/src/data/repositories/storage_repository.dart';
 import 'package:minglit_kit/src/logic/providers/supabase_provider.dart'
     show supabaseClientProvider;
 import 'package:minglit_kit/src/utils/exceptions.dart';

--- a/shared/packages/minglit_kit/lib/src/data/repositories/party_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/party_repository.dart
@@ -4,6 +4,7 @@ import 'package:minglit_kit/src/data/models/party.dart';
 import 'package:minglit_kit/src/data/models/party_entry_group.dart';
 import 'package:minglit_kit/src/data/models/ticket.dart';
 import 'package:minglit_kit/src/data/models/ticket_template.dart';
+import 'package:minglit_kit/src/data/repositories/storage_repository.dart';
 import 'package:minglit_kit/src/logic/providers/supabase_provider.dart'
     show supabaseClientProvider;
 import 'package:minglit_kit/src/utils/image_utils.dart';
@@ -74,32 +75,22 @@ abstract class _SupabasePartyContextBase implements _SupabasePartyContext {
       'file: ${file.name}',
     );
     try {
-      final extension = p.extension(file.name);
-      final timestamp = DateTime.now().millisecondsSinceEpoch;
-      // Structure: partner_id/timestamp_filename
-      // Using a random part to avoid collision if multiple files have
-      // same timestamp
-      final random = DateTime.now().microsecond;
-      final path = '$partnerId/${timestamp}_$random$extension';
+      final sourceExtension = p.extension(file.name).toLowerCase();
+      final extension = sourceExtension == '.png' ? '.png' : '.jpg';
+      final contentType = sourceExtension == '.png'
+          ? 'image/png'
+          : 'image/jpeg';
       final rawBytes = await file.readAsBytes();
       // Fix #1230: GPS/EXIF 메타데이터 유출 방지 — 업로드 전 재인코딩으로 완전 제거
       final bytes = stripExifAndReencode(rawBytes, filename: file.name);
 
-      await supabaseClient.storage
-          .from('party-assets')
-          .uploadBinary(
-            path,
-            bytes,
-            fileOptions: const FileOptions(
-              contentType: 'image/jpeg',
-              upsert: true,
-            ),
-          );
-
-      final url = supabaseClient.storage
-          .from('party-assets')
-          .getPublicUrl(path);
-      return url;
+      return await StorageRepository(supabase: supabaseClient).uploadBytes(
+        bytes: bytes,
+        bucket: 'party-assets',
+        pathPrefix: partnerId,
+        contentType: contentType,
+        extension: extension,
+      );
     } catch (e, st) {
       Log.e('❌ [PartyRepo] uploadPartyImage Error', e, st);
       rethrow;
@@ -222,12 +213,13 @@ abstract class _SupabasePartyContextBase implements _SupabasePartyContext {
   Future<Party> updateParty(Party party, {List<String>? tagIds}) async {
     Log.d('updateParty called | id: ${party.id}');
     try {
-      final partyJson = party.toDbJson();
-      partyJson.remove('partner_id');
-      partyJson.remove('location');
-      partyJson.remove('location_id');
+      final partyJson = party.toDbJson()
+        ..remove('partner_id')
+        ..remove('location')
+        ..remove('location_id');
 
-      // Fix #1733: entry_group_templates는 @JsonKey(includeToJson: false)로 toDbJson에서 제외 —
+      // Fix #1733: entry_group_templates는
+      // @JsonKey(includeToJson: false)로 toDbJson에서 제외 —
       // update 요청에도 명시적으로 포함해야 EF가 entry_group_templates를 교체할 수 있음
       final entryGroups = party.entryGroups;
 
@@ -238,13 +230,12 @@ abstract class _SupabasePartyContextBase implements _SupabasePartyContext {
         // Fix #1136: tag_ids는 null일 때 키 자체를 제외 — undefined와 null 구분을 위해
         'tag_ids': ?tagIds,
         if (entryGroups != null)
-          'entry_group_templates': entryGroups
-              .map(
-                (g) => g.toJson()
-                  ..remove('created_at')
-                  ..remove('updated_at'),
-              )
-              .toList(),
+          'entry_group_templates': entryGroups.map((g) {
+            final json = g.toJson()
+              ..remove('created_at')
+              ..remove('updated_at');
+            return json;
+          }).toList(),
       };
 
       final response = await supabaseClient.functions.invoke(

--- a/shared/packages/minglit_kit/lib/src/data/repositories/storage_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/storage_repository.dart
@@ -25,9 +25,18 @@ class StorageRepository {
   StorageRepository({SupabaseClient? supabase})
     : _supabase = supabase ?? Supabase.instance.client;
 
+  static const Set<String> _signedUploadBuckets = {
+    'verification-proofs',
+    'partner-proofs',
+    'party-assets',
+  };
+
   final SupabaseClient _supabase;
 
-  /// Uploads a file to Supabase Storage and returns the public URL.
+  /// Uploads a file to Supabase Storage.
+  ///
+  /// Covered private buckets return the stored path. Public buckets return the
+  /// public URL.
   ///
   /// [file]: The file to upload (XFile from image_picker/file_picker).
   /// [bucket]: Target bucket name
@@ -41,16 +50,25 @@ class StorageRepository {
   }) async {
     try {
       final rawBytes = await file.readAsBytes();
-      final extension = p.extension(file.path).isEmpty
-          ? '.jpg'
-          : p.extension(file.path);
+      final extension = _extensionForFile(file);
       // Fix #1230: GPS/EXIF 메타데이터 유출 방지 — 업로드 전 재인코딩으로 완전 제거
       final bytes = stripExifAndReencode(rawBytes, filename: file.name);
       // Generate a unique filename
       final filename = '${const Uuid().v4()}$extension';
       final fullPath = pathPrefix != null ? '$pathPrefix/$filename' : filename;
+      final contentType = file.mimeType ?? _contentTypeForExtension(extension);
 
       Log.d('Uploading file to $bucket/$fullPath...');
+
+      if (_signedUploadBuckets.contains(bucket)) {
+        return await _uploadSignedBytes(
+          bytes: bytes,
+          bucket: bucket,
+          pathPrefix: pathPrefix,
+          contentType: contentType,
+          extension: extension,
+        );
+      }
 
       await _supabase.storage
           .from(bucket)
@@ -58,7 +76,7 @@ class StorageRepository {
             fullPath,
             bytes,
             fileOptions: FileOptions(
-              contentType: file.mimeType,
+              contentType: contentType,
             ),
           );
 
@@ -90,6 +108,16 @@ class StorageRepository {
 
       Log.d('Uploading bytes to $bucket/$fullPath...');
 
+      if (_signedUploadBuckets.contains(bucket)) {
+        return await _uploadSignedBytes(
+          bytes: bytes,
+          bucket: bucket,
+          pathPrefix: pathPrefix,
+          contentType: contentType,
+          extension: extension,
+        );
+      }
+
       await _supabase.storage
           .from(bucket)
           .uploadBinary(
@@ -119,5 +147,120 @@ class StorageRepository {
       Log.e('❌ [StorageRepo] Delete failed', e, st);
       rethrow;
     }
+  }
+
+  Future<String> _uploadSignedBytes({
+    required Uint8List bytes,
+    required String bucket,
+    required String contentType,
+    required String extension,
+    String? pathPrefix,
+  }) async {
+    final presign = await _supabase.functions.invoke(
+      'storage-upload',
+      body: {
+        'action': 'presign',
+        'bucket': bucket,
+        'path_prefix': pathPrefix,
+        'declared_size': bytes.length,
+        'mime': contentType,
+        'extension': extension,
+      },
+    );
+    if (presign.status != 200 || presign.data is! Map) {
+      throw Exception(_functionError(presign, 'Storage presign failed'));
+    }
+
+    final presignData = (presign.data as Map).cast<String, dynamic>();
+    final uploadId = presignData['upload_id'] as String;
+    final path = presignData['path'] as String;
+    final token = presignData['token'] as String;
+
+    try {
+      await _supabase.storage
+          .from(bucket)
+          .uploadBinaryToSignedUrl(
+            path,
+            token,
+            bytes,
+            FileOptions(contentType: contentType),
+          );
+    } catch (_) {
+      await _abortSignedUpload(uploadId);
+      rethrow;
+    }
+
+    final complete = await _supabase.functions.invoke(
+      'storage-upload',
+      body: {
+        'action': 'complete',
+        'upload_id': uploadId,
+      },
+    );
+    if (complete.status != 200 || complete.data is! Map) {
+      throw Exception(_functionError(complete, 'Storage complete failed'));
+    }
+
+    final completeData = (complete.data as Map).cast<String, dynamic>();
+    if (completeData['status'] == 'rejected') {
+      throw Exception(
+        completeData['rejection_reason'] ?? 'Storage upload rejected',
+      );
+    }
+
+    final publicUrl = completeData['public_url'] as String?;
+    return publicUrl ?? (completeData['path'] as String? ?? path);
+  }
+
+  Future<void> _abortSignedUpload(String uploadId) async {
+    try {
+      await _supabase.functions.invoke(
+        'storage-upload',
+        body: {
+          'action': 'abort',
+          'upload_id': uploadId,
+        },
+      );
+    } on Object {
+      // Best effort: the active upload expires server-side if abort fails.
+    }
+  }
+
+  static String _functionError(FunctionResponse response, String fallback) {
+    final data = response.data;
+    if (data is Map) {
+      return (data['error'] as String?) ?? fallback;
+    }
+    return fallback;
+  }
+
+  static String _contentTypeForExtension(String extension) {
+    switch (extension.toLowerCase()) {
+      case '.jpg':
+      case '.jpeg':
+        return 'image/jpeg';
+      case '.png':
+        return 'image/png';
+      case '.webp':
+        return 'image/webp';
+      case '.pdf':
+        return 'application/pdf';
+      default:
+        return 'application/octet-stream';
+    }
+  }
+
+  static String _extensionForFile(XFile file) {
+    final pathExtension = p.extension(file.path);
+    if (pathExtension.isNotEmpty) {
+      return pathExtension;
+    }
+
+    final nameExtension = p.extension(file.name);
+    if (nameExtension.isNotEmpty) {
+      return nameExtension;
+    }
+
+    return '.jpg';
   }
 }

--- a/shared/packages/minglit_kit/lib/src/data/repositories/storage_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/storage_repository.dart
@@ -174,13 +174,15 @@ class StorageRepository {
     final presignData = (presign.data as Map).cast<String, dynamic>();
     final uploadId = presignData['upload_id'] as String;
     final path = presignData['path'] as String;
+    final uploadBucket = presignData['upload_bucket'] as String? ?? bucket;
+    final uploadPath = presignData['upload_path'] as String? ?? path;
     final token = presignData['token'] as String;
 
     try {
       await _supabase.storage
-          .from(bucket)
+          .from(uploadBucket)
           .uploadBinaryToSignedUrl(
-            path,
+            uploadPath,
             token,
             bytes,
             FileOptions(contentType: contentType),
@@ -209,7 +211,7 @@ class StorageRepository {
     }
 
     final publicUrl = completeData['public_url'] as String?;
-    return publicUrl ?? (completeData['path'] as String? ?? path);
+    return publicUrl ?? (completeData['path'] as String? ?? uploadPath);
   }
 
   Future<void> _abortSignedUpload(String uploadId) async {

--- a/shared/packages/minglit_kit/test/src/data/repositories/storage_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/storage_repository_test.dart
@@ -16,14 +16,17 @@ void main() {
   late MockSupabaseClient mockClient;
   late MockSupabaseStorageClient mockStorage;
   late MockStorageFileApi mockStorageFileApi;
+  late MockFunctionsClient mockFunctions;
   late StorageRepository repository;
 
   setUp(() {
     mockClient = MockSupabaseClient();
     mockStorage = MockSupabaseStorageClient();
     mockStorageFileApi = MockStorageFileApi();
+    mockFunctions = MockFunctionsClient();
 
     when(() => mockClient.storage).thenReturn(mockStorage);
+    when(() => mockClient.functions).thenReturn(mockFunctions);
     when(() => mockStorage.from(any())).thenReturn(mockStorageFileApi);
 
     repository = StorageRepository(supabase: mockClient);
@@ -43,13 +46,140 @@ void main() {
           ),
         ).thenThrow(Exception('Upload failed'));
 
-        expect(
-          () => repository.uploadBytes(
+        await expectLater(
+          repository.uploadBytes(
             bytes: testBytes,
             bucket: bucket,
           ),
           throwsA(isA<Exception>()),
         );
+      });
+
+      test('uses signed upload flow for covered private bucket', () async {
+        final testBytes = Uint8List.fromList([1, 2, 3]);
+        final responses = <FunctionResponse>[
+          FunctionResponse(
+            status: 200,
+            data: {
+              'upload_id': 'upload-1',
+              'path': 'user-1/file.jpg',
+              'token': 'token-1',
+            },
+          ),
+          FunctionResponse(
+            status: 200,
+            data: {
+              'upload_id': 'upload-1',
+              'path': 'user-1/file.jpg',
+              'status': 'completed',
+              'public_url': null,
+            },
+          ),
+        ];
+
+        when(
+          () => mockFunctions.invoke(
+            'storage-upload',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) async => responses.removeAt(0));
+        when(
+          () => mockStorageFileApi.uploadBinaryToSignedUrl(
+            any(),
+            any(),
+            any(),
+            any(),
+          ),
+        ).thenAnswer((_) async => 'user-1/file.jpg');
+
+        final result = await repository.uploadBytes(
+          bytes: testBytes,
+          bucket: 'partner-proofs',
+          pathPrefix: 'user-1',
+          contentType: 'image/jpeg',
+          extension: '.jpg',
+        );
+
+        expect(result, 'user-1/file.jpg');
+        verify(
+          () => mockStorageFileApi.uploadBinaryToSignedUrl(
+            'user-1/file.jpg',
+            'token-1',
+            testBytes,
+            any(),
+          ),
+        ).called(1);
+
+        final bodies = verify(
+          () => mockFunctions.invoke(
+            'storage-upload',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured.cast<Map<String, dynamic>>();
+        expect(bodies[0]['action'], 'presign');
+        expect(bodies[0]['bucket'], 'partner-proofs');
+        expect(bodies[0]['path_prefix'], 'user-1');
+        expect(bodies[0]['declared_size'], testBytes.length);
+        expect(bodies[1]['action'], 'complete');
+        expect(bodies[1]['upload_id'], 'upload-1');
+      });
+
+      test('aborts signed upload reservation when upload fails', () async {
+        final testBytes = Uint8List.fromList([1, 2, 3]);
+        final responses = <FunctionResponse>[
+          FunctionResponse(
+            status: 200,
+            data: {
+              'upload_id': 'upload-1',
+              'path': 'user-1/file.jpg',
+              'token': 'token-1',
+            },
+          ),
+          FunctionResponse(
+            status: 200,
+            data: {
+              'upload_id': 'upload-1',
+              'path': 'user-1/file.jpg',
+              'status': 'aborted',
+            },
+          ),
+        ];
+
+        when(
+          () => mockFunctions.invoke(
+            'storage-upload',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) async => responses.removeAt(0));
+        when(
+          () => mockStorageFileApi.uploadBinaryToSignedUrl(
+            any(),
+            any(),
+            any(),
+            any(),
+          ),
+        ).thenThrow(Exception('upload failed'));
+
+        await expectLater(
+          repository.uploadBytes(
+            bytes: testBytes,
+            bucket: 'partner-proofs',
+            pathPrefix: 'user-1',
+            contentType: 'image/jpeg',
+            extension: '.jpg',
+          ),
+          throwsA(isA<Exception>()),
+        );
+
+        final bodies = verify(
+          () => mockFunctions.invoke(
+            'storage-upload',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured.cast<Map<String, dynamic>>();
+        expect(bodies[0]['action'], 'presign');
+        expect(bodies[1]['action'], 'abort');
+        expect(bodies[1]['upload_id'], 'upload-1');
       });
     });
   });

--- a/shared/packages/minglit_kit/test/src/data/repositories/storage_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/storage_repository_test.dart
@@ -181,6 +181,73 @@ void main() {
         expect(bodies[1]['action'], 'abort');
         expect(bodies[1]['upload_id'], 'upload-1');
       });
+
+      test('uses staging upload bucket for public signed bucket', () async {
+        final testBytes = Uint8List.fromList([1, 2, 3]);
+        final responses = <FunctionResponse>[
+          FunctionResponse(
+            status: 200,
+            data: {
+              'upload_id': 'upload-1',
+              'bucket': 'party-assets',
+              'path': 'partner-1/hero.jpg',
+              'upload_bucket': 'party-assets-pending',
+              'upload_path': 'partner-1/hero.jpg',
+              'final_path': 'partner-1/hero.jpg',
+              'token': 'token-1',
+              'public_url': null,
+            },
+          ),
+          FunctionResponse(
+            status: 200,
+            data: {
+              'upload_id': 'upload-1',
+              'bucket': 'party-assets',
+              'path': 'partner-1/hero.jpg',
+              'status': 'completed',
+              'public_url':
+                  'https://storage.test/object/public/party-assets/partner-1/hero.jpg',
+            },
+          ),
+        ];
+
+        when(
+          () => mockFunctions.invoke(
+            'storage-upload',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) async => responses.removeAt(0));
+        when(
+          () => mockStorageFileApi.uploadBinaryToSignedUrl(
+            any(),
+            any(),
+            any(),
+            any(),
+          ),
+        ).thenAnswer((_) async => 'partner-1/hero.jpg');
+
+        final result = await repository.uploadBytes(
+          bytes: testBytes,
+          bucket: 'party-assets',
+          pathPrefix: 'partner-1',
+          contentType: 'image/jpeg',
+          extension: '.jpg',
+        );
+
+        expect(
+          result,
+          'https://storage.test/object/public/party-assets/partner-1/hero.jpg',
+        );
+        verify(() => mockStorage.from('party-assets-pending')).called(1);
+        verify(
+          () => mockStorageFileApi.uploadBinaryToSignedUrl(
+            'partner-1/hero.jpg',
+            'token-1',
+            testBytes,
+            any(),
+          ),
+        ).called(1);
+      });
     });
   });
 }

--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -32,4 +32,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-06-03 12:58_
+_Reviewed: 2026-06-03 23:00_

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -734,3 +734,9 @@ enabled = true
 verify_jwt = false  # JWT verification handled in function code
 import_map = "./deno.json"
 entrypoint = "./functions/commit-match-likes/index.ts"
+
+[functions.storage-upload]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/storage-upload/index.ts"

--- a/supabase/functions/BLUEDOC.md
+++ b/supabase/functions/BLUEDOC.md
@@ -19,6 +19,7 @@ minglit 의 backend API 진입점. 60+ EF 와 공용 `_shared/`, 테스트 유�
 | [payment-verify/](./payment-verify/BLUEDOC.md)                           | PortOne 결제 검증/승인 EF                                        |
 | [user-cancel-order/](./user-cancel-order/BLUEDOC.md)                     | 유저 신청 취소/환불 EF                                           |
 | [partner-manage-party/](./partner-manage-party/)                         | 파티/장소/티켓 템플릿/매칭 템플릿 파트너 관리 EF                 |
+| [storage-upload/](./storage-upload/)                                     | Storage signed upload presign/complete/abort                     |
 | [partner-approve-application/](./partner-approve-application/BLUEDOC.md) | 파트너 신청 승인 EF                                              |
 
 ## 핵심 컨벤션
@@ -41,4 +42,4 @@ minglit 의 backend API 진입점. 60+ EF 와 공용 `_shared/`, 테스트 유�
 
 ---
 
-_Reviewed: 2026-06-03 16:00_
+_Reviewed: 2026-06-03 23:00_

--- a/supabase/functions/auth-manifest.json
+++ b/supabase/functions/auth-manifest.json
@@ -266,6 +266,11 @@
       "envs": ["dev", "production"],
       "description": "PGMQ q_tags LLM 태그 추출 워커 (Fix #1489: system caller 전용)"
     },
+    "storage-upload": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "Storage signed upload presign/complete/abort — quota, byte-rate, concurrency, reconcile"
+    },
     "event-flow-simulator": {
       "callers": ["system", "public"],
       "envs": ["local", "development", "dev"],

--- a/supabase/functions/storage-upload/deno.json
+++ b/supabase/functions/storage-upload/deno.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  },
+  "tasks": {
+    "test": "deno test --allow-env --allow-net --allow-read"
+  }
+}

--- a/supabase/functions/storage-upload/index.ts
+++ b/supabase/functions/storage-upload/index.ts
@@ -1,0 +1,300 @@
+// storage-upload — EF-issued signed upload URL flow.
+// Fix #2993: Storage quota, byte-rate, concurrency, and reconcile pipeline.
+
+import {
+  minglitEdgeFunction,
+  type EFContext,
+} from "../_shared/edge_function.ts";
+import { parseAction } from "../_shared/request_utils.ts";
+import {
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+
+const COVERED_BUCKETS = new Set([
+  "verification-proofs",
+  "partner-proofs",
+  "party-assets",
+]);
+
+const EXTENSION_BY_MIME: Record<string, string> = {
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+  "application/pdf": ".pdf",
+};
+
+type RpcSingleResult<T> = {
+  data: T | null;
+  error: { message?: string } | null;
+};
+
+type ReserveUploadRow = {
+  upload_id: string;
+  object_path: string;
+  max_file_size_bytes: number;
+  public_bucket: boolean;
+};
+
+type CompleteUploadRow = {
+  upload_id: string;
+  bucket_id: string;
+  object_path: string;
+  status: string;
+  actual_size: number | null;
+  rejection_reason: string | null;
+  public_bucket: boolean;
+};
+
+type AbortUploadRow = {
+  upload_id: string;
+  bucket_id: string;
+  object_path: string;
+  status: string;
+};
+
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
+  if (req.method !== "POST") return errorResponse("Method not allowed", 405);
+  if (ctx.auth.type !== "user") {
+    return errorResponse("Unexpected auth type", 500);
+  }
+
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+
+  const { action, body } = result;
+  switch (action) {
+    case "presign":
+      return presignUpload(body, ctx);
+    case "complete":
+      return completeUpload(body, ctx);
+    case "abort":
+      return abortUpload(body, ctx);
+    default:
+      return errorResponse(`Unknown action: ${action}`, 400);
+  }
+};
+
+async function presignUpload(
+  body: Record<string, unknown>,
+  ctx: EFContext,
+): Promise<Response> {
+  const bucket = readString(body, "bucket");
+  const declaredSize = readPositiveInteger(body, "declared_size");
+  const mimeType = readString(body, "mime");
+  const pathPrefix = normalizePathPrefix(
+    readOptionalString(body, "path_prefix"),
+  );
+
+  if (bucket instanceof Response) return bucket;
+  if (declaredSize instanceof Response) return declaredSize;
+  if (mimeType instanceof Response) return mimeType;
+  if (pathPrefix instanceof Response) return pathPrefix;
+
+  const extension = normalizeExtension(
+    readOptionalString(body, "extension"),
+    mimeType,
+  );
+  if (extension instanceof Response) return extension;
+
+  if (!COVERED_BUCKETS.has(bucket)) {
+    return errorResponse("unsupported_storage_bucket", 400);
+  }
+
+  const objectPath = buildObjectPath(pathPrefix ?? ctx.auth.userId, extension);
+  const reserve = await ctx.supabase
+    .rpc("reserve_storage_upload", {
+      p_user_id: ctx.auth.userId,
+      p_bucket_id: bucket,
+      p_object_path: objectPath,
+      p_declared_size: declaredSize,
+      p_mime_type: mimeType,
+    })
+    .single() as RpcSingleResult<ReserveUploadRow>;
+
+  if (reserve.error || !reserve.data) {
+    return errorResponse(
+      reserve.error?.message ?? "storage_upload_reserve_failed",
+      400,
+    );
+  }
+
+  const signed = await ctx.supabase.storage
+    .from(bucket)
+    .createSignedUploadUrl(reserve.data.object_path);
+
+  if (signed.error || !signed.data) {
+    await abortUploadId(ctx, reserve.data.upload_id);
+    return errorResponse(
+      signed.error?.message ?? "storage_signed_url_failed",
+      500,
+    );
+  }
+
+  const publicUrl = reserve.data.public_bucket
+    ? ctx.supabase.storage.from(bucket).getPublicUrl(reserve.data.object_path)
+      .data.publicUrl
+    : null;
+
+  return successResponse({
+    upload_id: reserve.data.upload_id,
+    bucket,
+    path: reserve.data.object_path,
+    token: signed.data.token,
+    signed_url: signed.data.signedUrl,
+    public_url: publicUrl,
+    max_file_size_bytes: reserve.data.max_file_size_bytes,
+  });
+}
+
+async function completeUpload(
+  body: Record<string, unknown>,
+  ctx: EFContext,
+): Promise<Response> {
+  const uploadId = readString(body, "upload_id");
+  if (uploadId instanceof Response) return uploadId;
+
+  const result = await ctx.supabase
+    .rpc("complete_storage_upload", {
+      p_upload_id: uploadId,
+      p_user_id: ctx.auth.userId,
+    })
+    .single() as RpcSingleResult<CompleteUploadRow>;
+
+  if (result.error || !result.data) {
+    return errorResponse(
+      result.error?.message ?? "storage_upload_complete_failed",
+      400,
+    );
+  }
+
+  if (result.data.status === "rejected") {
+    await ctx.supabase.storage
+      .from(result.data.bucket_id)
+      .remove([result.data.object_path]);
+  }
+
+  const publicUrl = result.data.public_bucket
+    ? ctx.supabase.storage.from(result.data.bucket_id)
+      .getPublicUrl(result.data.object_path).data.publicUrl
+    : null;
+
+  return successResponse({
+    upload_id: result.data.upload_id,
+    bucket: result.data.bucket_id,
+    path: result.data.object_path,
+    status: result.data.status,
+    actual_size: result.data.actual_size,
+    rejection_reason: result.data.rejection_reason,
+    public_url: publicUrl,
+  });
+}
+
+async function abortUpload(
+  body: Record<string, unknown>,
+  ctx: EFContext,
+): Promise<Response> {
+  const uploadId = readString(body, "upload_id");
+  if (uploadId instanceof Response) return uploadId;
+
+  const result = await abortUploadId(ctx, uploadId);
+  if (result.error || !result.data) {
+    return errorResponse(
+      result.error?.message ?? "storage_upload_abort_failed",
+      400,
+    );
+  }
+
+  return successResponse({
+    upload_id: result.data.upload_id,
+    bucket: result.data.bucket_id,
+    path: result.data.object_path,
+    status: result.data.status,
+  });
+}
+
+function abortUploadId(
+  ctx: EFContext,
+  uploadId: string,
+): Promise<RpcSingleResult<AbortUploadRow>> {
+  return ctx.supabase
+    .rpc("abort_storage_upload", {
+      p_upload_id: uploadId,
+      p_user_id: ctx.auth.type === "user" ? ctx.auth.userId : "",
+    })
+    .single() as Promise<RpcSingleResult<AbortUploadRow>>;
+}
+
+function readString(
+  body: Record<string, unknown>,
+  field: string,
+): string | Response {
+  const value = body[field];
+  if (typeof value !== "string" || value.trim().isEmpty) {
+    return errorResponse(`Missing or invalid field: ${field}`, 400);
+  }
+  return value.trim();
+}
+
+function readOptionalString(
+  body: Record<string, unknown>,
+  field: string,
+): string | null | Response {
+  const value = body[field];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") {
+    return errorResponse(`Invalid field: ${field}`, 400);
+  }
+  return value;
+}
+
+function readPositiveInteger(
+  body: Record<string, unknown>,
+  field: string,
+): number | Response {
+  const value = body[field];
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    return errorResponse(`Missing or invalid field: ${field}`, 400);
+  }
+  return value as number;
+}
+
+function normalizePathPrefix(
+  value: string | null | Response,
+): string | null | Response {
+  if (value instanceof Response || value === null) return value;
+  const trimmed = value.trim().replace(/^\/+|\/+$/g, "");
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > 400 ||
+    trimmed.includes("..") ||
+    trimmed.includes("//")
+  ) {
+    return errorResponse("Invalid field: path_prefix", 400);
+  }
+  return trimmed;
+}
+
+function normalizeExtension(
+  value: string | null | Response,
+  mimeType: string,
+): string | Response {
+  if (value instanceof Response) return value;
+  const fallback = EXTENSION_BY_MIME[mimeType];
+  const raw = (value ?? fallback ?? "").trim().toLowerCase();
+  if (!raw) return errorResponse("Missing or invalid field: extension", 400);
+  const ext = raw.startsWith(".") ? raw : `.${raw}`;
+  if (!/^\.[a-z0-9]{1,8}$/.test(ext)) {
+    return errorResponse("Invalid field: extension", 400);
+  }
+  return ext === ".jpeg" ? ".jpg" : ext;
+}
+
+function buildObjectPath(pathPrefix: string, extension: string): string {
+  return `${pathPrefix}/${crypto.randomUUID()}${extension}`;
+}
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/storage-upload/index.ts
+++ b/supabase/functions/storage-upload/index.ts
@@ -29,9 +29,17 @@ type RpcSingleResult<T> = {
   error: { message?: string } | null;
 };
 
+type StorageResult<T> = {
+  data: T | null;
+  error: { message?: string } | null;
+};
+
 type ReserveUploadRow = {
   upload_id: string;
+  bucket_id: string;
   object_path: string;
+  upload_bucket_id: string;
+  upload_object_path: string;
   max_file_size_bytes: number;
   public_bucket: boolean;
 };
@@ -40,9 +48,12 @@ type CompleteUploadRow = {
   upload_id: string;
   bucket_id: string;
   object_path: string;
+  upload_bucket_id: string;
+  upload_object_path: string;
   status: string;
   actual_size: number | null;
   rejection_reason: string | null;
+  mime_type: string;
   public_bucket: boolean;
 };
 
@@ -123,8 +134,8 @@ async function presignUpload(
   }
 
   const signed = await ctx.supabase.storage
-    .from(bucket)
-    .createSignedUploadUrl(reserve.data.object_path);
+    .from(reserve.data.upload_bucket_id)
+    .createSignedUploadUrl(reserve.data.upload_object_path);
 
   if (signed.error || !signed.data) {
     await abortUploadId(ctx, reserve.data.upload_id);
@@ -134,18 +145,16 @@ async function presignUpload(
     );
   }
 
-  const publicUrl = reserve.data.public_bucket
-    ? ctx.supabase.storage.from(bucket).getPublicUrl(reserve.data.object_path)
-      .data.publicUrl
-    : null;
-
   return successResponse({
     upload_id: reserve.data.upload_id,
-    bucket,
-    path: reserve.data.object_path,
+    bucket: reserve.data.bucket_id,
+    path: reserve.data.upload_object_path,
+    upload_bucket: reserve.data.upload_bucket_id,
+    upload_path: reserve.data.upload_object_path,
+    final_path: reserve.data.object_path,
     token: signed.data.token,
     signed_url: signed.data.signedUrl,
-    public_url: publicUrl,
+    public_url: null,
     max_file_size_bytes: reserve.data.max_file_size_bytes,
   });
 }
@@ -171,26 +180,25 @@ async function completeUpload(
     );
   }
 
-  if (result.data.status === "rejected") {
-    await ctx.supabase.storage
-      .from(result.data.bucket_id)
-      .remove([result.data.object_path]);
+  let upload = result.data;
+
+  if (upload.status === "rejected") {
+    const cleanup = await removeStorageObject(
+      ctx,
+      upload.upload_bucket_id,
+      upload.upload_object_path,
+      "storage_rejected_object_cleanup_failed",
+    );
+    if (cleanup) return cleanup;
   }
 
-  const publicUrl = result.data.public_bucket
-    ? ctx.supabase.storage.from(result.data.bucket_id)
-      .getPublicUrl(result.data.object_path).data.publicUrl
-    : null;
+  if (upload.status === "publishing") {
+    const published = await publishPublicUpload(ctx, upload);
+    if (published instanceof Response) return published;
+    upload = published;
+  }
 
-  return successResponse({
-    upload_id: result.data.upload_id,
-    bucket: result.data.bucket_id,
-    path: result.data.object_path,
-    status: result.data.status,
-    actual_size: result.data.actual_size,
-    rejection_reason: result.data.rejection_reason,
-    public_url: publicUrl,
-  });
+  return uploadResponse(ctx, upload);
 }
 
 async function abortUpload(
@@ -226,6 +234,91 @@ function abortUploadId(
       p_user_id: ctx.auth.type === "user" ? ctx.auth.userId : "",
     })
     .single() as Promise<RpcSingleResult<AbortUploadRow>>;
+}
+
+async function publishPublicUpload(
+  ctx: EFContext,
+  upload: CompleteUploadRow,
+): Promise<CompleteUploadRow | Response> {
+  const downloaded = await ctx.supabase.storage
+    .from(upload.upload_bucket_id)
+    .download(upload.upload_object_path) as StorageResult<Blob>;
+  if (downloaded.error || !downloaded.data) {
+    return errorResponse(
+      downloaded.error?.message ?? "storage_staging_download_failed",
+      500,
+    );
+  }
+
+  const publishedObject = await ctx.supabase.storage
+    .from(upload.bucket_id)
+    .upload(upload.object_path, downloaded.data, {
+      contentType: upload.mime_type,
+      upsert: false,
+    }) as StorageResult<unknown>;
+  if (publishedObject.error) {
+    return errorResponse(
+      publishedObject.error.message ?? "storage_public_publish_failed",
+      500,
+    );
+  }
+
+  const published = await ctx.supabase
+    .rpc("publish_storage_upload", {
+      p_upload_id: upload.upload_id,
+      p_user_id: ctx.auth.type === "user" ? ctx.auth.userId : "",
+    })
+    .single() as RpcSingleResult<CompleteUploadRow>;
+
+  if (published.error || !published.data) {
+    await ctx.supabase.storage
+      .from(upload.bucket_id)
+      .remove([upload.object_path]);
+    return errorResponse(
+      published.error?.message ?? "storage_upload_publish_failed",
+      500,
+    );
+  }
+
+  await ctx.supabase.storage
+    .from(upload.upload_bucket_id)
+    .remove([upload.upload_object_path]);
+
+  return published.data;
+}
+
+async function removeStorageObject(
+  ctx: EFContext,
+  bucket: string,
+  path: string,
+  errorCode: string,
+): Promise<Response | null> {
+  const removed = await ctx.supabase.storage
+    .from(bucket)
+    .remove([path]) as StorageResult<unknown>;
+  if (removed.error) {
+    return errorResponse(removed.error.message ?? errorCode, 500);
+  }
+  return null;
+}
+
+function uploadResponse(ctx: EFContext, upload: CompleteUploadRow): Response {
+  const publicUrl = upload.public_bucket && upload.status === "completed"
+    ? ctx.supabase.storage.from(upload.bucket_id)
+      .getPublicUrl(upload.object_path).data.publicUrl
+    : null;
+
+  return successResponse({
+    upload_id: upload.upload_id,
+    bucket: upload.bucket_id,
+    path: upload.object_path,
+    upload_bucket: upload.upload_bucket_id,
+    upload_path: upload.upload_object_path,
+    status: upload.status,
+    actual_size: upload.actual_size,
+    rejection_reason: upload.rejection_reason,
+    public_url: publicUrl,
+  });
 }
 
 function readString(

--- a/supabase/functions/storage-upload/index.ts
+++ b/supabase/functions/storage-upload/index.ts
@@ -2,14 +2,11 @@
 // Fix #2993: Storage quota, byte-rate, concurrency, and reconcile pipeline.
 
 import {
-  minglitEdgeFunction,
   type EFContext,
+  minglitEdgeFunction,
 } from "../_shared/edge_function.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import {
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 
 const COVERED_BUCKETS = new Set([
   "verification-proofs",
@@ -326,7 +323,7 @@ function readString(
   field: string,
 ): string | Response {
   const value = body[field];
-  if (typeof value !== "string" || value.trim().isEmpty) {
+  if (typeof value !== "string" || value.trim().length === 0) {
     return errorResponse(`Missing or invalid field: ${field}`, 400);
   }
   return value.trim();

--- a/supabase/functions/storage-upload/index_test.ts
+++ b/supabase/functions/storage-upload/index_test.ts
@@ -2,10 +2,10 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
+  type Handler,
   makeCtx,
   readJson,
   runHandler,
-  type Handler,
 } from "../_shared/_testing/mod.ts";
 import { importHandlerWithStubbedServe } from "../_test_utils/mock_http.ts";
 
@@ -49,10 +49,13 @@ function makeStorageUploadSupabase(opts: {
     rpc(name: string, args: Record<string, unknown>) {
       calls.push({ type: "rpc", name, args });
       return {
-        single: () => Promise.resolve(rpcResults.shift() ?? {
-          data: null,
-          error: { message: `no fake rpc result for ${name}` },
-        }),
+        single: () =>
+          Promise.resolve(
+            rpcResults.shift() ?? {
+              data: null,
+              error: { message: `no fake rpc result for ${name}` },
+            },
+          ),
       };
     },
     storage: {
@@ -72,7 +75,8 @@ function makeStorageUploadSupabase(opts: {
               data: {
                 path,
                 token: "signed-token",
-                signedUrl: `https://storage.test/${bucket}/${path}?token=signed-token`,
+                signedUrl:
+                  `https://storage.test/${bucket}/${path}?token=signed-token`,
               },
               error: null,
             });
@@ -85,7 +89,8 @@ function makeStorageUploadSupabase(opts: {
             });
             return {
               data: {
-                publicUrl: `https://storage.test/object/public/${bucket}/${path}`,
+                publicUrl:
+                  `https://storage.test/object/public/${bucket}/${path}`,
               },
             };
           },
@@ -125,6 +130,24 @@ function makeStorageUploadSupabase(opts: {
   };
 
   return { supabase, calls };
+}
+
+function completeUploadRow(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    upload_id: "upload-1",
+    bucket_id: "party-assets",
+    object_path: "partner-1/hero.jpg",
+    upload_bucket_id: "party-assets-pending",
+    upload_object_path: "partner-1/hero.jpg",
+    status: "completed",
+    actual_size: 1024,
+    rejection_reason: null,
+    mime_type: "image/jpeg",
+    public_bucket: true,
+    ...overrides,
+  };
 }
 
 Deno.test("presign creates reservation and signed upload token", async () => {
@@ -405,4 +428,316 @@ Deno.test("presign aborts reservation when signed URL creation fails", async () 
     calls.some((call) => call.name === "abort_storage_upload"),
     true,
   );
+});
+
+Deno.test("handler rejects non-user auth and unknown actions", async () => {
+  const handler = await getHandler();
+  const { supabase } = makeStorageUploadSupabase({ rpcResults: [] });
+
+  const nonUser = await runHandler(handler, {
+    method: "POST",
+    body: { action: "presign" },
+    ctx: makeCtx({
+      supabase: supabase as never,
+      auth: { type: "system" },
+    }),
+  });
+  assertEquals(nonUser.status, 500);
+  assertEquals((await readPayload(nonUser)).error, "Unexpected auth type");
+
+  const unknown = await runHandler(handler, {
+    method: "POST",
+    body: { action: "retry" },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+  assertEquals(unknown.status, 400);
+  assertEquals((await readPayload(unknown)).error, "Unknown action: retry");
+});
+
+Deno.test("presign validates input before reserving upload", async () => {
+  const handler = await getHandler();
+  const cases: Array<{
+    name: string;
+    body: Record<string, unknown>;
+    error: string;
+  }> = [
+    {
+      name: "missing bucket",
+      body: {
+        declared_size: 1024,
+        mime: "image/png",
+        extension: ".png",
+      },
+      error: "Missing or invalid field: bucket",
+    },
+    {
+      name: "bad declared size",
+      body: {
+        bucket: "party-assets",
+        declared_size: 0,
+        mime: "image/png",
+        extension: ".png",
+      },
+      error: "Missing or invalid field: declared_size",
+    },
+    {
+      name: "non-string path prefix",
+      body: {
+        bucket: "party-assets",
+        path_prefix: 42,
+        declared_size: 1024,
+        mime: "image/png",
+        extension: ".png",
+      },
+      error: "Invalid field: path_prefix",
+    },
+    {
+      name: "empty path prefix",
+      body: {
+        bucket: "party-assets",
+        path_prefix: " / ",
+        declared_size: 1024,
+        mime: "image/png",
+        extension: ".png",
+      },
+      error: "Invalid field: path_prefix",
+    },
+    {
+      name: "nested separator path prefix",
+      body: {
+        bucket: "party-assets",
+        path_prefix: "partner//hero",
+        declared_size: 1024,
+        mime: "image/png",
+        extension: ".png",
+      },
+      error: "Invalid field: path_prefix",
+    },
+    {
+      name: "unsafe extension",
+      body: {
+        bucket: "party-assets",
+        declared_size: 1024,
+        mime: "image/png",
+        extension: ".png!",
+      },
+      error: "Invalid field: extension",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const { supabase, calls } = makeStorageUploadSupabase({ rpcResults: [] });
+    const response = await runHandler(handler, {
+      method: "POST",
+      body: { action: "presign", ...testCase.body },
+      ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+    });
+
+    assertEquals(response.status, 400, testCase.name);
+    assertEquals((await readPayload(response)).error, testCase.error);
+    assertEquals(calls.length, 0, testCase.name);
+  }
+});
+
+Deno.test("presign returns reservation RPC failures", async () => {
+  const handler = await getHandler();
+  const { supabase } = makeStorageUploadSupabase({
+    rpcResults: [{
+      data: null,
+      error: { message: "daily_quota_exceeded" },
+    }],
+  });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "presign",
+      bucket: "party-assets",
+      declared_size: 1024,
+      mime: "image/png",
+      extension: ".png",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+
+  assertEquals(response.status, 400);
+  assertEquals((await readPayload(response)).error, "daily_quota_exceeded");
+});
+
+Deno.test("complete returns DB reconcile failures", async () => {
+  const handler = await getHandler();
+  const { supabase } = makeStorageUploadSupabase({
+    rpcResults: [{
+      data: null,
+      error: { message: "storage_upload_not_found" },
+    }],
+  });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "complete",
+      upload_id: "missing-upload",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+
+  assertEquals(response.status, 400);
+  assertEquals((await readPayload(response)).error, "storage_upload_not_found");
+});
+
+Deno.test("complete validates upload id", async () => {
+  const handler = await getHandler();
+  const { supabase, calls } = makeStorageUploadSupabase({ rpcResults: [] });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "complete",
+      upload_id: " ",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+
+  assertEquals(response.status, 400);
+  assertEquals(
+    (await readPayload(response)).error,
+    "Missing or invalid field: upload_id",
+  );
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("complete fails when staging download fails", async () => {
+  const handler = await getHandler();
+  const { supabase } = makeStorageUploadSupabase({
+    rpcResults: [{
+      data: completeUploadRow({ status: "publishing" }),
+      error: null,
+    }],
+    downloadError: { message: "download failed" },
+  });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "complete",
+      upload_id: "upload-1",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+
+  assertEquals(response.status, 500);
+  assertEquals((await readPayload(response)).error, "download failed");
+});
+
+Deno.test("complete fails when public publish upload fails", async () => {
+  const handler = await getHandler();
+  const { supabase } = makeStorageUploadSupabase({
+    rpcResults: [{
+      data: completeUploadRow({ status: "publishing" }),
+      error: null,
+    }],
+    uploadError: { message: "publish failed" },
+  });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "complete",
+      upload_id: "upload-1",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+
+  assertEquals(response.status, 500);
+  assertEquals((await readPayload(response)).error, "publish failed");
+});
+
+Deno.test("complete removes public object when publish RPC fails", async () => {
+  const handler = await getHandler();
+  const { supabase, calls } = makeStorageUploadSupabase({
+    rpcResults: [
+      {
+        data: completeUploadRow({ status: "publishing" }),
+        error: null,
+      },
+      {
+        data: null,
+        error: { message: "publish rpc failed" },
+      },
+    ],
+  });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "complete",
+      upload_id: "upload-1",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+
+  assertEquals(response.status, 500);
+  assertEquals((await readPayload(response)).error, "publish rpc failed");
+  assertEquals(
+    calls.some((call) =>
+      call.type === "storage.remove" &&
+      call.bucket === "party-assets" &&
+      call.paths?.[0] === "partner-1/hero.jpg"
+    ),
+    true,
+  );
+});
+
+Deno.test("abort marks upload aborted", async () => {
+  const handler = await getHandler();
+  const { supabase } = makeStorageUploadSupabase({
+    rpcResults: [{
+      data: {
+        upload_id: "upload-1",
+        bucket_id: "partner-proofs",
+        object_path: "user-1/file.jpg",
+        status: "aborted",
+      },
+      error: null,
+    }],
+  });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "abort",
+      upload_id: "upload-1",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+  const payload = await readPayload(response);
+
+  assertEquals(response.status, 200);
+  assertEquals(payload.upload_id, "upload-1");
+  assertEquals(payload.bucket, "partner-proofs");
+  assertEquals(payload.path, "user-1/file.jpg");
+  assertEquals(payload.status, "aborted");
+});
+
+Deno.test("abort returns DB failures", async () => {
+  const handler = await getHandler();
+  const { supabase } = makeStorageUploadSupabase({
+    rpcResults: [{
+      data: null,
+      error: { message: "storage_upload_not_found" },
+    }],
+  });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "abort",
+      upload_id: "missing-upload",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+
+  assertEquals(response.status, 400);
+  assertEquals((await readPayload(response)).error, "storage_upload_not_found");
 });

--- a/supabase/functions/storage-upload/index_test.ts
+++ b/supabase/functions/storage-upload/index_test.ts
@@ -1,0 +1,250 @@
+// storage-upload/index_test.ts — handler unit tests for signed upload flow.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  makeCtx,
+  readJson,
+  runHandler,
+  type Handler,
+} from "../_shared/_testing/mod.ts";
+import { importHandlerWithStubbedServe } from "../_test_utils/mock_http.ts";
+
+let _handler: Handler | null = null;
+async function getHandler(): Promise<Handler> {
+  if (_handler) return _handler;
+  _handler = await importHandlerWithStubbedServe<Handler>(
+    new URL("./index.ts", import.meta.url),
+  );
+  return _handler!;
+}
+
+type RpcResult = {
+  data: Record<string, unknown> | null;
+  error: { message?: string } | null;
+};
+
+function makeStorageUploadSupabase(opts: {
+  rpcResults: RpcResult[];
+  signedError?: { message: string } | null;
+}) {
+  const calls: Array<{
+    type: string;
+    name?: string;
+    args?: unknown;
+    bucket?: string;
+    paths?: string[];
+  }> = [];
+  const rpcResults = [...opts.rpcResults];
+
+  const supabase = {
+    rpc(name: string, args: Record<string, unknown>) {
+      calls.push({ type: "rpc", name, args });
+      return {
+        single: () => Promise.resolve(rpcResults.shift() ?? {
+          data: null,
+          error: { message: `no fake rpc result for ${name}` },
+        }),
+      };
+    },
+    storage: {
+      from(bucket: string) {
+        calls.push({ type: "storage.from", bucket });
+        return {
+          createSignedUploadUrl(path: string) {
+            calls.push({
+              type: "storage.createSignedUploadUrl",
+              bucket,
+              args: { path },
+            });
+            if (opts.signedError) {
+              return Promise.resolve({ data: null, error: opts.signedError });
+            }
+            return Promise.resolve({
+              data: {
+                path,
+                token: "signed-token",
+                signedUrl: `https://storage.test/${bucket}/${path}?token=signed-token`,
+              },
+              error: null,
+            });
+          },
+          getPublicUrl(path: string) {
+            calls.push({
+              type: "storage.getPublicUrl",
+              bucket,
+              args: { path },
+            });
+            return {
+              data: {
+                publicUrl: `https://storage.test/object/public/${bucket}/${path}`,
+              },
+            };
+          },
+          remove(paths: string[]) {
+            calls.push({ type: "storage.remove", bucket, paths });
+            return Promise.resolve({ data: paths, error: null });
+          },
+        };
+      },
+    },
+  };
+
+  return { supabase, calls };
+}
+
+Deno.test("presign creates reservation and signed upload token", async () => {
+  const handler = await getHandler();
+  const { supabase, calls } = makeStorageUploadSupabase({
+    rpcResults: [{
+      data: {
+        upload_id: "upload-1",
+        object_path: "partner-1/generated.jpg",
+        max_file_size_bytes: 52428800,
+        public_bucket: true,
+      },
+      error: null,
+    }],
+  });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "presign",
+      bucket: "party-assets",
+      path_prefix: "partner-1",
+      declared_size: 1024,
+      mime: "image/jpeg",
+      extension: ".jpg",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+  const payload = await readJson(response);
+
+  assertEquals(response.status, 200);
+  assertEquals(payload.upload_id, "upload-1");
+  assertEquals(payload.path, "partner-1/generated.jpg");
+  assertEquals(payload.token, "signed-token");
+  assertEquals(
+    payload.public_url,
+    "https://storage.test/object/public/party-assets/partner-1/generated.jpg",
+  );
+
+  const reserve = calls.find((call) => call.name === "reserve_storage_upload");
+  assertEquals(reserve?.type, "rpc");
+  const reserveArgs = reserve?.args as Record<string, unknown>;
+  assertEquals(reserveArgs.p_user_id, "user-1");
+  assertEquals(reserveArgs.p_bucket_id, "party-assets");
+  assertStringIncludes(reserveArgs.p_object_path as string, "partner-1/");
+  assertEquals(reserveArgs.p_declared_size, 1024);
+  assertEquals(reserveArgs.p_mime_type, "image/jpeg");
+});
+
+Deno.test("presign rejects unsupported buckets before RPC", async () => {
+  const handler = await getHandler();
+  const { supabase, calls } = makeStorageUploadSupabase({ rpcResults: [] });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "presign",
+      bucket: "bug-report-attachments",
+      declared_size: 1024,
+      mime: "image/png",
+      extension: ".png",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+  const payload = await readJson(response);
+
+  assertEquals(response.status, 400);
+  assertEquals(payload.error, "unsupported_storage_bucket");
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("complete removes object when DB reconcile rejects it", async () => {
+  const handler = await getHandler();
+  const { supabase, calls } = makeStorageUploadSupabase({
+    rpcResults: [{
+      data: {
+        upload_id: "upload-1",
+        bucket_id: "partner-proofs",
+        object_path: "user-1/mismatch.jpg",
+        status: "rejected",
+        actual_size: 2000,
+        rejection_reason: "actual_size_exceeds_declared_size",
+        public_bucket: false,
+      },
+      error: null,
+    }],
+  });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "complete",
+      upload_id: "upload-1",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+  const payload = await readJson(response);
+
+  assertEquals(response.status, 200);
+  assertEquals(payload.status, "rejected");
+  assertEquals(payload.rejection_reason, "actual_size_exceeds_declared_size");
+  assertEquals(
+    calls.some((call) =>
+      call.type === "storage.remove" &&
+      call.bucket === "partner-proofs" &&
+      call.paths?.[0] === "user-1/mismatch.jpg"
+    ),
+    true,
+  );
+});
+
+Deno.test("presign aborts reservation when signed URL creation fails", async () => {
+  const handler = await getHandler();
+  const { supabase, calls } = makeStorageUploadSupabase({
+    rpcResults: [
+      {
+        data: {
+          upload_id: "upload-1",
+          object_path: "user-1/file.jpg",
+          max_file_size_bytes: 10485760,
+          public_bucket: false,
+        },
+        error: null,
+      },
+      {
+        data: {
+          upload_id: "upload-1",
+          bucket_id: "partner-proofs",
+          object_path: "user-1/file.jpg",
+          status: "aborted",
+        },
+        error: null,
+      },
+    ],
+    signedError: { message: "storage unavailable" },
+  });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "presign",
+      bucket: "partner-proofs",
+      path_prefix: "user-1",
+      declared_size: 1024,
+      mime: "image/jpeg",
+      extension: ".jpg",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+  const payload = await readJson(response);
+
+  assertEquals(response.status, 500);
+  assertEquals(payload.error, "storage unavailable");
+  assertEquals(
+    calls.some((call) => call.name === "abort_storage_upload"),
+    true,
+  );
+});

--- a/supabase/functions/storage-upload/index_test.ts
+++ b/supabase/functions/storage-upload/index_test.ts
@@ -23,9 +23,18 @@ type RpcResult = {
   error: { message?: string } | null;
 };
 
+type JsonRecord = Record<string, unknown>;
+
+async function readPayload(response: Response): Promise<JsonRecord> {
+  return await readJson(response) as JsonRecord;
+}
+
 function makeStorageUploadSupabase(opts: {
   rpcResults: RpcResult[];
   signedError?: { message: string } | null;
+  removeError?: { message: string } | null;
+  downloadError?: { message: string } | null;
+  uploadError?: { message: string } | null;
 }) {
   const calls: Array<{
     type: string;
@@ -80,8 +89,34 @@ function makeStorageUploadSupabase(opts: {
               },
             };
           },
+          download(path: string) {
+            calls.push({ type: "storage.download", bucket, args: { path } });
+            if (opts.downloadError) {
+              return Promise.resolve({ data: null, error: opts.downloadError });
+            }
+            return Promise.resolve({
+              data: new Blob([new Uint8Array([1, 2, 3])], {
+                type: "image/jpeg",
+              }),
+              error: null,
+            });
+          },
+          upload(path: string, _body: Blob, options: Record<string, unknown>) {
+            calls.push({
+              type: "storage.upload",
+              bucket,
+              args: { path, options },
+            });
+            if (opts.uploadError) {
+              return Promise.resolve({ data: null, error: opts.uploadError });
+            }
+            return Promise.resolve({ data: { path }, error: null });
+          },
           remove(paths: string[]) {
             calls.push({ type: "storage.remove", bucket, paths });
+            if (opts.removeError) {
+              return Promise.resolve({ data: null, error: opts.removeError });
+            }
             return Promise.resolve({ data: paths, error: null });
           },
         };
@@ -98,7 +133,10 @@ Deno.test("presign creates reservation and signed upload token", async () => {
     rpcResults: [{
       data: {
         upload_id: "upload-1",
+        bucket_id: "party-assets",
         object_path: "partner-1/generated.jpg",
+        upload_bucket_id: "party-assets-pending",
+        upload_object_path: "partner-1/generated.jpg",
         max_file_size_bytes: 52428800,
         public_bucket: true,
       },
@@ -118,15 +156,21 @@ Deno.test("presign creates reservation and signed upload token", async () => {
     },
     ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
   });
-  const payload = await readJson(response);
+  const payload = await readPayload(response);
 
   assertEquals(response.status, 200);
   assertEquals(payload.upload_id, "upload-1");
   assertEquals(payload.path, "partner-1/generated.jpg");
+  assertEquals(payload.upload_bucket, "party-assets-pending");
+  assertEquals(payload.final_path, "partner-1/generated.jpg");
   assertEquals(payload.token, "signed-token");
+  assertEquals(payload.public_url, null);
   assertEquals(
-    payload.public_url,
-    "https://storage.test/object/public/party-assets/partner-1/generated.jpg",
+    calls.some((call) =>
+      call.type === "storage.createSignedUploadUrl" &&
+      call.bucket === "party-assets-pending"
+    ),
+    true,
   );
 
   const reserve = calls.find((call) => call.name === "reserve_storage_upload");
@@ -154,7 +198,7 @@ Deno.test("presign rejects unsupported buckets before RPC", async () => {
     },
     ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
   });
-  const payload = await readJson(response);
+  const payload = await readPayload(response);
 
   assertEquals(response.status, 400);
   assertEquals(payload.error, "unsupported_storage_bucket");
@@ -169,9 +213,12 @@ Deno.test("complete removes object when DB reconcile rejects it", async () => {
         upload_id: "upload-1",
         bucket_id: "partner-proofs",
         object_path: "user-1/mismatch.jpg",
+        upload_bucket_id: "partner-proofs",
+        upload_object_path: "user-1/mismatch.jpg",
         status: "rejected",
         actual_size: 2000,
         rejection_reason: "actual_size_exceeds_declared_size",
+        mime_type: "image/jpeg",
         public_bucket: false,
       },
       error: null,
@@ -186,7 +233,7 @@ Deno.test("complete removes object when DB reconcile rejects it", async () => {
     },
     ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
   });
-  const payload = await readJson(response);
+  const payload = await readPayload(response);
 
   assertEquals(response.status, 200);
   assertEquals(payload.status, "rejected");
@@ -201,6 +248,114 @@ Deno.test("complete removes object when DB reconcile rejects it", async () => {
   );
 });
 
+Deno.test("complete publishes public uploads only after DB reconcile", async () => {
+  const handler = await getHandler();
+  const { supabase, calls } = makeStorageUploadSupabase({
+    rpcResults: [
+      {
+        data: {
+          upload_id: "upload-1",
+          bucket_id: "party-assets",
+          object_path: "partner-1/hero.jpg",
+          upload_bucket_id: "party-assets-pending",
+          upload_object_path: "partner-1/hero.jpg",
+          status: "publishing",
+          actual_size: 1024,
+          rejection_reason: null,
+          mime_type: "image/jpeg",
+          public_bucket: true,
+        },
+        error: null,
+      },
+      {
+        data: {
+          upload_id: "upload-1",
+          bucket_id: "party-assets",
+          object_path: "partner-1/hero.jpg",
+          upload_bucket_id: "party-assets-pending",
+          upload_object_path: "partner-1/hero.jpg",
+          status: "completed",
+          actual_size: 1024,
+          rejection_reason: null,
+          mime_type: "image/jpeg",
+          public_bucket: true,
+        },
+        error: null,
+      },
+    ],
+  });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "complete",
+      upload_id: "upload-1",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+  const payload = await readPayload(response);
+
+  assertEquals(response.status, 200);
+  assertEquals(payload.status, "completed");
+  assertEquals(
+    payload.public_url,
+    "https://storage.test/object/public/party-assets/partner-1/hero.jpg",
+  );
+  assertEquals(
+    calls.some((call) =>
+      call.type === "storage.download" &&
+      call.bucket === "party-assets-pending"
+    ),
+    true,
+  );
+  assertEquals(
+    calls.some((call) =>
+      call.type === "storage.upload" &&
+      call.bucket === "party-assets"
+    ),
+    true,
+  );
+  assertEquals(
+    calls.some((call) => call.name === "publish_storage_upload"),
+    true,
+  );
+});
+
+Deno.test("complete fails when rejected object cleanup fails", async () => {
+  const handler = await getHandler();
+  const { supabase } = makeStorageUploadSupabase({
+    rpcResults: [{
+      data: {
+        upload_id: "upload-1",
+        bucket_id: "party-assets",
+        object_path: "partner-1/mismatch.jpg",
+        upload_bucket_id: "party-assets-pending",
+        upload_object_path: "partner-1/mismatch.jpg",
+        status: "rejected",
+        actual_size: 2000,
+        rejection_reason: "actual_size_exceeds_declared_size",
+        mime_type: "image/jpeg",
+        public_bucket: true,
+      },
+      error: null,
+    }],
+    removeError: { message: "remove failed" },
+  });
+
+  const response = await runHandler(handler, {
+    method: "POST",
+    body: {
+      action: "complete",
+      upload_id: "upload-1",
+    },
+    ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
+  });
+  const payload = await readPayload(response);
+
+  assertEquals(response.status, 500);
+  assertEquals(payload.error, "remove failed");
+});
+
 Deno.test("presign aborts reservation when signed URL creation fails", async () => {
   const handler = await getHandler();
   const { supabase, calls } = makeStorageUploadSupabase({
@@ -208,7 +363,10 @@ Deno.test("presign aborts reservation when signed URL creation fails", async () 
       {
         data: {
           upload_id: "upload-1",
+          bucket_id: "partner-proofs",
           object_path: "user-1/file.jpg",
+          upload_bucket_id: "partner-proofs",
+          upload_object_path: "user-1/file.jpg",
           max_file_size_bytes: 10485760,
           public_bucket: false,
         },
@@ -239,7 +397,7 @@ Deno.test("presign aborts reservation when signed URL creation fails", async () 
     },
     ctx: makeCtx({ supabase: supabase as never, userId: "user-1" }),
   });
-  const payload = await readJson(response);
+  const payload = await readPayload(response);
 
   assertEquals(response.status, 500);
   assertEquals(payload.error, "storage unavailable");

--- a/supabase/migrations/20260603230000_storage_signed_upload_pipeline.sql
+++ b/supabase/migrations/20260603230000_storage_signed_upload_pipeline.sql
@@ -25,8 +25,27 @@ SET
   ]
 WHERE id = 'party-assets';
 
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'party-assets-pending',
+  'party-assets-pending',
+  false,
+  52428800,
+  ARRAY[
+    'image/jpeg',
+    'image/png',
+    'image/webp'
+  ]
+)
+ON CONFLICT (id) DO UPDATE
+SET
+  public = false,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
 CREATE TABLE IF NOT EXISTS public.storage_upload_bucket_policies (
   bucket_id text PRIMARY KEY REFERENCES storage.buckets(id) ON DELETE CASCADE,
+  upload_bucket_id text NOT NULL REFERENCES storage.buckets(id) ON DELETE CASCADE,
   public_bucket boolean NOT NULL DEFAULT false,
   max_file_size_bytes bigint NOT NULL CHECK (max_file_size_bytes > 0),
   allowed_mime_types text[] NOT NULL CHECK (array_length(allowed_mime_types, 1) > 0),
@@ -36,7 +55,8 @@ CREATE TABLE IF NOT EXISTS public.storage_upload_bucket_policies (
   max_concurrent_uploads integer NOT NULL CHECK (max_concurrent_uploads > 0),
   upload_ttl interval NOT NULL DEFAULT interval '2 hours',
   is_enabled boolean NOT NULL DEFAULT true,
-  updated_at timestamptz NOT NULL DEFAULT now()
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (public_bucket = false OR upload_bucket_id <> bucket_id)
 );
 
 ALTER TABLE public.storage_upload_bucket_policies ENABLE ROW LEVEL SECURITY;
@@ -45,6 +65,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON public.storage_upload_bucket_policies TO
 
 INSERT INTO public.storage_upload_bucket_policies (
   bucket_id,
+  upload_bucket_id,
   public_bucket,
   max_file_size_bytes,
   allowed_mime_types,
@@ -56,6 +77,7 @@ INSERT INTO public.storage_upload_bucket_policies (
 VALUES
   (
     'verification-proofs',
+    'verification-proofs',
     false,
     10485760,
     ARRAY['image/jpeg', 'image/png', 'image/webp', 'application/pdf'],
@@ -65,6 +87,7 @@ VALUES
     5
   ),
   (
+    'partner-proofs',
     'partner-proofs',
     false,
     10485760,
@@ -76,6 +99,7 @@ VALUES
   ),
   (
     'party-assets',
+    'party-assets-pending',
     true,
     52428800,
     ARRAY['image/jpeg', 'image/png', 'image/webp'],
@@ -86,6 +110,7 @@ VALUES
   )
 ON CONFLICT (bucket_id) DO UPDATE
 SET
+  upload_bucket_id = EXCLUDED.upload_bucket_id,
   public_bucket = EXCLUDED.public_bucket,
   max_file_size_bytes = EXCLUDED.max_file_size_bytes,
   allowed_mime_types = EXCLUDED.allowed_mime_types,
@@ -101,17 +126,20 @@ CREATE TABLE IF NOT EXISTS public.active_storage_uploads (
   user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   bucket_id text NOT NULL REFERENCES storage.buckets(id) ON DELETE CASCADE,
   object_path text NOT NULL,
+  upload_bucket_id text NOT NULL REFERENCES storage.buckets(id) ON DELETE CASCADE,
+  upload_object_path text NOT NULL,
   declared_size bigint NOT NULL CHECK (declared_size > 0),
   mime_type text NOT NULL,
   status text NOT NULL DEFAULT 'pending'
-    CHECK (status IN ('pending', 'completed', 'aborted', 'rejected', 'expired')),
+    CHECK (status IN ('pending', 'publishing', 'completed', 'aborted', 'rejected', 'expired')),
   actual_size bigint CHECK (actual_size IS NULL OR actual_size >= 0),
   rejection_reason text,
   created_at timestamptz NOT NULL DEFAULT now(),
   expires_at timestamptz NOT NULL DEFAULT (now() + interval '2 hours'),
   completed_at timestamptz,
   updated_at timestamptz NOT NULL DEFAULT now(),
-  UNIQUE (bucket_id, object_path)
+  UNIQUE (bucket_id, object_path),
+  UNIQUE (upload_bucket_id, upload_object_path)
 );
 
 ALTER TABLE public.active_storage_uploads ENABLE ROW LEVEL SECURITY;
@@ -123,7 +151,7 @@ CREATE INDEX IF NOT EXISTS idx_active_storage_uploads_user_status
 
 CREATE INDEX IF NOT EXISTS idx_active_storage_uploads_pending_expiry
   ON public.active_storage_uploads(expires_at)
-  WHERE status = 'pending';
+  WHERE status IN ('pending', 'publishing');
 
 CREATE OR REPLACE FUNCTION public.storage_object_metadata_size(p_metadata jsonb)
 RETURNS bigint
@@ -157,7 +185,7 @@ BEGIN
       status = 'expired',
       updated_at = p_now,
       rejection_reason = 'upload_token_expired'
-    WHERE status = 'pending'
+    WHERE status IN ('pending', 'publishing')
       AND expires_at < p_now
     RETURNING 1
   )
@@ -176,7 +204,10 @@ CREATE OR REPLACE FUNCTION public.reserve_storage_upload(
 )
 RETURNS TABLE (
   upload_id uuid,
+  bucket_id text,
   object_path text,
+  upload_bucket_id text,
+  upload_object_path text,
   max_file_size_bytes bigint,
   public_bucket boolean
 )
@@ -199,7 +230,7 @@ BEGIN
   SELECT *
   INTO v_policy
   FROM public.storage_upload_bucket_policies
-  WHERE bucket_id = p_bucket_id
+  WHERE storage_upload_bucket_policies.bucket_id = p_bucket_id
     AND is_enabled = true;
 
   IF NOT FOUND THEN
@@ -256,7 +287,7 @@ BEGIN
   INTO v_pending_count
   FROM public.active_storage_uploads
   WHERE user_id = p_user_id
-    AND status = 'pending'
+    AND status IN ('pending', 'publishing')
     AND expires_at > now();
 
   IF v_pending_count >= v_policy.max_concurrent_uploads THEN
@@ -286,7 +317,7 @@ BEGIN
   INTO v_pending_bytes
   FROM public.active_storage_uploads
   WHERE user_id = p_user_id
-    AND status = 'pending'
+    AND status IN ('pending', 'publishing')
     AND expires_at > now();
 
   IF v_current_bytes + v_pending_bytes + p_declared_size > v_policy.quota_bytes THEN
@@ -297,6 +328,8 @@ BEGIN
     user_id,
     bucket_id,
     object_path,
+    upload_bucket_id,
+    upload_object_path,
     declared_size,
     mime_type,
     expires_at
@@ -304,6 +337,8 @@ BEGIN
   VALUES (
     p_user_id,
     p_bucket_id,
+    p_object_path,
+    v_policy.upload_bucket_id,
     p_object_path,
     p_declared_size,
     p_mime_type,
@@ -313,6 +348,9 @@ BEGIN
 
   RETURN QUERY SELECT
     v_upload_id,
+    p_bucket_id,
+    p_object_path,
+    v_policy.upload_bucket_id,
     p_object_path,
     v_policy.max_file_size_bytes,
     v_policy.public_bucket;
@@ -327,9 +365,12 @@ RETURNS TABLE (
   upload_id uuid,
   bucket_id text,
   object_path text,
+  upload_bucket_id text,
+  upload_object_path text,
   status text,
   actual_size bigint,
   rejection_reason text,
+  mime_type text,
   public_bucket boolean
 )
 LANGUAGE plpgsql
@@ -357,7 +398,7 @@ BEGIN
   SELECT *
   INTO v_policy
   FROM public.storage_upload_bucket_policies
-  WHERE bucket_id = v_upload.bucket_id;
+  WHERE storage_upload_bucket_policies.bucket_id = v_upload.bucket_id;
 
   IF NOT FOUND THEN
     RAISE EXCEPTION 'storage_upload_policy_missing';
@@ -368,9 +409,12 @@ BEGIN
       v_upload.id,
       v_upload.bucket_id,
       v_upload.object_path,
+      v_upload.upload_bucket_id,
+      v_upload.upload_object_path,
       v_upload.status,
       v_upload.actual_size,
       v_upload.rejection_reason,
+      v_upload.mime_type,
       v_policy.public_bucket;
     RETURN;
   END IF;
@@ -378,8 +422,8 @@ BEGIN
   SELECT *
   INTO v_object
   FROM storage.objects
-  WHERE bucket_id = v_upload.bucket_id
-    AND name = v_upload.object_path;
+  WHERE storage.objects.bucket_id = v_upload.upload_bucket_id
+    AND storage.objects.name = v_upload.upload_object_path;
 
   IF NOT FOUND THEN
     RAISE EXCEPTION 'storage_object_not_found';
@@ -410,9 +454,35 @@ BEGIN
       v_upload.id,
       v_upload.bucket_id,
       v_upload.object_path,
+      v_upload.upload_bucket_id,
+      v_upload.upload_object_path,
       v_upload.status,
       v_upload.actual_size,
       v_upload.rejection_reason,
+      v_upload.mime_type,
+      v_policy.public_bucket;
+    RETURN;
+  END IF;
+
+  IF v_policy.public_bucket THEN
+    UPDATE public.active_storage_uploads
+    SET
+      status = 'publishing',
+      actual_size = v_actual_size,
+      updated_at = now()
+    WHERE id = v_upload.id
+    RETURNING * INTO v_upload;
+
+    RETURN QUERY SELECT
+      v_upload.id,
+      v_upload.bucket_id,
+      v_upload.object_path,
+      v_upload.upload_bucket_id,
+      v_upload.upload_object_path,
+      v_upload.status,
+      v_upload.actual_size,
+      v_upload.rejection_reason,
+      v_upload.mime_type,
       v_policy.public_bucket;
     RETURN;
   END IF;
@@ -428,16 +498,138 @@ BEGIN
 
   UPDATE public.minglit_files
   SET owner_id = p_user_id
-  WHERE bucket_id = v_upload.bucket_id
-    AND file_path = v_upload.object_path;
+  WHERE public.minglit_files.bucket_id = v_upload.bucket_id
+    AND public.minglit_files.file_path = v_upload.object_path;
 
   RETURN QUERY SELECT
     v_upload.id,
     v_upload.bucket_id,
     v_upload.object_path,
+    v_upload.upload_bucket_id,
+    v_upload.upload_object_path,
     v_upload.status,
     v_upload.actual_size,
     v_upload.rejection_reason,
+    v_upload.mime_type,
+    v_policy.public_bucket;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.publish_storage_upload(
+  p_upload_id uuid,
+  p_user_id uuid
+)
+RETURNS TABLE (
+  upload_id uuid,
+  bucket_id text,
+  object_path text,
+  upload_bucket_id text,
+  upload_object_path text,
+  status text,
+  actual_size bigint,
+  rejection_reason text,
+  mime_type text,
+  public_bucket boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, storage, auth, extensions
+AS $$
+DECLARE
+  v_upload public.active_storage_uploads%ROWTYPE;
+  v_policy public.storage_upload_bucket_policies%ROWTYPE;
+  v_object storage.objects%ROWTYPE;
+BEGIN
+  SELECT *
+  INTO v_upload
+  FROM public.active_storage_uploads
+  WHERE id = p_upload_id
+    AND user_id = p_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'active_upload_not_found';
+  END IF;
+
+  SELECT *
+  INTO v_policy
+  FROM public.storage_upload_bucket_policies
+  WHERE storage_upload_bucket_policies.bucket_id = v_upload.bucket_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'storage_upload_policy_missing';
+  END IF;
+
+  IF NOT v_policy.public_bucket THEN
+    RAISE EXCEPTION 'storage_upload_publish_not_required';
+  END IF;
+
+  IF v_upload.status = 'completed' THEN
+    RETURN QUERY SELECT
+      v_upload.id,
+      v_upload.bucket_id,
+      v_upload.object_path,
+      v_upload.upload_bucket_id,
+      v_upload.upload_object_path,
+      v_upload.status,
+      v_upload.actual_size,
+      v_upload.rejection_reason,
+      v_upload.mime_type,
+      v_policy.public_bucket;
+    RETURN;
+  END IF;
+
+  IF v_upload.status <> 'publishing' THEN
+    RAISE EXCEPTION 'storage_upload_not_ready_to_publish';
+  END IF;
+
+  SELECT *
+  INTO v_object
+  FROM storage.objects
+  WHERE storage.objects.bucket_id = v_upload.bucket_id
+    AND storage.objects.name = v_upload.object_path;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'storage_published_object_not_found';
+  END IF;
+
+  UPDATE public.minglit_files
+  SET owner_id = p_user_id
+  WHERE storage_object_id = v_object.id;
+
+  IF NOT FOUND THEN
+    INSERT INTO public.minglit_files (
+      storage_object_id,
+      bucket_id,
+      file_path,
+      owner_id
+    )
+    VALUES (
+      v_object.id,
+      v_upload.bucket_id,
+      v_upload.object_path,
+      p_user_id
+    );
+  END IF;
+
+  UPDATE public.active_storage_uploads
+  SET
+    status = 'completed',
+    completed_at = now(),
+    updated_at = now()
+  WHERE id = v_upload.id
+  RETURNING * INTO v_upload;
+
+  RETURN QUERY SELECT
+    v_upload.id,
+    v_upload.bucket_id,
+    v_upload.object_path,
+    v_upload.upload_bucket_id,
+    v_upload.upload_object_path,
+    v_upload.status,
+    v_upload.actual_size,
+    v_upload.rejection_reason,
+    v_upload.mime_type,
     v_policy.public_bucket;
 END;
 $$;
@@ -494,7 +686,7 @@ CREATE OR REPLACE FUNCTION public.handle_storage_object_created()
 RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = public, storage, auth, extensions
+SET search_path = public
 AS $$
 DECLARE
   v_owner_id uuid;
@@ -505,8 +697,10 @@ BEGIN
     SELECT user_id
     INTO v_owner_id
     FROM public.active_storage_uploads
-    WHERE bucket_id = new.bucket_id
-      AND object_path = new.name
+    WHERE upload_bucket_id = new.bucket_id
+      AND upload_object_path = new.name
+      AND active_storage_uploads.bucket_id = new.bucket_id
+      AND active_storage_uploads.object_path = new.name
       AND status = 'pending'
     ORDER BY created_at DESC
     LIMIT 1;
@@ -525,12 +719,14 @@ REVOKE ALL ON FUNCTION public.storage_object_metadata_size(jsonb) FROM PUBLIC, a
 REVOKE ALL ON FUNCTION public.cleanup_stale_storage_uploads(timestamptz) FROM PUBLIC, anon, authenticated;
 REVOKE ALL ON FUNCTION public.reserve_storage_upload(uuid, text, text, bigint, text) FROM PUBLIC, anon, authenticated;
 REVOKE ALL ON FUNCTION public.complete_storage_upload(uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.publish_storage_upload(uuid, uuid) FROM PUBLIC, anon, authenticated;
 REVOKE ALL ON FUNCTION public.abort_storage_upload(uuid, uuid) FROM PUBLIC, anon, authenticated;
 
 GRANT EXECUTE ON FUNCTION public.storage_object_metadata_size(jsonb) TO service_role;
 GRANT EXECUTE ON FUNCTION public.cleanup_stale_storage_uploads(timestamptz) TO service_role;
 GRANT EXECUTE ON FUNCTION public.reserve_storage_upload(uuid, text, text, bigint, text) TO service_role;
 GRANT EXECUTE ON FUNCTION public.complete_storage_upload(uuid, uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.publish_storage_upload(uuid, uuid) TO service_role;
 GRANT EXECUTE ON FUNCTION public.abort_storage_upload(uuid, uuid) TO service_role;
 
 COMMENT ON TABLE public.active_storage_uploads IS
@@ -539,3 +735,5 @@ COMMENT ON FUNCTION public.reserve_storage_upload(uuid, text, text, bigint, text
   'Fix #2993: service_role-only presign guard for Storage uploads. Enforces bucket policy, user/partner path scope, byte-rate, quota, and concurrency.';
 COMMENT ON FUNCTION public.complete_storage_upload(uuid, uuid) IS
   'Fix #2993: service_role-only post-upload reconcile. Closes active upload and rejects declared/actual size mismatches.';
+COMMENT ON FUNCTION public.publish_storage_upload(uuid, uuid) IS
+  'Fix #2993: service_role-only public bucket publish step after private staging upload is reconciled.';

--- a/supabase/migrations/20260603230000_storage_signed_upload_pipeline.sql
+++ b/supabase/migrations/20260603230000_storage_signed_upload_pipeline.sql
@@ -1,0 +1,541 @@
+-- Fix #2993: signed Storage upload pipeline with quota/rate/concurrency guardrails.
+
+-- Covered product buckets get hard Storage-level size/MIME limits. The global
+-- local limit remains 50MiB; per-bucket limits below are the product contract.
+UPDATE storage.buckets
+SET
+  public = false,
+  file_size_limit = 10485760,
+  allowed_mime_types = ARRAY[
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'application/pdf'
+  ]
+WHERE id IN ('verification-proofs', 'partner-proofs');
+
+UPDATE storage.buckets
+SET
+  public = true,
+  file_size_limit = 52428800,
+  allowed_mime_types = ARRAY[
+    'image/jpeg',
+    'image/png',
+    'image/webp'
+  ]
+WHERE id = 'party-assets';
+
+CREATE TABLE IF NOT EXISTS public.storage_upload_bucket_policies (
+  bucket_id text PRIMARY KEY REFERENCES storage.buckets(id) ON DELETE CASCADE,
+  public_bucket boolean NOT NULL DEFAULT false,
+  max_file_size_bytes bigint NOT NULL CHECK (max_file_size_bytes > 0),
+  allowed_mime_types text[] NOT NULL CHECK (array_length(allowed_mime_types, 1) > 0),
+  path_owner_mode text NOT NULL CHECK (path_owner_mode IN ('user', 'partner')),
+  hourly_byte_limit bigint NOT NULL CHECK (hourly_byte_limit > 0),
+  quota_bytes bigint NOT NULL CHECK (quota_bytes > 0),
+  max_concurrent_uploads integer NOT NULL CHECK (max_concurrent_uploads > 0),
+  upload_ttl interval NOT NULL DEFAULT interval '2 hours',
+  is_enabled boolean NOT NULL DEFAULT true,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.storage_upload_bucket_policies ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.storage_upload_bucket_policies FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.storage_upload_bucket_policies TO service_role;
+
+INSERT INTO public.storage_upload_bucket_policies (
+  bucket_id,
+  public_bucket,
+  max_file_size_bytes,
+  allowed_mime_types,
+  path_owner_mode,
+  hourly_byte_limit,
+  quota_bytes,
+  max_concurrent_uploads
+)
+VALUES
+  (
+    'verification-proofs',
+    false,
+    10485760,
+    ARRAY['image/jpeg', 'image/png', 'image/webp', 'application/pdf'],
+    'user',
+    524288000,
+    5368709120,
+    5
+  ),
+  (
+    'partner-proofs',
+    false,
+    10485760,
+    ARRAY['image/jpeg', 'image/png', 'image/webp', 'application/pdf'],
+    'user',
+    524288000,
+    5368709120,
+    5
+  ),
+  (
+    'party-assets',
+    true,
+    52428800,
+    ARRAY['image/jpeg', 'image/png', 'image/webp'],
+    'partner',
+    524288000,
+    5368709120,
+    5
+  )
+ON CONFLICT (bucket_id) DO UPDATE
+SET
+  public_bucket = EXCLUDED.public_bucket,
+  max_file_size_bytes = EXCLUDED.max_file_size_bytes,
+  allowed_mime_types = EXCLUDED.allowed_mime_types,
+  path_owner_mode = EXCLUDED.path_owner_mode,
+  hourly_byte_limit = EXCLUDED.hourly_byte_limit,
+  quota_bytes = EXCLUDED.quota_bytes,
+  max_concurrent_uploads = EXCLUDED.max_concurrent_uploads,
+  is_enabled = true,
+  updated_at = now();
+
+CREATE TABLE IF NOT EXISTS public.active_storage_uploads (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  bucket_id text NOT NULL REFERENCES storage.buckets(id) ON DELETE CASCADE,
+  object_path text NOT NULL,
+  declared_size bigint NOT NULL CHECK (declared_size > 0),
+  mime_type text NOT NULL,
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'completed', 'aborted', 'rejected', 'expired')),
+  actual_size bigint CHECK (actual_size IS NULL OR actual_size >= 0),
+  rejection_reason text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL DEFAULT (now() + interval '2 hours'),
+  completed_at timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (bucket_id, object_path)
+);
+
+ALTER TABLE public.active_storage_uploads ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.active_storage_uploads FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.active_storage_uploads TO service_role;
+
+CREATE INDEX IF NOT EXISTS idx_active_storage_uploads_user_status
+  ON public.active_storage_uploads(user_id, status, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_active_storage_uploads_pending_expiry
+  ON public.active_storage_uploads(expires_at)
+  WHERE status = 'pending';
+
+CREATE OR REPLACE FUNCTION public.storage_object_metadata_size(p_metadata jsonb)
+RETURNS bigint
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public, storage, extensions
+AS $$
+  SELECT CASE
+    WHEN p_metadata ? 'size' AND (p_metadata->>'size') ~ '^[0-9]+$'
+      THEN (p_metadata->>'size')::bigint
+    WHEN p_metadata ? 'contentLength' AND (p_metadata->>'contentLength') ~ '^[0-9]+$'
+      THEN (p_metadata->>'contentLength')::bigint
+    WHEN p_metadata ? 'content-length' AND (p_metadata->>'content-length') ~ '^[0-9]+$'
+      THEN (p_metadata->>'content-length')::bigint
+    ELSE 0
+  END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.cleanup_stale_storage_uploads(p_now timestamptz DEFAULT now())
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, storage, auth, extensions
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  WITH expired AS (
+    UPDATE public.active_storage_uploads
+    SET
+      status = 'expired',
+      updated_at = p_now,
+      rejection_reason = 'upload_token_expired'
+    WHERE status = 'pending'
+      AND expires_at < p_now
+    RETURNING 1
+  )
+  SELECT count(*)::integer INTO v_count FROM expired;
+
+  RETURN v_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reserve_storage_upload(
+  p_user_id uuid,
+  p_bucket_id text,
+  p_object_path text,
+  p_declared_size bigint,
+  p_mime_type text
+)
+RETURNS TABLE (
+  upload_id uuid,
+  object_path text,
+  max_file_size_bytes bigint,
+  public_bucket boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, storage, auth, extensions
+AS $$
+DECLARE
+  v_policy public.storage_upload_bucket_policies%ROWTYPE;
+  v_first_segment text;
+  v_partner_id uuid;
+  v_pending_count integer;
+  v_recent_bytes bigint;
+  v_current_bytes bigint;
+  v_pending_bytes bigint;
+  v_upload_id uuid;
+BEGIN
+  PERFORM public.cleanup_stale_storage_uploads();
+
+  SELECT *
+  INTO v_policy
+  FROM public.storage_upload_bucket_policies
+  WHERE bucket_id = p_bucket_id
+    AND is_enabled = true;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'unsupported_storage_bucket';
+  END IF;
+
+  IF p_declared_size <= 0 THEN
+    RAISE EXCEPTION 'invalid_declared_size';
+  END IF;
+
+  IF p_declared_size > v_policy.max_file_size_bytes THEN
+    RAISE EXCEPTION 'upload_size_exceeds_bucket_limit';
+  END IF;
+
+  IF NOT (p_mime_type = ANY(v_policy.allowed_mime_types)) THEN
+    RAISE EXCEPTION 'unsupported_upload_mime_type';
+  END IF;
+
+  IF p_object_path IS NULL
+    OR length(p_object_path) < 3
+    OR length(p_object_path) > 512
+    OR p_object_path LIKE '/%'
+    OR p_object_path LIKE '%//%'
+    OR p_object_path LIKE '%..%'
+  THEN
+    RAISE EXCEPTION 'invalid_storage_path';
+  END IF;
+
+  v_first_segment := split_part(p_object_path, '/', 1);
+
+  IF v_policy.path_owner_mode = 'user' THEN
+    IF v_first_segment <> p_user_id::text THEN
+      RAISE EXCEPTION 'storage_path_user_prefix_required';
+    END IF;
+  ELSIF v_policy.path_owner_mode = 'partner' THEN
+    BEGIN
+      v_partner_id := v_first_segment::uuid;
+    EXCEPTION WHEN invalid_text_representation THEN
+      RAISE EXCEPTION 'storage_path_partner_prefix_required';
+    END;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.partner_member_permissions pmp
+      WHERE pmp.partner_id = v_partner_id
+        AND pmp.user_id = p_user_id
+        AND 'PARTY_MANAGE' = ANY(pmp.permissions)
+    ) THEN
+      RAISE EXCEPTION 'storage_upload_partner_permission_required';
+    END IF;
+  END IF;
+
+  SELECT count(*)::integer
+  INTO v_pending_count
+  FROM public.active_storage_uploads
+  WHERE user_id = p_user_id
+    AND status = 'pending'
+    AND expires_at > now();
+
+  IF v_pending_count >= v_policy.max_concurrent_uploads THEN
+    RAISE EXCEPTION 'storage_upload_concurrency_exceeded';
+  END IF;
+
+  SELECT COALESCE(sum(declared_size), 0)
+  INTO v_recent_bytes
+  FROM public.active_storage_uploads
+  WHERE user_id = p_user_id
+    AND status <> 'rejected'
+    AND created_at >= now() - interval '1 hour';
+
+  IF v_recent_bytes + p_declared_size > v_policy.hourly_byte_limit THEN
+    RAISE EXCEPTION 'storage_upload_byte_rate_exceeded';
+  END IF;
+
+  SELECT COALESCE(sum(public.storage_object_metadata_size(o.metadata)), 0)
+  INTO v_current_bytes
+  FROM public.minglit_files f
+  JOIN storage.objects o ON o.id = f.storage_object_id
+  JOIN public.storage_upload_bucket_policies p ON p.bucket_id = o.bucket_id
+  WHERE f.owner_id = p_user_id
+    AND p.is_enabled = true;
+
+  SELECT COALESCE(sum(declared_size), 0)
+  INTO v_pending_bytes
+  FROM public.active_storage_uploads
+  WHERE user_id = p_user_id
+    AND status = 'pending'
+    AND expires_at > now();
+
+  IF v_current_bytes + v_pending_bytes + p_declared_size > v_policy.quota_bytes THEN
+    RAISE EXCEPTION 'storage_upload_quota_exceeded';
+  END IF;
+
+  INSERT INTO public.active_storage_uploads (
+    user_id,
+    bucket_id,
+    object_path,
+    declared_size,
+    mime_type,
+    expires_at
+  )
+  VALUES (
+    p_user_id,
+    p_bucket_id,
+    p_object_path,
+    p_declared_size,
+    p_mime_type,
+    now() + v_policy.upload_ttl
+  )
+  RETURNING id INTO v_upload_id;
+
+  RETURN QUERY SELECT
+    v_upload_id,
+    p_object_path,
+    v_policy.max_file_size_bytes,
+    v_policy.public_bucket;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.complete_storage_upload(
+  p_upload_id uuid,
+  p_user_id uuid
+)
+RETURNS TABLE (
+  upload_id uuid,
+  bucket_id text,
+  object_path text,
+  status text,
+  actual_size bigint,
+  rejection_reason text,
+  public_bucket boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, storage, auth, extensions
+AS $$
+DECLARE
+  v_upload public.active_storage_uploads%ROWTYPE;
+  v_policy public.storage_upload_bucket_policies%ROWTYPE;
+  v_object record;
+  v_actual_size bigint;
+  v_allowed_size bigint;
+BEGIN
+  SELECT *
+  INTO v_upload
+  FROM public.active_storage_uploads
+  WHERE id = p_upload_id
+    AND user_id = p_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'active_upload_not_found';
+  END IF;
+
+  SELECT *
+  INTO v_policy
+  FROM public.storage_upload_bucket_policies
+  WHERE bucket_id = v_upload.bucket_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'storage_upload_policy_missing';
+  END IF;
+
+  IF v_upload.status <> 'pending' THEN
+    RETURN QUERY SELECT
+      v_upload.id,
+      v_upload.bucket_id,
+      v_upload.object_path,
+      v_upload.status,
+      v_upload.actual_size,
+      v_upload.rejection_reason,
+      v_policy.public_bucket;
+    RETURN;
+  END IF;
+
+  SELECT *
+  INTO v_object
+  FROM storage.objects
+  WHERE bucket_id = v_upload.bucket_id
+    AND name = v_upload.object_path;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'storage_object_not_found';
+  END IF;
+
+  v_actual_size := public.storage_object_metadata_size(v_object.metadata);
+  IF v_actual_size = 0 THEN
+    v_actual_size := v_upload.declared_size;
+  END IF;
+
+  v_allowed_size := LEAST(
+    v_policy.max_file_size_bytes,
+    ((v_upload.declared_size * 105) + 99) / 100
+  );
+
+  IF v_actual_size > v_allowed_size THEN
+    UPDATE public.active_storage_uploads
+    SET
+      status = 'rejected',
+      actual_size = v_actual_size,
+      rejection_reason = 'actual_size_exceeds_declared_size',
+      completed_at = now(),
+      updated_at = now()
+    WHERE id = v_upload.id
+    RETURNING * INTO v_upload;
+
+    RETURN QUERY SELECT
+      v_upload.id,
+      v_upload.bucket_id,
+      v_upload.object_path,
+      v_upload.status,
+      v_upload.actual_size,
+      v_upload.rejection_reason,
+      v_policy.public_bucket;
+    RETURN;
+  END IF;
+
+  UPDATE public.active_storage_uploads
+  SET
+    status = 'completed',
+    actual_size = v_actual_size,
+    completed_at = now(),
+    updated_at = now()
+  WHERE id = v_upload.id
+  RETURNING * INTO v_upload;
+
+  UPDATE public.minglit_files
+  SET owner_id = p_user_id
+  WHERE bucket_id = v_upload.bucket_id
+    AND file_path = v_upload.object_path;
+
+  RETURN QUERY SELECT
+    v_upload.id,
+    v_upload.bucket_id,
+    v_upload.object_path,
+    v_upload.status,
+    v_upload.actual_size,
+    v_upload.rejection_reason,
+    v_policy.public_bucket;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.abort_storage_upload(
+  p_upload_id uuid,
+  p_user_id uuid
+)
+RETURNS TABLE (
+  upload_id uuid,
+  bucket_id text,
+  object_path text,
+  status text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, storage, auth, extensions
+AS $$
+DECLARE
+  v_upload public.active_storage_uploads%ROWTYPE;
+BEGIN
+  UPDATE public.active_storage_uploads
+  SET
+    status = 'aborted',
+    rejection_reason = 'client_aborted',
+    updated_at = now()
+  WHERE id = p_upload_id
+    AND user_id = p_user_id
+    AND status = 'pending'
+  RETURNING * INTO v_upload;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'active_upload_not_found_or_not_pending';
+  END IF;
+
+  RETURN QUERY SELECT
+    v_upload.id,
+    v_upload.bucket_id,
+    v_upload.object_path,
+    v_upload.status;
+END;
+$$;
+
+-- Signed upload tokens now gate covered product uploads. Remove broad
+-- authenticated INSERT policies so clients cannot bypass the presign EF.
+DROP POLICY IF EXISTS "Users can upload own verification proofs" ON storage.objects;
+DROP POLICY IF EXISTS "Partners can upload party assets" ON storage.objects;
+DROP POLICY IF EXISTS "Partners can upload own proofs" ON storage.objects;
+
+-- Existing trigger assumed storage.objects.owner is present. Signed upload
+-- token requests may not carry the end-user JWT, so recover owner_id from the
+-- active upload reservation when available.
+CREATE OR REPLACE FUNCTION public.handle_storage_object_created()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, storage, auth, extensions
+AS $$
+DECLARE
+  v_owner_id uuid;
+BEGIN
+  v_owner_id := new.owner;
+
+  IF v_owner_id IS NULL THEN
+    SELECT user_id
+    INTO v_owner_id
+    FROM public.active_storage_uploads
+    WHERE bucket_id = new.bucket_id
+      AND object_path = new.name
+      AND status = 'pending'
+    ORDER BY created_at DESC
+    LIMIT 1;
+  END IF;
+
+  IF v_owner_id IS NOT NULL THEN
+    INSERT INTO public.minglit_files (storage_object_id, bucket_id, file_path, owner_id)
+    VALUES (new.id, new.bucket_id, new.name, v_owner_id);
+  END IF;
+
+  RETURN new;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.storage_object_metadata_size(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.cleanup_stale_storage_uploads(timestamptz) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.reserve_storage_upload(uuid, text, text, bigint, text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.complete_storage_upload(uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.abort_storage_upload(uuid, uuid) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.storage_object_metadata_size(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.cleanup_stale_storage_uploads(timestamptz) TO service_role;
+GRANT EXECUTE ON FUNCTION public.reserve_storage_upload(uuid, text, text, bigint, text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.complete_storage_upload(uuid, uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.abort_storage_upload(uuid, uuid) TO service_role;
+
+COMMENT ON TABLE public.active_storage_uploads IS
+  'Fix #2993: EF-issued signed Storage upload reservations. Tracks declared size, concurrency, quota, and reconcile state.';
+COMMENT ON FUNCTION public.reserve_storage_upload(uuid, text, text, bigint, text) IS
+  'Fix #2993: service_role-only presign guard for Storage uploads. Enforces bucket policy, user/partner path scope, byte-rate, quota, and concurrency.';
+COMMENT ON FUNCTION public.complete_storage_upload(uuid, uuid) IS
+  'Fix #2993: service_role-only post-upload reconcile. Closes active upload and rejects declared/actual size mismatches.';

--- a/supabase/migrations/20260603230000_storage_signed_upload_pipeline.sql
+++ b/supabase/migrations/20260603230000_storage_signed_upload_pipeline.sql
@@ -283,6 +283,13 @@ BEGIN
     END IF;
   END IF;
 
+  -- Serialize all reservation accounting for a user. Concurrency, hourly byte
+  -- rate, and quota checks are user-scoped, so the lock must be user-scoped too.
+  PERFORM pg_advisory_xact_lock(
+    hashtext('storage_upload_reserve'),
+    hashtext(p_user_id::text)
+  );
+
   SELECT count(*)::integer
   INTO v_pending_count
   FROM public.active_storage_uploads

--- a/supabase/tests/database/107_storage_signed_upload_pipeline_test.sql
+++ b/supabase/tests/database/107_storage_signed_upload_pipeline_test.sql
@@ -1,6 +1,6 @@
 -- Fix #2993: signed Storage upload guardrails.
 BEGIN;
-SELECT plan(25);
+SELECT plan(32);
 
 SET search_path TO public, storage, extensions;
 SELECT tests.authenticate_as_service_role();
@@ -27,6 +27,22 @@ SELECT is(
   (SELECT file_size_limit FROM storage.buckets WHERE id = 'party-assets'),
   52428800::bigint,
   '#2993: party-assets has a 50MiB hard bucket limit'
+);
+
+SELECT is(
+  (SELECT public FROM storage.buckets WHERE id = 'party-assets-pending'),
+  false,
+  '#2993: party-assets pending uploads use a private staging bucket'
+);
+
+SELECT is(
+  (
+    SELECT upload_bucket_id
+    FROM public.storage_upload_bucket_policies
+    WHERE bucket_id = 'party-assets'
+  ),
+  'party-assets-pending',
+  '#2993: party-assets policy presigns the private staging bucket'
 );
 
 SELECT ok(
@@ -191,13 +207,93 @@ SELECT throws_ok(
   '#2993: user-owned buckets require the user id path prefix'
 );
 
-SELECT lives_ok(
-  format(
-    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'party-assets', %L, 1024, 'image/jpeg')$$,
-    current_setting('tests.storage_user_id'),
-    current_setting('tests.storage_partner_id') || '/hero.jpg'
-  ),
+CREATE TEMP TABLE t_party_upload AS
+SELECT *
+FROM public.reserve_storage_upload(
+  current_setting('tests.storage_user_id')::uuid,
+  'party-assets',
+  current_setting('tests.storage_partner_id') || '/hero.jpg',
+  1024,
+  'image/jpeg'
+);
+
+SELECT ok(
+  (SELECT upload_id IS NOT NULL FROM t_party_upload),
   '#2993: party-assets reserve allows partner members with PARTY_MANAGE'
+);
+
+SELECT is(
+  (SELECT upload_bucket_id FROM t_party_upload),
+  'party-assets-pending',
+  '#2993: party-assets reserve returns the private staging bucket'
+);
+
+INSERT INTO storage.objects (id, bucket_id, name, owner, owner_id, metadata)
+VALUES (
+  gen_random_uuid(),
+  'party-assets-pending',
+  (SELECT upload_object_path FROM t_party_upload),
+  NULL,
+  NULL,
+  '{"size": 1024}'::jsonb
+);
+
+CREATE TEMP TABLE t_party_complete AS
+SELECT *
+FROM public.complete_storage_upload(
+  (SELECT upload_id FROM t_party_upload),
+  current_setting('tests.storage_user_id')::uuid
+);
+
+SELECT is(
+  (SELECT status FROM t_party_complete),
+  'publishing',
+  '#2993: public bucket reconcile validates staging object before publish'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.minglit_files
+    WHERE bucket_id = 'party-assets-pending'
+      AND file_path = (SELECT upload_object_path FROM t_party_upload)
+  ),
+  0,
+  '#2993: private staging objects are not exposed as product files'
+);
+
+INSERT INTO storage.objects (id, bucket_id, name, owner, owner_id, metadata)
+VALUES (
+  gen_random_uuid(),
+  'party-assets',
+  (SELECT object_path FROM t_party_upload),
+  NULL,
+  NULL,
+  '{"size": 1024}'::jsonb
+);
+
+CREATE TEMP TABLE t_party_publish AS
+SELECT *
+FROM public.publish_storage_upload(
+  (SELECT upload_id FROM t_party_upload),
+  current_setting('tests.storage_user_id')::uuid
+);
+
+SELECT is(
+  (SELECT status FROM t_party_publish),
+  'completed',
+  '#2993: publish_storage_upload completes public assets after final object exists'
+);
+
+SELECT is(
+  (
+    SELECT owner_id
+    FROM public.minglit_files
+    WHERE bucket_id = 'party-assets'
+      AND file_path = (SELECT object_path FROM t_party_upload)
+  ),
+  current_setting('tests.storage_user_id')::uuid,
+  '#2993: published public asset is registered only after publish'
 );
 
 SELECT throws_ok(

--- a/supabase/tests/database/107_storage_signed_upload_pipeline_test.sql
+++ b/supabase/tests/database/107_storage_signed_upload_pipeline_test.sql
@@ -1,6 +1,6 @@
 -- Fix #2993: signed Storage upload guardrails.
 BEGIN;
-SELECT plan(32);
+SELECT plan(33);
 
 SET search_path TO public, storage, extensions;
 SELECT tests.authenticate_as_service_role();
@@ -69,6 +69,18 @@ SELECT results_eq(
   '#2993: covered buckets no longer expose direct authenticated INSERT policies'
 );
 
+SELECT set_config(
+  'tests.storage_advisory_lock_count_before',
+  (
+    SELECT count(*)::int
+    FROM pg_locks
+    WHERE locktype = 'advisory'
+      AND pid = pg_backend_pid()
+      AND granted
+  )::text,
+  true
+);
+
 CREATE TEMP TABLE t_upload AS
 SELECT *
 FROM public.reserve_storage_upload(
@@ -82,6 +94,18 @@ FROM public.reserve_storage_upload(
 SELECT ok(
   (SELECT upload_id IS NOT NULL FROM t_upload),
   '#2993: reserve_storage_upload creates an active upload'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM pg_locks
+    WHERE locktype = 'advisory'
+      AND pid = pg_backend_pid()
+      AND granted
+  ),
+  current_setting('tests.storage_advisory_lock_count_before')::int + 1,
+  '#2993: reserve serializes user-scoped quota checks with a transaction advisory lock'
 );
 
 SELECT is(

--- a/supabase/tests/database/107_storage_signed_upload_pipeline_test.sql
+++ b/supabase/tests/database/107_storage_signed_upload_pipeline_test.sql
@@ -1,0 +1,321 @@
+-- Fix #2993: signed Storage upload guardrails.
+BEGIN;
+SELECT plan(25);
+
+SET search_path TO public, storage, extensions;
+SELECT tests.authenticate_as_service_role();
+
+SELECT set_config('tests.storage_user_id', tests.create_supabase_user('storage_upload_user')::text, true);
+SELECT set_config('tests.storage_other_user_id', tests.create_supabase_user('storage_upload_other')::text, true);
+SELECT set_config('tests.storage_byte_user_id', tests.create_supabase_user('storage_upload_byte')::text, true);
+SELECT set_config('tests.storage_quota_user_id', tests.create_supabase_user('storage_upload_quota')::text, true);
+WITH p AS (
+  INSERT INTO public.partners (name)
+  VALUES ('Storage Upload Test Partner')
+  RETURNING id
+)
+SELECT set_config('tests.storage_partner_id', (SELECT id FROM p)::text, true);
+
+INSERT INTO public.partner_member_permissions (partner_id, user_id, role)
+VALUES (
+  current_setting('tests.storage_partner_id')::uuid,
+  current_setting('tests.storage_user_id')::uuid,
+  'owner'
+);
+
+SELECT is(
+  (SELECT file_size_limit FROM storage.buckets WHERE id = 'party-assets'),
+  52428800::bigint,
+  '#2993: party-assets has a 50MiB hard bucket limit'
+);
+
+SELECT ok(
+  (
+    SELECT allowed_mime_types @> ARRAY['application/pdf']::text[]
+    FROM storage.buckets
+    WHERE id = 'partner-proofs'
+  ),
+  '#2993: partner-proofs allows PDF documents'
+);
+
+SELECT results_eq(
+  $$SELECT count(*)::int
+      FROM pg_policies
+     WHERE schemaname = 'storage'
+       AND tablename = 'objects'
+       AND cmd = 'INSERT'
+       AND policyname IN (
+         'Users can upload own verification proofs',
+         'Partners can upload party assets',
+         'Partners can upload own proofs'
+       )$$,
+  ARRAY[0],
+  '#2993: covered buckets no longer expose direct authenticated INSERT policies'
+);
+
+CREATE TEMP TABLE t_upload AS
+SELECT *
+FROM public.reserve_storage_upload(
+  current_setting('tests.storage_user_id')::uuid,
+  'partner-proofs',
+  current_setting('tests.storage_user_id') || '/biz_reg.jpg',
+  1024,
+  'image/jpeg'
+);
+
+SELECT ok(
+  (SELECT upload_id IS NOT NULL FROM t_upload),
+  '#2993: reserve_storage_upload creates an active upload'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.active_storage_uploads
+    WHERE id = (SELECT upload_id FROM t_upload)
+      AND status = 'pending'
+  ),
+  1,
+  '#2993: reserved upload starts pending'
+);
+
+INSERT INTO storage.objects (id, bucket_id, name, owner, owner_id, metadata)
+VALUES (
+  gen_random_uuid(),
+  'partner-proofs',
+  (SELECT object_path FROM t_upload),
+  NULL,
+  NULL,
+  '{"size": 1024}'::jsonb
+);
+
+SELECT is(
+  (
+    SELECT owner_id
+    FROM public.minglit_files
+    WHERE bucket_id = 'partner-proofs'
+      AND file_path = (SELECT object_path FROM t_upload)
+  ),
+  current_setting('tests.storage_user_id')::uuid,
+  '#2993: storage object trigger recovers owner from active upload'
+);
+
+CREATE TEMP TABLE t_complete AS
+SELECT *
+FROM public.complete_storage_upload(
+  (SELECT upload_id FROM t_upload),
+  current_setting('tests.storage_user_id')::uuid
+);
+
+SELECT is(
+  (SELECT status FROM t_complete),
+  'completed',
+  '#2993: complete_storage_upload closes a matching upload'
+);
+
+SELECT is(
+  (SELECT actual_size FROM t_complete),
+  1024::bigint,
+  '#2993: complete_storage_upload records actual size'
+);
+
+CREATE TEMP TABLE t_mismatch_upload AS
+SELECT *
+FROM public.reserve_storage_upload(
+  current_setting('tests.storage_user_id')::uuid,
+  'partner-proofs',
+  current_setting('tests.storage_user_id') || '/mismatch.jpg',
+  1000,
+  'image/jpeg'
+);
+
+INSERT INTO storage.objects (id, bucket_id, name, owner, owner_id, metadata)
+VALUES (
+  gen_random_uuid(),
+  'partner-proofs',
+  (SELECT object_path FROM t_mismatch_upload),
+  NULL,
+  NULL,
+  '{"size": 2000}'::jsonb
+);
+
+CREATE TEMP TABLE t_mismatch_complete AS
+SELECT *
+FROM public.complete_storage_upload(
+  (SELECT upload_id FROM t_mismatch_upload),
+  current_setting('tests.storage_user_id')::uuid
+);
+
+SELECT is(
+  (SELECT status FROM t_mismatch_complete),
+  'rejected',
+  '#2993: complete_storage_upload rejects actual size mismatch'
+);
+
+SELECT is(
+  (SELECT rejection_reason FROM t_mismatch_complete),
+  'actual_size_exceeds_declared_size',
+  '#2993: rejected reconcile records reason'
+);
+
+SELECT throws_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'partner-proofs', %L, 10485761, 'image/jpeg')$$,
+    current_setting('tests.storage_user_id'),
+    current_setting('tests.storage_user_id') || '/too-large.jpg'
+  ),
+  'P0001',
+  'upload_size_exceeds_bucket_limit',
+  '#2993: reserve rejects files above bucket max'
+);
+
+SELECT throws_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'partner-proofs', %L, 1024, 'application/x-msdownload')$$,
+    current_setting('tests.storage_user_id'),
+    current_setting('tests.storage_user_id') || '/bad.exe'
+  ),
+  'P0001',
+  'unsupported_upload_mime_type',
+  '#2993: reserve rejects unsupported MIME types'
+);
+
+SELECT throws_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'partner-proofs', %L, 1024, 'image/jpeg')$$,
+    current_setting('tests.storage_user_id'),
+    current_setting('tests.storage_other_user_id') || '/forged.jpg'
+  ),
+  'P0001',
+  'storage_path_user_prefix_required',
+  '#2993: user-owned buckets require the user id path prefix'
+);
+
+SELECT lives_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'party-assets', %L, 1024, 'image/jpeg')$$,
+    current_setting('tests.storage_user_id'),
+    current_setting('tests.storage_partner_id') || '/hero.jpg'
+  ),
+  '#2993: party-assets reserve allows partner members with PARTY_MANAGE'
+);
+
+SELECT throws_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'party-assets', %L, 1024, 'image/jpeg')$$,
+    current_setting('tests.storage_other_user_id'),
+    current_setting('tests.storage_partner_id') || '/forbidden.jpg'
+  ),
+  'P0001',
+  'storage_upload_partner_permission_required',
+  '#2993: party-assets reserve rejects users without partner permission'
+);
+
+UPDATE public.active_storage_uploads
+SET status = 'aborted'
+WHERE user_id = current_setting('tests.storage_other_user_id')::uuid;
+
+SELECT lives_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'partner-proofs', %L, 100, 'image/jpeg')$$,
+    current_setting('tests.storage_other_user_id'),
+    current_setting('tests.storage_other_user_id') || '/concurrency-1.jpg'
+  ),
+  '#2993: concurrency setup 1'
+);
+SELECT lives_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'partner-proofs', %L, 100, 'image/jpeg')$$,
+    current_setting('tests.storage_other_user_id'),
+    current_setting('tests.storage_other_user_id') || '/concurrency-2.jpg'
+  ),
+  '#2993: concurrency setup 2'
+);
+SELECT lives_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'partner-proofs', %L, 100, 'image/jpeg')$$,
+    current_setting('tests.storage_other_user_id'),
+    current_setting('tests.storage_other_user_id') || '/concurrency-3.jpg'
+  ),
+  '#2993: concurrency setup 3'
+);
+SELECT lives_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'partner-proofs', %L, 100, 'image/jpeg')$$,
+    current_setting('tests.storage_other_user_id'),
+    current_setting('tests.storage_other_user_id') || '/concurrency-4.jpg'
+  ),
+  '#2993: concurrency setup 4'
+);
+SELECT lives_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'partner-proofs', %L, 100, 'image/jpeg')$$,
+    current_setting('tests.storage_other_user_id'),
+    current_setting('tests.storage_other_user_id') || '/concurrency-5.jpg'
+  ),
+  '#2993: concurrency setup 5'
+);
+
+SELECT throws_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'partner-proofs', %L, 100, 'image/jpeg')$$,
+    current_setting('tests.storage_other_user_id'),
+    current_setting('tests.storage_other_user_id') || '/concurrency-6.jpg'
+  ),
+  'P0001',
+  'storage_upload_concurrency_exceeded',
+  '#2993: reserve enforces max concurrent active uploads'
+);
+
+UPDATE public.storage_upload_bucket_policies
+SET hourly_byte_limit = 150,
+    quota_bytes = 10000
+WHERE bucket_id = 'verification-proofs';
+
+SELECT lives_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'verification-proofs', %L, 100, 'image/jpeg')$$,
+    current_setting('tests.storage_byte_user_id'),
+    current_setting('tests.storage_byte_user_id') || '/byte-1.jpg'
+  ),
+  '#2993: byte-rate setup reserve succeeds'
+);
+
+SELECT throws_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'verification-proofs', %L, 100, 'image/jpeg')$$,
+    current_setting('tests.storage_byte_user_id'),
+    current_setting('tests.storage_byte_user_id') || '/byte-2.jpg'
+  ),
+  'P0001',
+  'storage_upload_byte_rate_exceeded',
+  '#2993: reserve enforces hourly byte-rate'
+);
+
+UPDATE public.storage_upload_bucket_policies
+SET hourly_byte_limit = 10000,
+    quota_bytes = 150
+WHERE bucket_id = 'verification-proofs';
+
+SELECT lives_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'verification-proofs', %L, 100, 'image/jpeg')$$,
+    current_setting('tests.storage_quota_user_id'),
+    current_setting('tests.storage_quota_user_id') || '/quota-1.jpg'
+  ),
+  '#2993: quota setup reserve succeeds'
+);
+
+SELECT throws_ok(
+  format(
+    $$SELECT * FROM public.reserve_storage_upload(%L::uuid, 'verification-proofs', %L, 100, 'image/jpeg')$$,
+    current_setting('tests.storage_quota_user_id'),
+    current_setting('tests.storage_quota_user_id') || '/quota-2.jpg'
+  ),
+  'P0001',
+  'storage_upload_quota_exceeded',
+  '#2993: reserve enforces per-user quota'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## Goal
Closes #2993.

Implement the signed Storage upload path for covered product buckets so clients no longer write directly to `storage.objects` for `verification-proofs`, `partner-proofs`, or `party-assets`.

## Changes
- Added `storage-upload` Edge Function with `presign`, `complete`, and `abort` actions.
- Added Storage bucket hard limits/MIME allowlists, `active_storage_uploads`, reservation/reconcile RPCs, and removal of covered direct INSERT policies.
- Routed Flutter uploads for verification proofs, partner proofs, and party assets through the signed upload flow while keeping bug-report uploads on the existing direct path.
- Changed public `party-assets` uploads to use private `party-assets-pending` staging; `complete` publishes to the public bucket only after DB reconcile passes.
- Added `publish_storage_upload` RPC and hard-fail cleanup handling for rejected uploads when Storage `remove()` fails.
- Serialized `reserve_storage_upload` accounting with a user-scoped transaction advisory lock so concurrency, hourly byte-rate, and quota checks cannot be bypassed by parallel presign calls.
- Tightened string validation in the EF so blank `upload_id`/bucket-style fields are rejected before RPC calls.
- Added focused Flutter repository tests, Edge Function unit tests, pgTAP coverage, and backend architecture docs.
- Documented TUS/resumable upload as deferred for these small image/document flows.

## Verification
- PASS: `flutter test test/src/data/repositories/storage_repository_test.dart` from `shared/packages/minglit_kit`
- PASS: `flutter analyze lib/src/data/repositories/storage_repository.dart test/src/data/repositories/storage_repository_test.dart lib/src/data/repositories/party_repository.dart lib/src/data/repositories/partner_application_repository.dart lib/src/data/repositories/partner_repository.dart` from `shared/packages/minglit_kit`
- PASS: `/tmp/deno-pr3023/bin/deno test --allow-all functions/storage-upload/index_test.ts` from `supabase`
- PASS: `/tmp/deno-pr3023/bin/deno test --allow-all --coverage=cov_profile functions/storage-upload/index_test.ts` from `supabase`
- PASS: `/tmp/diffcover-pr3023/bin/diff-cover supabase/coverage.lcov --compare-branch=mark/dev-staging --fail-under=90 ...` (`storage-upload/index.ts` diff coverage 100%)
- PASS: `/tmp/deno-pr3023/bin/deno test --allow-all --coverage=cov_profile functions/` from `supabase` (1112 passed, 9 ignored)
- PASS: `supabase stop --no-backup` then `supabase start` (fresh local stack with updated migration)
- PASS: `supabase test db supabase/tests/database/00_setup.sql supabase/tests/database/107_storage_signed_upload_pipeline_test.sql`
- PASS: `supabase test db` (124 files, 2254 tests)
- PASS: `python3 -m json.tool supabase/functions/auth-manifest.json`
- PASS: `python3 -m json.tool supabase/functions/storage-upload/deno.json`
- PASS: `git diff --check`

## References
- Supabase signed upload URL: https://supabase.com/docs/reference/javascript/storage-from-createsigneduploadurl
- Supabase upload to signed URL: https://supabase.com/docs/reference/javascript/storage-from-uploadtosignedurl
- Supabase Storage upload restrictions: https://supabase.com/docs/guides/storage/uploads/standard-uploads

## Residual Risk
- Public asset publish now performs an EF-mediated Storage download/upload between private staging and final public bucket. If final publish succeeds but private staging cleanup later fails, the final asset is already safe and the leftover staging object remains private.
- Quota accounting uses current `minglit_files`/`storage.objects` metadata plus active reservations; orphaned Storage objects outside `minglit_files` remain a cleanup/inventory concern.