### PR TITLE
fix(ci): build iOS deploys with iOS 26 SDK

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -11,7 +11,7 @@
 | [`run-partner-cuj.sh`](./run-partner-cuj.sh) | `apps/app_partner/integration_test/cuj/` CUJ 실행. 모든 CUJ 파일을 실행한 뒤 실패 목록 aggregate | `shared-cuj-integration` (app-name=partner 일 때), `monitor-dev-cuj` |
 | [`check-bluedoc-freshness.sh`](./check-bluedoc-freshness.sh) | PR 에서 새/삭제 파일에 대해 가장 가까운 ancestor BLUEDOC.md 갱신 강제. 통과: 이정표 표 갱신 또는 BLUEDOC 의 `_Reviewed_` 날짜 bump. + 모든 BLUEDOC.md 의 Reviewed 형식 검증 | `pr-gate.check-bluedoc-freshness` (required check) |
 | [`check-pr-issue-reference.sh`](./check-pr-issue-reference.sh) | dev-staging PR 본문에 이슈 종료 의도(`Closes/Fixes/Resolves`) 또는 명시적 비종료 사유(`Refs` + 이유 / `No linked issue`)가 있는지 검사 | `pr-gate.static-checks` |
-| [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | iOS deploy 브랜치·timeout·heartbeat·Flutter SPM off 계약 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
+| [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | iOS deploy 브랜치·runner SDK·timeout·heartbeat·Flutter SPM off 계약 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
 | [`check-android-deploy-workflow-contract.py`](./check-android-deploy-workflow-contract.py) | Android deploy release archive token 계약 + merge promotion 뒤 snapshot metadata 탐색 회귀 검증 | `pr-gate.static-checks` |
 | [`check-dev-soak-workflow-contract.py`](./check-dev-soak-workflow-contract.py) | dev event-flow cron install + `monitor-dev-cuj` + `dev-rc-cut-gate` + `shared-soak-gate` 판정 계약 검증 | `pr-gate.static-checks` |
 | [`check-dev-cut-workflow-contract.py`](./check-dev-cut-workflow-contract.py) | promotion cut workflow 의 full-history checkout, merge auto-merge mode, `shared-notify` repo 컨텍스트 계약 검증 | `pr-gate.static-checks` |
@@ -35,4 +35,4 @@
 - [.github/BLUEDOC.md](../BLUEDOC.md) — 상위 진입점
 
 ---
-_Reviewed: 2026-06-03 15:15_
+_Reviewed: 2026-06-04 07:16_

--- a/.github/scripts/check-ios-deploy-branch-conditions.sh
+++ b/.github/scripts/check-ios-deploy-branch-conditions.sh
@@ -83,6 +83,12 @@ timeout_minutes="$( (grep -nE "^[[:space:]]*timeout-minutes:[[:space:]]*[0-9]+" 
   | head -n1 \
   | sed -E 's/.*timeout-minutes:[[:space:]]*([0-9]+).*/\1/')"
 
+if ! grep -nE "^[[:space:]]*runs-on:[[:space:]]*macos-26([[:space:]]*(#.*)?)?$" "$WORKFLOW_FILE" >/dev/null; then
+  echo "ERROR: shared-ios-deploy must run on macos-26 so App Store Connect uploads are built with iOS 26 SDK"
+  grep -nE "^[[:space:]]*runs-on:" "$WORKFLOW_FILE" || true
+  exit 1
+fi
+
 if [[ -z "$timeout_minutes" ]]; then
   echo "ERROR: Could not detect timeout-minutes in $WORKFLOW_FILE"
   exit 1
@@ -124,4 +130,4 @@ for pubspec in "${APP_PUBSPECS[@]}"; do
   assert_flutter_spm_disabled "$pubspec"
 done
 
-echo "OK: iOS deploy workflow contract validated (branch, timeout, heartbeat, exit-code, SPM disabled)"
+echo "OK: iOS deploy workflow contract validated (branch, runner SDK, timeout, heartbeat, exit-code, SPM disabled)"

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -47,6 +47,7 @@
 - `close-cut-issue-on-pr-merge` 는 promotion PR body 의 `minglit:cut-issue-number` marker 를 보고 PR merge 시 해당 cut issue 를 닫는다.
 - `dev-deploy` 는 dev push 후 web + mobile dev 배포를 orchestrate 한다.
 - `main-deploy` 는 main push 후 prod 배포를 orchestrate 한다. version bump commit 없이 deploy-time metadata 를 계산하고 `shared-promo-tag` 로 `promo/main-*` marker 를 만든다.
+- `shared-ios-deploy` 는 App Store Connect 업로드 SDK 요구사항 때문에 `macos-26` runner 에 고정한다. 회귀 검사는 `.github/scripts/check-ios-deploy-branch-conditions.sh` 가 담당한다.
 - `shared-promo-tag` 는 `promo/rc-*`, `promo/main-*` tag 생성의 공통 release-bot 구현이다. Concrete workflow 는 target ref, tag name, commit SHA 만 넘긴다.
 - `deploy-dev-event-flow-cron` 은 `dev` push 에서만 dev Supabase `dev-event-flow-simulator` pg_cron 을 설치한다. `monitor-event-flow-distributed` 는 `--ref dev` 수동 smoke 전용이고, hourly/daily 는 legacy manual smoke 다.
 - `deploy-android-*`, `deploy-ios-*`, `deploy-vercel` 은 branch-level deploy 에서 호출하는 concrete adapter 다. 직접 push/schedule 로 실행하지 않는다.
@@ -77,4 +78,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — branch별 required check / auto-merge 흐름
 
 ---
-_Reviewed: 2026-06-03 15:15_
+_Reviewed: 2026-06-04 07:16_

--- a/.github/workflows/shared-ios-deploy.yml
+++ b/.github/workflows/shared-ios-deploy.yml
@@ -79,7 +79,7 @@ jobs:
 
   ios-deploy:
     needs: [version]
-    runs-on: macos-15  # Fix #2371: connectivity_plus 7.1.1 requires iOS 18 SDK / Xcode 16+.
+    runs-on: macos-26  # App Store Connect upload requires iOS 26 SDK / Xcode 26+.
     timeout-minutes: 120
     environment: ${{ inputs.deploy-stage == 'main' && 'production' || 'preview' }}
     permissions:


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## What
- Move `shared-ios-deploy` from `macos-15` to `macos-26` so iOS deploy jobs build with Xcode/iOS 26 SDK before App Store Connect upload.
- Extend `check-ios-deploy-branch-conditions.sh` to guard the `macos-26` runner contract.
- Refresh the nearby BLUEDOC entries for the runner SDK contract.

## Why
Refs #3017. The latest dev deploy run `26911520211` built both iOS IPAs and published GitHub Release assets, then failed only at App Store Connect upload with `Validation failed (409) SDK version issue`: the IPA was built with iOS 18.5 SDK while App Store Connect requires iOS 26 SDK or later.

This does not close #3017: this PR fixes the deploy workflow source on `dev-staging`, but #3017 should stay open until the change reaches `dev` and a subsequent `dev-deploy` proves both iOS deploy jobs pass.

GitHub-hosted runner references:
- `macos-26` is a supported GitHub-hosted runner label: https://docs.github.com/en/actions/reference/runners/github-hosted-runners
- The `macos-26` image includes Xcode 26.x and iOS 26 SDKs: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md

## Verification
- `bash .github/scripts/check-ios-deploy-branch-conditions.sh`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- `git diff --check HEAD~1..HEAD`

## Residual Risk
- Full IPA upload cannot be reproduced from this Linux worktree. The definitive sensor is the next `dev-deploy` run after promotion to `dev`.
