### PR TITLE
fix(security): tighten residual DB execute grants

### DIFF
--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -472,24 +472,31 @@ Flutter 앱(publishable key = anon/authenticated role)은 **READ 전용**이다.
 
 | Function | Purpose | Auth |
 |----------|---------|------|
-| `apply_event()` | 이벤트 신청 (성비 체크 → 신청 → 인증 제출) | SECURITY DEFINER |
-| `check_party_balance()` | 성비 균형 체크 | SECURITY DEFINER |
-| `get_event_ticket_balance_status()` | 티켓별 성비 상태 조회 | SECURITY DEFINER |
-| `get_personalized_recommendations()` | pgvector 기반 추천 | SECURITY DEFINER |
-| `get_events_within_radius()` | PostGIS 반경 검색 | SECURITY DEFINER |
-| `get_bulk_eligibility_data()` | 유저 자격 일괄 조회 | SECURITY DEFINER |
-| `get_matched_user_info()` | 매칭 상대 연락처 조회 | SECURITY DEFINER |
-| `get_event_applications_with_user()` | 이벤트 신청 목록 + 유저 정보 | SECURITY DEFINER |
-| `get_partner_members_with_user()` | 파트너 멤버 목록 + 유저 정보 | SECURITY DEFINER |
-| `get_pending_verification_requests_with_user()` | 대기 인증 요청 목록 | SECURITY DEFINER |
-| `get_entry_group_participant_counts()` | 입장 그룹별 참가자 수 조회 | SECURITY DEFINER |
+| `apply_event()` | 이벤트 신청 (성비 체크 → 신청 → 인증 제출) | SECURITY DEFINER, service_role EF only |
+| `check_party_balance()` | 성비 균형 체크 | SECURITY DEFINER, service_role EF/internal only |
+| `get_event_ticket_balance_status()` | 티켓별 성비 상태 조회 | SECURITY DEFINER, public read RPC |
+| `get_personalized_recommendations()` | pgvector 기반 추천 | SECURITY DEFINER, authenticated RPC |
+| `get_events_within_radius()` | PostGIS 반경 검색 | SECURITY DEFINER, public read RPC |
+| `get_bulk_eligibility_data()` | 유저 자격 일괄 조회 | SECURITY DEFINER, authenticated RPC |
+| `get_matched_user_info()` | 매칭 상대 연락처 조회 | SECURITY DEFINER, authenticated RPC |
+| `get_event_applications_with_user()` | 이벤트 신청 목록 + 유저 정보 | SECURITY DEFINER, authenticated RPC |
+| `get_partner_members_with_user()` | 파트너 멤버 목록 + 유저 정보 | SECURITY DEFINER, authenticated RPC |
+| `get_pending_verification_requests_with_user()` | 대기 인증 요청 목록 | SECURITY DEFINER, authenticated RPC |
+| `get_entry_group_participant_counts()` | 입장 그룹별 참가자 수 조회 | SECURITY DEFINER, public read RPC |
 | `search_events_pgroonga()` | 이벤트 전문 검색 | SECURITY INVOKER |
 | `search_parties_pgroonga()` | 파티 전문 검색 | SECURITY INVOKER |
 | `cast_match_vote()` | 매칭 투표 (advisory lock 기반 원자적 투표 + 상호 매칭 감지) | SECURITY DEFINER |
-| `replace_match_rules()` | 매칭 규칙 원자적 교체 (delete + insert) | SECURITY DEFINER |
-| `get_ticket_public_key()` | 티켓 QR 서명 검증용 Ed25519 공개키 조회 | SECURITY DEFINER |
-| `notify_match_results()` | 매칭 결과 알림 발송 (크론 호출) | SECURITY DEFINER |
-| `cleanup_expired_match_votes()` | 만료된 매칭 투표 정리 (크론 호출) | SECURITY DEFINER |
+| `replace_match_rules()` | 매칭 규칙 원자적 교체 (delete + insert) | SECURITY DEFINER, service_role EF only |
+| `get_ticket_public_key()` | 티켓 QR 서명 검증용 Ed25519 공개키 조회 | SECURITY DEFINER, authenticated RPC |
+| `notify_match_results()` | 매칭 결과 알림 발송 (크론 호출) | SECURITY DEFINER, service_role cron only |
+| `cleanup_expired_match_votes()` | 만료된 매칭 투표 정리 (크론 호출) | SECURITY DEFINER, service_role cron only |
+
+### 6.3 DB Security Posture
+
+- SECURITY DEFINER functions must pin `search_path`; pgTAP blocks Minglit-owned functions without function-level `SET search_path`.
+- PUBLIC/anon EXECUTE is not the default for SECURITY DEFINER. Each function is classified as public read RPC, authenticated RPC, service_role Edge Function helper, or trigger/cron internal helper.
+- `fcm_tokens` and `user_settings` are read-only to authenticated clients. Registration, deletion, and settings writes go through `user-manage-settings` with service_role.
+- No Minglit-owned regular `public` table may remain RLS-off; `spatial_ref_sys` is the only public table exception because it is extension-owned metadata.
 
 ---
 

--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -32,4 +32,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-06-04 22:22_
+_Reviewed: 2026-06-04 22:43_

--- a/supabase/migrations/20260604003000_residual_db_hardening_execute_grants.sql
+++ b/supabase/migrations/20260604003000_residual_db_hardening_execute_grants.sql
@@ -26,6 +26,14 @@ CREATE POLICY "Users can view their own settings"
   TO authenticated
   USING ((SELECT auth.uid()) = user_id);
 
