### PR TITLE
fix(ci): extend CUJ integration timeout

### DIFF
--- a/.github/scripts/check-dev-soak-workflow-contract.py
+++ b/.github/scripts/check-dev-soak-workflow-contract.py
@@ -15,6 +15,7 @@ ROOT = Path(__file__).resolve().parents[2]
 MONITOR_DISTRIBUTED = ROOT / ".github/workflows/monitor-event-flow-distributed.yml"
 MONITOR_DEV_STAGING_HEALTH = ROOT / ".github/workflows/monitor-dev-staging-health.yml"
 MONITOR_DEV_CUJ = ROOT / ".github/workflows/monitor-dev-cuj.yml"
+SHARED_CUJ_INTEGRATION = ROOT / ".github/workflows/shared-cuj-integration.yml"
 DEPLOY_DEV_EVENT_FLOW_CRON = ROOT / ".github/workflows/deploy-dev-event-flow-cron.yml"
 SET_DEV_SOAK_STATUS = ROOT / ".github/workflows/set-dev-soak-status.yml"
 DEV_RC_CUT_GATE = ROOT / ".github/workflows/dev-rc-cut-gate.yml"
@@ -253,6 +254,14 @@ def assert_monitor_dev_cuj_contract() -> None:
 
 
 def assert_cuj_runner_contract() -> None:
+    workflow = load_workflow(SHARED_CUJ_INTEGRATION)
+    jobs = jobs_config(workflow, SHARED_CUJ_INTEGRATION)
+    cuj_job = jobs.get("cuj-integration", {})
+    if not isinstance(cuj_job, dict):
+        fail("shared-cuj-integration must define cuj-integration job")
+    if int(cuj_job.get("timeout-minutes", 0)) < 60:
+        fail("shared-cuj-integration timeout-minutes must be >= 60")
+
     for path in [RUN_USER_CUJ, RUN_PARTNER_CUJ]:
         script = path.read_text(encoding="utf-8")
         required_fragments = [

--- a/.github/workflows/shared-cuj-integration.yml
+++ b/.github/workflows/shared-cuj-integration.yml
@@ -33,7 +33,9 @@ on:
 jobs:
   cuj-integration:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # User CUJ currently runs more files than partner CUJ and each file rebuilds
+    # the dev APK on a cold runner. Keep this above the observed 30m ceiling.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## What
- Increase the reusable `shared-cuj-integration` job timeout from 30 to 60 minutes.
- Extend `check-dev-soak-workflow-contract.py` so the CUJ reusable timeout cannot regress below 60 minutes.

## Why
Refs #3011. The latest `monitor-dev-cuj` run `26911517106` showed `cuj-user / cuj-integration` still running and passing CUJ files until GitHub cancelled the job at the 30 minute reusable workflow timeout. `cuj-partner` passed in the same run, and no user CUJ assertion failure appeared before cancellation.

This does not close #3011: the fix must reach `dev`, then a subsequent `monitor-dev-cuj` run must prove `dev-soak/cuj-user` passes.

## Verification
- `python3 .github/scripts/check-dev-soak-workflow-contract.py`
- `python3 -m py_compile .github/scripts/check-dev-soak-workflow-contract.py`
- `git diff --check origin/dev-staging..HEAD`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`

## Residual Risk
- Full Android emulator CUJ execution was not rerun in this Linux worker session. The definitive sensor is the next `monitor-dev-cuj` run after promotion to `dev`.