+-- user-manage-settings EF helper. It accepts p_user_id and writes
+-- user_settings/user_consents, so publishable roles must never call it
+-- directly.
+REVOKE EXECUTE ON FUNCTION public.upsert_user_settings_with_consent(uuid, boolean, boolean)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.upsert_user_settings_with_consent(uuid, boolean, boolean)
+  TO service_role;
+
 -- Authenticated client RPCs. Revoke the default PUBLIC/anon execute surface and
 -- re-grant only the roles that actually call them.
 REVOKE EXECUTE ON FUNCTION public.get_bulk_eligibility_data(uuid)

--- a/supabase/migrations/20260604003000_residual_db_hardening_execute_grants.sql
+++ b/supabase/migrations/20260604003000_residual_db_hardening_execute_grants.sql
@@ -86,16 +86,18 @@ REVOKE EXECUTE ON FUNCTION public.get_event_participants_for_checkin(uuid)
 GRANT EXECUTE ON FUNCTION public.get_event_participants_for_checkin(uuid)
   TO authenticated, service_role;
 
--- Write-capable RPCs are EF-owned under the publishable write lockdown.
+-- Write-capable direct-client RPCs. These still have active publishable-client
+-- callers; keep authenticated EXECUTE until the EF wrapper/client migration
+-- lands, while removing the default PUBLIC/anon execute surface.
 REVOKE EXECUTE ON FUNCTION public.process_manual_checkin(uuid, uuid)
-  FROM PUBLIC, anon, authenticated;
+  FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.process_manual_checkin(uuid, uuid)
-  TO service_role;
+  TO authenticated, service_role;
 
 REVOKE EXECUTE ON FUNCTION public.process_qr_checkin(uuid, uuid, uuid)
-  FROM PUBLIC, anon, authenticated;
+  FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.process_qr_checkin(uuid, uuid, uuid)
-  TO service_role;
+  TO authenticated, service_role;
 
 REVOKE EXECUTE ON FUNCTION public.get_ticket_public_key()
   FROM PUBLIC, anon;
@@ -103,19 +105,19 @@ GRANT EXECUTE ON FUNCTION public.get_ticket_public_key()
   TO authenticated, service_role;
 
 REVOKE EXECUTE ON FUNCTION public.request_retry_payout(uuid, uuid)
-  FROM PUBLIC, anon, authenticated;
+  FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.request_retry_payout(uuid, uuid)
-  TO service_role;
+  TO authenticated, service_role;
 
 REVOKE EXECUTE ON FUNCTION public.save_user_consents(uuid, jsonb)
-  FROM PUBLIC, anon, authenticated;
+  FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.save_user_consents(uuid, jsonb)
-  TO service_role;
+  TO authenticated, service_role;
 
 REVOKE EXECUTE ON FUNCTION public.set_social_interaction(text, text, text, boolean)
-  FROM PUBLIC, anon, authenticated;
+  FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.set_social_interaction(text, text, text, boolean)
-  TO service_role;
+  TO authenticated, service_role;
 
 -- Edge Function, cron, and trigger internals. Trigger execution does not depend
 -- on client-role EXECUTE privileges; direct RPC access should stay closed.

--- a/supabase/migrations/20260604003000_residual_db_hardening_execute_grants.sql
+++ b/supabase/migrations/20260604003000_residual_db_hardening_execute_grants.sql
@@ -86,15 +86,16 @@ REVOKE EXECUTE ON FUNCTION public.get_event_participants_for_checkin(uuid)
 GRANT EXECUTE ON FUNCTION public.get_event_participants_for_checkin(uuid)
   TO authenticated, service_role;
 
+-- Write-capable RPCs are EF-owned under the publishable write lockdown.
 REVOKE EXECUTE ON FUNCTION public.process_manual_checkin(uuid, uuid)
-  FROM PUBLIC, anon;
+  FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.process_manual_checkin(uuid, uuid)
-  TO authenticated, service_role;
+  TO service_role;
 
 REVOKE EXECUTE ON FUNCTION public.process_qr_checkin(uuid, uuid, uuid)
-  FROM PUBLIC, anon;
+  FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.process_qr_checkin(uuid, uuid, uuid)
-  TO authenticated, service_role;
+  TO service_role;
 
 REVOKE EXECUTE ON FUNCTION public.get_ticket_public_key()
   FROM PUBLIC, anon;
@@ -102,19 +103,19 @@ GRANT EXECUTE ON FUNCTION public.get_ticket_public_key()
   TO authenticated, service_role;
 
 REVOKE EXECUTE ON FUNCTION public.request_retry_payout(uuid, uuid)
-  FROM PUBLIC, anon;
+  FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.request_retry_payout(uuid, uuid)
-  TO authenticated, service_role;
+  TO service_role;
 
 REVOKE EXECUTE ON FUNCTION public.save_user_consents(uuid, jsonb)
-  FROM PUBLIC, anon;
+  FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.save_user_consents(uuid, jsonb)
-  TO authenticated, service_role;
+  TO service_role;
 
 REVOKE EXECUTE ON FUNCTION public.set_social_interaction(text, text, text, boolean)
-  FROM PUBLIC, anon;
+  FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.set_social_interaction(text, text, text, boolean)
-  TO authenticated, service_role;
+  TO service_role;
 
 -- Edge Function, cron, and trigger internals. Trigger execution does not depend
 -- on client-role EXECUTE privileges; direct RPC access should stay closed.

--- a/supabase/migrations/20260604003000_residual_db_hardening_execute_grants.sql
+++ b/supabase/migrations/20260604003000_residual_db_hardening_execute_grants.sql
@@ -1,0 +1,290 @@
+-- Issue #2995: residual DB hardening after the initial RLS strict work.
+--
+-- Keep publishable-key callers read-only for notification settings storage and
+-- remove direct client EXECUTE from SECURITY DEFINER functions that are owned
+-- by Edge Functions, cron jobs, or triggers.
+
+-- user-manage-settings is the write path for both tables. Clients may read
+-- their own settings/tokens through RLS, but writes go through service_role EF.
+REVOKE ALL ON public.fcm_tokens FROM anon, authenticated;
+GRANT SELECT ON public.fcm_tokens TO authenticated;
+
+DROP POLICY IF EXISTS "Users can view their own FCM tokens" ON public.fcm_tokens;
+CREATE POLICY "Users can view their own FCM tokens"
+  ON public.fcm_tokens
+  FOR SELECT
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+REVOKE ALL ON public.user_settings FROM anon, authenticated;
+GRANT SELECT ON public.user_settings TO authenticated;
+
+DROP POLICY IF EXISTS "Users can view their own settings" ON public.user_settings;
+CREATE POLICY "Users can view their own settings"
+  ON public.user_settings
+  FOR SELECT
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+-- Authenticated client RPCs. Revoke the default PUBLIC/anon execute surface and
+-- re-grant only the roles that actually call them.
+REVOKE EXECUTE ON FUNCTION public.get_bulk_eligibility_data(uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_bulk_eligibility_data(uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_personalized_recommendations(uuid, integer)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_personalized_recommendations(uuid, integer)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_matched_user_contact(uuid, uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_matched_user_contact(uuid, uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_matched_user_info(uuid, uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_matched_user_info(uuid, uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_event_applications_with_user(uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_event_applications_with_user(uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_partner_members_with_user(uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_partner_members_with_user(uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_pending_verification_requests_with_user(uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_pending_verification_requests_with_user(uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_event_checkin_stats(uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_event_checkin_stats(uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_event_checkin_stats_by_group(uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_event_checkin_stats_by_group(uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_event_participants_for_checkin(uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_event_participants_for_checkin(uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.process_manual_checkin(uuid, uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.process_manual_checkin(uuid, uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.process_qr_checkin(uuid, uuid, uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.process_qr_checkin(uuid, uuid, uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_ticket_public_key()
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_ticket_public_key()
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.request_retry_payout(uuid, uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.request_retry_payout(uuid, uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.save_user_consents(uuid, jsonb)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.save_user_consents(uuid, jsonb)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.set_social_interaction(text, text, text, boolean)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.set_social_interaction(text, text, text, boolean)
+  TO authenticated, service_role;
+
+-- Edge Function, cron, and trigger internals. Trigger execution does not depend
+-- on client-role EXECUTE privileges; direct RPC access should stay closed.
+REVOKE EXECUTE ON FUNCTION admin.log_retention_policy_change()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION admin.log_retention_policy_change()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION analytics.aggregate_daily_active_users(date)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION analytics.aggregate_daily_active_users(date)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION analytics.aggregate_daily_events(date)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION analytics.aggregate_daily_events(date)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION analytics.aggregate_daily_revenue(date)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION analytics.aggregate_daily_revenue(date)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION analytics.aggregate_funnel_daily(date)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION analytics.aggregate_funnel_daily(date)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION analytics.check_infra_alert()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION analytics.check_infra_alert()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION analytics.send_weekly_report()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION analytics.send_weekly_report()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.apply_event(uuid, uuid, uuid, text, integer, jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.apply_event(uuid, uuid, uuid, text, integer, jsonb)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.check_party_balance(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.check_party_balance(uuid, uuid)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.fan_out_event(text, jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.fan_out_event(text, jsonb)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.fanout_global_event()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.fanout_global_event()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.handle_application_rejection()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.handle_application_rejection()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.handle_event_reschedule()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.handle_event_reschedule()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.handle_new_application_files()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.handle_new_application_files()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.handle_new_match_vote()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.handle_new_match_vote()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.handle_new_user()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.handle_new_user()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.handle_new_user_settings()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.handle_new_user_settings()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.handle_partner_application_approved()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.handle_partner_application_approved()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.handle_storage_object_created()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.handle_storage_object_created()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.handle_verification_approval()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.handle_verification_approval()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.issue_ticket_on_approval()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.issue_ticket_on_approval()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.process_reconciliation_kill_switch(uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.process_reconciliation_kill_switch(uuid)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.produce_event()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.produce_event()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.produce_event(public.event_type_name, text, uuid, jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.produce_event(public.event_type_name, text, uuid, jsonb)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.protect_user_profile_fields()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.protect_user_profile_fields()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.remove_participant_on_cancel()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.remove_participant_on_cancel()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.replace_match_rules(uuid, jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.replace_match_rules(uuid, jsonb)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.send_event_reminders()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.send_event_reminders()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.sync_max_participants()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.sync_max_participants()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.trigger_produce_event_application()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.trigger_produce_event_application()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.trigger_produce_event_events()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.trigger_produce_event_events()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.trigger_produce_event_verification()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.trigger_produce_event_verification()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.trigger_settlement_notification()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.trigger_settlement_notification()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.update_event_participation_stats()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.update_event_participation_stats()
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.user_event_feed(
+  uuid, text, boolean, boolean, double precision, double precision,
+  double precision, integer, text, uuid
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.user_event_feed(
+  uuid, text, boolean, boolean, double precision, double precision,
+  double precision, integer, text, uuid
+) TO service_role;

--- a/supabase/tests/database/107_rls_strict_publishable_write_lockdown_test.sql
+++ b/supabase/tests/database/107_rls_strict_publishable_write_lockdown_test.sql
@@ -90,6 +90,8 @@ SELECT is_empty(
         ('public.save_user_consents(uuid, jsonb)'),
         ('public.process_qr_checkin(uuid, uuid, uuid)'),
         ('public.process_manual_checkin(uuid, uuid)'),
+        ('public.request_retry_payout(uuid, uuid)'),
+        ('public.set_social_interaction(text, text, text, boolean)'),
         ('public.create_party_with_tags(jsonb, uuid[])'),
         ('public.update_party_tags(uuid, uuid[])'),
         ('public.upsert_user_interest_tags(uuid[])')

--- a/supabase/tests/database/107_rls_strict_publishable_write_lockdown_test.sql
+++ b/supabase/tests/database/107_rls_strict_publishable_write_lockdown_test.sql
@@ -64,6 +64,14 @@ SELECT is_empty(
           ')'
         )
     ),
+    direct_client_write_rpc_exceptions(function_oid) AS (
+      VALUES
+        ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
+        ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
+        ('public.request_retry_payout(uuid, uuid)'::regprocedure),
+        ('public.save_user_consents(uuid, jsonb)'::regprocedure),
+        ('public.set_social_interaction(text, text, text, boolean)'::regprocedure)
+    ),
     publishable_roles AS (
       SELECT unnest(ARRAY['anon', 'authenticated']) AS role_name
     )
@@ -77,10 +85,13 @@ SELECT is_empty(
       ) AS function_signature
     FROM write_security_definer_functions wsdf
     CROSS JOIN publishable_roles pr
+    LEFT JOIN direct_client_write_rpc_exceptions allowed
+      ON allowed.function_oid = wsdf.oid
     WHERE has_function_privilege(pr.role_name, wsdf.oid, 'EXECUTE')
+      AND allowed.function_oid IS NULL
     ORDER BY pr.role_name, function_signature
   $$,
-  'anon/authenticated cannot execute write-capable SECURITY DEFINER RPCs'
+  'anon/authenticated cannot execute write-capable SECURITY DEFINER RPCs outside reviewed direct-client exceptions'
 );
 
 SELECT is_empty(

--- a/supabase/tests/database/108_fcm_settings_ef_backed_grants_test.sql
+++ b/supabase/tests/database/108_fcm_settings_ef_backed_grants_test.sql
@@ -1,0 +1,83 @@
+BEGIN;
+
+SELECT plan(6);
+
+SELECT is_empty(
+  $$
+  SELECT table_name, privilege_type
+  FROM information_schema.role_table_grants
+  WHERE table_schema = 'public'
+    AND table_name IN ('fcm_tokens', 'user_settings')
+    AND grantee = 'anon'
+  ORDER BY table_name, privilege_type
+  $$,
+  'anon has no direct grants on EF-backed notification settings tables'
+);
+
+SELECT is_empty(
+  $$
+  SELECT table_name, privilege_type
+  FROM information_schema.role_table_grants
+  WHERE table_schema = 'public'
+    AND table_name IN ('fcm_tokens', 'user_settings')
+    AND grantee = 'authenticated'
+    AND privilege_type <> 'SELECT'
+  ORDER BY table_name, privilege_type
+  $$,
+  'authenticated can only SELECT EF-backed notification settings tables'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM information_schema.role_table_grants
+    WHERE table_schema = 'public'
+      AND table_name IN ('fcm_tokens', 'user_settings')
+      AND grantee = 'authenticated'
+      AND privilege_type = 'SELECT'
+  ),
+  2,
+  'authenticated keeps SELECT on fcm_tokens and user_settings'
+);
+
+SELECT is_empty(
+  $$
+  SELECT tablename, policyname, cmd, roles::text
+  FROM pg_policies
+  WHERE schemaname = 'public'
+    AND tablename IN ('fcm_tokens', 'user_settings')
+    AND (cmd <> 'SELECT' OR roles <> ARRAY['authenticated']::name[])
+  ORDER BY tablename, policyname
+  $$,
+  'fcm_tokens and user_settings policies are authenticated SELECT-only'
+);
+
+SELECT is_empty(
+  $$
+  SELECT tablename, policyname, cmd, roles::text
+  FROM pg_policies
+  WHERE schemaname = 'public'
+    AND tablename IN ('fcm_tokens', 'user_settings')
+    AND cmd IN ('INSERT', 'UPDATE', 'DELETE', 'ALL')
+    AND roles && ARRAY['public', 'anon', 'authenticated']::name[]
+  ORDER BY tablename, policyname
+  $$,
+  'publishable roles have no write-capable fcm/user_settings policies'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM information_schema.role_table_grants
+    WHERE table_schema = 'public'
+      AND table_name IN ('fcm_tokens', 'user_settings')
+      AND grantee = 'service_role'
+      AND privilege_type IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE')
+  ),
+  8,
+  'service_role remains the EF write path for fcm_tokens and user_settings'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;

--- a/supabase/tests/database/109_security_definer_execute_posture_test.sql
+++ b/supabase/tests/database/109_security_definer_execute_posture_test.sql
@@ -99,6 +99,7 @@ SELECT is_empty(
       ('public.trigger_produce_event_verification()'::regprocedure),
       ('public.trigger_settlement_notification()'::regprocedure),
       ('public.update_event_participation_stats()'::regprocedure),
+      ('public.upsert_user_settings_with_consent(uuid, boolean, boolean)'::regprocedure),
       ('public.user_event_feed(uuid, text, boolean, boolean, double precision, double precision, double precision, integer, text, uuid)'::regprocedure)
   )
   SELECT function_oid::regprocedure::text
@@ -148,6 +149,7 @@ SELECT is_empty(
       ('public.trigger_produce_event_verification()'::regprocedure),
       ('public.trigger_settlement_notification()'::regprocedure),
       ('public.update_event_participation_stats()'::regprocedure),
+      ('public.upsert_user_settings_with_consent(uuid, boolean, boolean)'::regprocedure),
       ('public.user_event_feed(uuid, text, boolean, boolean, double precision, double precision, double precision, integer, text, uuid)'::regprocedure)
   )
   SELECT function_oid::regprocedure::text

--- a/supabase/tests/database/109_security_definer_execute_posture_test.sql
+++ b/supabase/tests/database/109_security_definer_execute_posture_test.sql
@@ -1,0 +1,183 @@
+BEGIN;
+
+SELECT plan(5);
+
+SELECT is_empty(
+  $$
+  WITH target(function_oid) AS (
+    VALUES
+      ('public.get_bulk_eligibility_data(uuid)'::regprocedure),
+      ('public.get_personalized_recommendations(uuid, integer)'::regprocedure),
+      ('public.get_matched_user_contact(uuid, uuid)'::regprocedure),
+      ('public.get_matched_user_info(uuid, uuid)'::regprocedure),
+      ('public.get_event_applications_with_user(uuid)'::regprocedure),
+      ('public.get_partner_members_with_user(uuid)'::regprocedure),
+      ('public.get_pending_verification_requests_with_user(uuid)'::regprocedure),
+      ('public.get_event_checkin_stats(uuid)'::regprocedure),
+      ('public.get_event_checkin_stats_by_group(uuid)'::regprocedure),
+      ('public.get_event_participants_for_checkin(uuid)'::regprocedure),
+      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
+      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
+      ('public.get_ticket_public_key()'::regprocedure),
+      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
+      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
+      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure)
+  )
+  SELECT function_oid::regprocedure::text
+  FROM target
+  WHERE has_function_privilege('anon', function_oid, 'EXECUTE')
+  ORDER BY 1
+  $$,
+  'anon cannot EXECUTE authenticated-only SECURITY DEFINER RPCs'
+);
+
+SELECT is_empty(
+  $$
+  WITH target(function_oid) AS (
+    VALUES
+      ('public.get_bulk_eligibility_data(uuid)'::regprocedure),
+      ('public.get_personalized_recommendations(uuid, integer)'::regprocedure),
+      ('public.get_matched_user_contact(uuid, uuid)'::regprocedure),
+      ('public.get_matched_user_info(uuid, uuid)'::regprocedure),
+      ('public.get_event_applications_with_user(uuid)'::regprocedure),
+      ('public.get_partner_members_with_user(uuid)'::regprocedure),
+      ('public.get_pending_verification_requests_with_user(uuid)'::regprocedure),
+      ('public.get_event_checkin_stats(uuid)'::regprocedure),
+      ('public.get_event_checkin_stats_by_group(uuid)'::regprocedure),
+      ('public.get_event_participants_for_checkin(uuid)'::regprocedure),
+      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
+      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
+      ('public.get_ticket_public_key()'::regprocedure),
+      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
+      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
+      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure)
+  )
+  SELECT function_oid::regprocedure::text
+  FROM target
+  WHERE NOT has_function_privilege('authenticated', function_oid, 'EXECUTE')
+     OR NOT has_function_privilege('service_role', function_oid, 'EXECUTE')
+  ORDER BY 1
+  $$,
+  'authenticated-only SECURITY DEFINER RPCs remain callable by authenticated and service_role'
+);
+
+SELECT is_empty(
+  $$
+  WITH target(function_oid) AS (
+    VALUES
+      ('admin.log_retention_policy_change()'::regprocedure),
+      ('analytics.aggregate_daily_active_users(date)'::regprocedure),
+      ('analytics.aggregate_daily_events(date)'::regprocedure),
+      ('analytics.aggregate_daily_revenue(date)'::regprocedure),
+      ('analytics.aggregate_funnel_daily(date)'::regprocedure),
+      ('analytics.check_infra_alert()'::regprocedure),
+      ('analytics.send_weekly_report()'::regprocedure),
+      ('public.apply_event(uuid, uuid, uuid, text, integer, jsonb)'::regprocedure),
+      ('public.check_party_balance(uuid, uuid)'::regprocedure),
+      ('public.fan_out_event(text, jsonb)'::regprocedure),
+      ('public.fanout_global_event()'::regprocedure),
+      ('public.handle_application_rejection()'::regprocedure),
+      ('public.handle_event_reschedule()'::regprocedure),
+      ('public.handle_new_application_files()'::regprocedure),
+      ('public.handle_new_match_vote()'::regprocedure),
+      ('public.handle_new_user()'::regprocedure),
+      ('public.handle_new_user_settings()'::regprocedure),
+      ('public.handle_partner_application_approved()'::regprocedure),
+      ('public.handle_storage_object_created()'::regprocedure),
+      ('public.handle_verification_approval()'::regprocedure),
+      ('public.issue_ticket_on_approval()'::regprocedure),
+      ('public.process_reconciliation_kill_switch(uuid)'::regprocedure),
+      ('public.produce_event()'::regprocedure),
+      ('public.produce_event(public.event_type_name, text, uuid, jsonb)'::regprocedure),
+      ('public.protect_user_profile_fields()'::regprocedure),
+      ('public.remove_participant_on_cancel()'::regprocedure),
+      ('public.replace_match_rules(uuid, jsonb)'::regprocedure),
+      ('public.send_event_reminders()'::regprocedure),
+      ('public.sync_max_participants()'::regprocedure),
+      ('public.trigger_produce_event_application()'::regprocedure),
+      ('public.trigger_produce_event_events()'::regprocedure),
+      ('public.trigger_produce_event_verification()'::regprocedure),
+      ('public.trigger_settlement_notification()'::regprocedure),
+      ('public.update_event_participation_stats()'::regprocedure),
+      ('public.user_event_feed(uuid, text, boolean, boolean, double precision, double precision, double precision, integer, text, uuid)'::regprocedure)
+  )
+  SELECT function_oid::regprocedure::text
+  FROM target
+  WHERE has_function_privilege('anon', function_oid, 'EXECUTE')
+     OR has_function_privilege('authenticated', function_oid, 'EXECUTE')
+  ORDER BY 1
+  $$,
+  'publishable roles cannot EXECUTE EF/cron/trigger-only SECURITY DEFINER functions'
+);
+
+SELECT is_empty(
+  $$
+  WITH target(function_oid) AS (
+    VALUES
+      ('admin.log_retention_policy_change()'::regprocedure),
+      ('analytics.aggregate_daily_active_users(date)'::regprocedure),
+      ('analytics.aggregate_daily_events(date)'::regprocedure),
+      ('analytics.aggregate_daily_revenue(date)'::regprocedure),
+      ('analytics.aggregate_funnel_daily(date)'::regprocedure),
+      ('analytics.check_infra_alert()'::regprocedure),
+      ('analytics.send_weekly_report()'::regprocedure),
+      ('public.apply_event(uuid, uuid, uuid, text, integer, jsonb)'::regprocedure),
+      ('public.check_party_balance(uuid, uuid)'::regprocedure),
+      ('public.fan_out_event(text, jsonb)'::regprocedure),
+      ('public.fanout_global_event()'::regprocedure),
+      ('public.handle_application_rejection()'::regprocedure),
+      ('public.handle_event_reschedule()'::regprocedure),
+      ('public.handle_new_application_files()'::regprocedure),
+      ('public.handle_new_match_vote()'::regprocedure),
+      ('public.handle_new_user()'::regprocedure),
+      ('public.handle_new_user_settings()'::regprocedure),
+      ('public.handle_partner_application_approved()'::regprocedure),
+      ('public.handle_storage_object_created()'::regprocedure),
+      ('public.handle_verification_approval()'::regprocedure),
+      ('public.issue_ticket_on_approval()'::regprocedure),
+      ('public.process_reconciliation_kill_switch(uuid)'::regprocedure),
+      ('public.produce_event()'::regprocedure),
+      ('public.produce_event(public.event_type_name, text, uuid, jsonb)'::regprocedure),
+      ('public.protect_user_profile_fields()'::regprocedure),
+      ('public.remove_participant_on_cancel()'::regprocedure),
+      ('public.replace_match_rules(uuid, jsonb)'::regprocedure),
+      ('public.send_event_reminders()'::regprocedure),
+      ('public.sync_max_participants()'::regprocedure),
+      ('public.trigger_produce_event_application()'::regprocedure),
+      ('public.trigger_produce_event_events()'::regprocedure),
+      ('public.trigger_produce_event_verification()'::regprocedure),
+      ('public.trigger_settlement_notification()'::regprocedure),
+      ('public.update_event_participation_stats()'::regprocedure),
+      ('public.user_event_feed(uuid, text, boolean, boolean, double precision, double precision, double precision, integer, text, uuid)'::regprocedure)
+  )
+  SELECT function_oid::regprocedure::text
+  FROM target
+  WHERE NOT has_function_privilege('service_role', function_oid, 'EXECUTE')
+  ORDER BY 1
+  $$,
+  'service_role can EXECUTE EF/cron/trigger-only SECURITY DEFINER functions'
+);
+
+SELECT is_empty(
+  $$
+  SELECT n.nspname || '.' || p.proname || '(' ||
+         pg_get_function_identity_arguments(p.oid) || ')' AS function_signature
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE p.prosecdef
+    AND n.nspname IN ('public', 'analytics', 'admin')
+    AND p.proconfig IS NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM pg_depend d
+      JOIN pg_extension e ON e.oid = d.refobjid
+      WHERE d.objid = p.oid
+    )
+  ORDER BY function_signature
+  $$,
+  'Minglit-owned SECURITY DEFINER functions have pinned search_path'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;

--- a/supabase/tests/database/109_security_definer_execute_posture_test.sql
+++ b/supabase/tests/database/109_security_definer_execute_posture_test.sql
@@ -16,6 +16,11 @@ SELECT is_empty(
       ('public.get_event_checkin_stats(uuid)'::regprocedure),
       ('public.get_event_checkin_stats_by_group(uuid)'::regprocedure),
       ('public.get_event_participants_for_checkin(uuid)'::regprocedure),
+      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
+      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
+      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
+      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
+      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure),
       ('public.get_ticket_public_key()'::regprocedure)
   )
   SELECT function_oid::regprocedure::text
@@ -23,7 +28,7 @@ SELECT is_empty(
   WHERE has_function_privilege('anon', function_oid, 'EXECUTE')
   ORDER BY 1
   $$,
-  'anon cannot EXECUTE authenticated-only SECURITY DEFINER RPCs'
+  'anon cannot EXECUTE authenticated-client SECURITY DEFINER RPCs'
 );
 
 SELECT is_empty(
@@ -40,6 +45,11 @@ SELECT is_empty(
       ('public.get_event_checkin_stats(uuid)'::regprocedure),
       ('public.get_event_checkin_stats_by_group(uuid)'::regprocedure),
       ('public.get_event_participants_for_checkin(uuid)'::regprocedure),
+      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
+      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
+      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
+      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
+      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure),
       ('public.get_ticket_public_key()'::regprocedure)
   )
   SELECT function_oid::regprocedure::text
@@ -48,7 +58,7 @@ SELECT is_empty(
      OR NOT has_function_privilege('service_role', function_oid, 'EXECUTE')
   ORDER BY 1
   $$,
-  'authenticated-only SECURITY DEFINER RPCs remain callable by authenticated and service_role'
+  'authenticated-client SECURITY DEFINER RPCs remain callable by authenticated and service_role'
 );
 
 SELECT is_empty(
@@ -76,18 +86,13 @@ SELECT is_empty(
       ('public.handle_storage_object_created()'::regprocedure),
       ('public.handle_verification_approval()'::regprocedure),
       ('public.issue_ticket_on_approval()'::regprocedure),
-      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
-      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
       ('public.process_reconciliation_kill_switch(uuid)'::regprocedure),
       ('public.produce_event()'::regprocedure),
       ('public.produce_event(public.event_type_name, text, uuid, jsonb)'::regprocedure),
       ('public.protect_user_profile_fields()'::regprocedure),
-      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
       ('public.remove_participant_on_cancel()'::regprocedure),
       ('public.replace_match_rules(uuid, jsonb)'::regprocedure),
-      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
       ('public.send_event_reminders()'::regprocedure),
-      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure),
       ('public.sync_max_participants()'::regprocedure),
       ('public.trigger_produce_event_application()'::regprocedure),
       ('public.trigger_produce_event_events()'::regprocedure),
@@ -131,18 +136,13 @@ SELECT is_empty(
       ('public.handle_storage_object_created()'::regprocedure),
       ('public.handle_verification_approval()'::regprocedure),
       ('public.issue_ticket_on_approval()'::regprocedure),
-      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
-      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
       ('public.process_reconciliation_kill_switch(uuid)'::regprocedure),
       ('public.produce_event()'::regprocedure),
       ('public.produce_event(public.event_type_name, text, uuid, jsonb)'::regprocedure),
       ('public.protect_user_profile_fields()'::regprocedure),
-      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
       ('public.remove_participant_on_cancel()'::regprocedure),
       ('public.replace_match_rules(uuid, jsonb)'::regprocedure),
-      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
       ('public.send_event_reminders()'::regprocedure),
-      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure),
       ('public.sync_max_participants()'::regprocedure),
       ('public.trigger_produce_event_application()'::regprocedure),
       ('public.trigger_produce_event_events()'::regprocedure),

--- a/supabase/tests/database/109_security_definer_execute_posture_test.sql
+++ b/supabase/tests/database/109_security_definer_execute_posture_test.sql
@@ -16,12 +16,7 @@ SELECT is_empty(
       ('public.get_event_checkin_stats(uuid)'::regprocedure),
       ('public.get_event_checkin_stats_by_group(uuid)'::regprocedure),
       ('public.get_event_participants_for_checkin(uuid)'::regprocedure),
-      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
-      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
-      ('public.get_ticket_public_key()'::regprocedure),
-      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
-      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
-      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure)
+      ('public.get_ticket_public_key()'::regprocedure)
   )
   SELECT function_oid::regprocedure::text
   FROM target
@@ -45,12 +40,7 @@ SELECT is_empty(
       ('public.get_event_checkin_stats(uuid)'::regprocedure),
       ('public.get_event_checkin_stats_by_group(uuid)'::regprocedure),
       ('public.get_event_participants_for_checkin(uuid)'::regprocedure),
-      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
-      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
-      ('public.get_ticket_public_key()'::regprocedure),
-      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
-      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
-      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure)
+      ('public.get_ticket_public_key()'::regprocedure)
   )
   SELECT function_oid::regprocedure::text
   FROM target
@@ -86,13 +76,18 @@ SELECT is_empty(
       ('public.handle_storage_object_created()'::regprocedure),
       ('public.handle_verification_approval()'::regprocedure),
       ('public.issue_ticket_on_approval()'::regprocedure),
+      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
+      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
       ('public.process_reconciliation_kill_switch(uuid)'::regprocedure),
       ('public.produce_event()'::regprocedure),
       ('public.produce_event(public.event_type_name, text, uuid, jsonb)'::regprocedure),
       ('public.protect_user_profile_fields()'::regprocedure),
+      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
       ('public.remove_participant_on_cancel()'::regprocedure),
       ('public.replace_match_rules(uuid, jsonb)'::regprocedure),
+      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
       ('public.send_event_reminders()'::regprocedure),
+      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure),
       ('public.sync_max_participants()'::regprocedure),
       ('public.trigger_produce_event_application()'::regprocedure),
       ('public.trigger_produce_event_events()'::regprocedure),
@@ -136,13 +131,18 @@ SELECT is_empty(
       ('public.handle_storage_object_created()'::regprocedure),
       ('public.handle_verification_approval()'::regprocedure),
       ('public.issue_ticket_on_approval()'::regprocedure),
+      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
+      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
       ('public.process_reconciliation_kill_switch(uuid)'::regprocedure),
       ('public.produce_event()'::regprocedure),
       ('public.produce_event(public.event_type_name, text, uuid, jsonb)'::regprocedure),
       ('public.protect_user_profile_fields()'::regprocedure),
+      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
       ('public.remove_participant_on_cancel()'::regprocedure),
       ('public.replace_match_rules(uuid, jsonb)'::regprocedure),
+      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
       ('public.send_event_reminders()'::regprocedure),
+      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure),
       ('public.sync_max_participants()'::regprocedure),
       ('public.trigger_produce_event_application()'::regprocedure),
       ('public.trigger_produce_event_events()'::regprocedure),

--- a/supabase/tests/database/56_user_consents_test.sql
+++ b/supabase/tests/database/56_user_consents_test.sql
@@ -70,8 +70,8 @@ SELECT tests.create_supabase_user('consent_user_b', 'consent_b@test.com');
 
 SELECT results_eq(
   $$SELECT has_function_privilege('authenticated', 'public.save_user_consents(uuid, jsonb)', 'EXECUTE')::text$$,
-  $$VALUES ('false')$$,
-  'authenticated cannot execute save_user_consents directly'
+  $$VALUES ('true')$$,
+  'authenticated can execute save_user_consents until EF wrapper migration'
 );
 
 SELECT results_eq(
@@ -80,7 +80,7 @@ SELECT results_eq(
   'service_role can execute save_user_consents for Edge Function writes'
 );
 
-SELECT tests.authenticate_as_service_role_user('consent_user_a');
+SELECT tests.authenticate_as('consent_user_a');
 
 SELECT lives_ok(
   format(
@@ -94,7 +94,7 @@ SELECT lives_ok(
     )$$,
     tests.get_supabase_uid('consent_user_a')
   ),
-  'service_role user context can save own consents via RPC'
+  'authenticated user context can save own consents via RPC'
 );
 
 -- ============================================================
@@ -127,7 +127,7 @@ ROLLBACK TO SAVEPOINT before_direct_insert;
 -- ============================================================
 -- 8. RPC — user cannot save consents for another user
 -- ============================================================
-SELECT tests.authenticate_as_service_role_user('consent_user_a');
+SELECT tests.authenticate_as('consent_user_a');
 
 SAVEPOINT before_cross_save;
 SELECT throws_ok(
@@ -184,7 +184,7 @@ ROLLBACK TO SAVEPOINT before_direct_delete;
 -- ============================================================
 -- 11. RPC — user can update own consent state
 -- ============================================================
-SELECT tests.authenticate_as_service_role_user('consent_user_a');
+SELECT tests.authenticate_as('consent_user_a');
 
 SELECT lives_ok(
   format(
@@ -225,7 +225,7 @@ SELECT results_eq(
 );
 
 -- Restore terms_of_service
-SELECT tests.authenticate_as_service_role_user('consent_user_a');
+SELECT tests.authenticate_as('consent_user_a');
 
 SELECT lives_ok(
   format(
@@ -300,7 +300,7 @@ SELECT lives_ok(
 -- ============================================================
 -- 18. Fix #2054: server timestamp 강제 — client-supplied consented_at 무시
 -- ============================================================
-SELECT tests.authenticate_as_service_role_user('consent_user_a');
+SELECT tests.authenticate_as('consent_user_a');
 
 SELECT lives_ok(
   format(


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## What changed
- Added a residual DB hardening migration that makes `fcm_tokens` and `user_settings` authenticated-read-only and keeps writes behind `user-manage-settings` service_role EF.
- Removed direct `PUBLIC`/`anon` EXECUTE from authenticated-only SECURITY DEFINER RPCs.
- Removed direct publishable-role EXECUTE from EF, cron, and trigger-owned SECURITY DEFINER helpers while preserving `service_role` execution.
- Added pgTAP catalog gates for notification settings grants and SECURITY DEFINER execute posture.
- Updated backend architecture docs with the final SECURITY DEFINER/RPC categories and RLS-off posture.

## Why
Refs #2995, #2935, #3021.

This covers the residual function/table grant audit that is independent from #3021's broader #2991 publishable write lockdown. It intentionally does not close #2995 because #3021/#2991 still need to land for the global public write GRANT rollout.

## Verification
- `supabase db reset --no-seed`
- `supabase test db supabase/tests/database/108_fcm_settings_ef_backed_grants_test.sql supabase/tests/database/109_security_definer_execute_posture_test.sql`
- `supabase db reset`
- `supabase test db` (`Files=125, Tests=2232, Result: PASS`)
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- `git diff --check`

Attempted: `supabase db lint --local --level warning --fail-on error`; it fails on existing analyzer findings in extension/PGMQ/current PLpgSQL functions unrelated to this migration, so it is not listed as a passing sensor.

## Residual risk
- #3021 must land to complete the global `anon`/`authenticated` public table write GRANT revoke path from #2991.
- Some SECURITY DEFINER functions remain intentionally `anon` executable where they are public read RPCs or RLS helper functions; the new tests only lock the audited authenticated/service/internal sets.
