### PR TITLE
security: accept non-applicable leaked password advisor

### DIFF
--- a/.github/BLUEDOC.md
+++ b/.github/BLUEDOC.md
@@ -10,6 +10,7 @@ GitHub 통합 폴더 — CI/CD 워크플로우, composite actions, shell scripts
 | [`actions/`](./actions/BLUEDOC.md) | 워크플로우가 `uses:` 로 호출하는 composite actions (deploy-flutter-app, deploy-nextjs-app, ios-deploy) |
 | [`scripts/`](./scripts/BLUEDOC.md) | 워크플로우가 `bash` 로 실행하는 shell 헬퍼 (env 파일 생성, CUJ 실행 등) |
 | [`dependabot.yml`](./dependabot.yml) | dependabot 의존성 자동 업데이트 설정 (npm + GitHub Actions 그룹화, weekly) |
+| [`advisor-accepted-findings.json`](./advisor-accepted-findings.json) | monitor-security-advisor 가 이슈화하지 않을 Supabase advisor accepted finding 목록 |
 | [`release.yml`](./release.yml) | GitHub Release notes 자동 생성 카테고리 (Features/Bug Fixes/Refactor/Docs) |
 
 ## 핵심 컨벤션
@@ -24,4 +25,4 @@ GitHub 통합 폴더 — CI/CD 워크플로우, composite actions, shell scripts
 - [BLUEDOC 컨벤션](../docs/infra/bluedoc/BLUEDOC.md)
 
 ---
-_Reviewed: 2026-05-23 16:18_
+_Reviewed: 2026-06-04 19:37_

--- a/.github/advisor-accepted-findings.json
+++ b/.github/advisor-accepted-findings.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "auth_leaked_password_protection",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 2756,
+    "reason": "Minglit production auth does not support email/password signup or login. Password-backed accounts are limited to dev/test seed and simulator flows, so Supabase Auth leaked-password protection is not an applicable production control."
+  }
+]

--- a/.github/workflows/monitor-security-advisor.yml
+++ b/.github/workflows/monitor-security-advisor.yml
@@ -34,6 +34,9 @@ jobs:
       matrix:
         type: [security, performance]
     steps:
+      - name: Run actions/checkout@v6
+        uses: actions/checkout@v6
+
       - name: Resolve target environment
         id: env
         run: |
@@ -52,6 +55,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           PROJECT_ID: ${{ steps.env.outputs.PROJECT_ID }}
           TYPE: ${{ matrix.type }}
+          ENV: ${{ steps.env.outputs.ENV }}
         run: |
           if [ -z "$PROJECT_ID" ]; then
             echo "::error::PROJECT_ID is empty — register SUPABASE_${{ steps.env.outputs.ENV == 'main' && 'MAIN' || 'DEV' }}_PROJECT_ID"
@@ -102,15 +106,54 @@ jobs:
             elif .data? then .data
             else [] end
           ')
-          ERRORS=$(echo "$ITEMS" | jq '[.[] | select((.level // .severity // "" | ascii_upcase) == "ERROR")] | length')
-          WARNS=$(echo "$ITEMS" | jq '[.[] | select((.level // .severity // "" | ascii_upcase) == "WARN")] | length')
-          TOTAL=$(echo "$ITEMS" | jq 'length')
+          ACCEPTED_FILE=".github/advisor-accepted-findings.json"
+          if [ -f "$ACCEPTED_FILE" ]; then
+            ACCEPTED_ITEMS=$(echo "$ITEMS" | jq -c \
+              --slurpfile accepted "$ACCEPTED_FILE" \
+              --arg type "$TYPE" \
+              --arg env "$ENV" '
+              def finding_name: (.name // .title // .code // "");
+              def accepted:
+                . as $finding
+                | any($accepted[0][]; . as $rule
+                    | ($rule.type == null or $rule.type == $type)
+                    and (($rule.envs // ["dev", "main"]) | index($env))
+                    and ($rule.name == ($finding | finding_name)));
+              [ .[] | select(accepted) ]
+            ')
+            UNSUPPRESSED_ITEMS=$(echo "$ITEMS" | jq -c \
+              --slurpfile accepted "$ACCEPTED_FILE" \
+              --arg type "$TYPE" \
+              --arg env "$ENV" '
+              def finding_name: (.name // .title // .code // "");
+              def accepted:
+                . as $finding
+                | any($accepted[0][]; . as $rule
+                    | ($rule.type == null or $rule.type == $type)
+                    and (($rule.envs // ["dev", "main"]) | index($env))
+                    and ($rule.name == ($finding | finding_name)));
+              [ .[] | select(accepted | not) ]
+            ')
+          else
+            ACCEPTED_ITEMS="[]"
+            UNSUPPRESSED_ITEMS="$ITEMS"
+          fi
+          echo "$ACCEPTED_ITEMS" > "advisor-${TYPE}-accepted.json"
+          echo "$UNSUPPRESSED_ITEMS" > "advisor-${TYPE}-unsuppressed.json"
+
+          ERRORS=$(echo "$UNSUPPRESSED_ITEMS" | jq '[.[] | select((.level // .severity // "" | ascii_upcase) == "ERROR")] | length')
+          WARNS=$(echo "$UNSUPPRESSED_ITEMS" | jq '[.[] | select((.level // .severity // "" | ascii_upcase) == "WARN")] | length')
+          TOTAL=$(echo "$UNSUPPRESSED_ITEMS" | jq 'length')
+          RAW_TOTAL=$(echo "$ITEMS" | jq 'length')
+          ACCEPTED=$(echo "$ACCEPTED_ITEMS" | jq 'length')
 
           echo "type=${TYPE}" >> "$GITHUB_OUTPUT"
           echo "errors=$ERRORS" >> "$GITHUB_OUTPUT"
           echo "warns=$WARNS" >> "$GITHUB_OUTPUT"
           echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
-          echo "::notice::advisor=${TYPE} total=$TOTAL errors=$ERRORS warns=$WARNS"
+          echo "raw_total=$RAW_TOTAL" >> "$GITHUB_OUTPUT"
+          echo "accepted=$ACCEPTED" >> "$GITHUB_OUTPUT"
+          echo "::notice::advisor=${TYPE} raw_total=$RAW_TOTAL accepted=$ACCEPTED unsuppressed=$TOTAL errors=$ERRORS warns=$WARNS"
 
       - name: Create or update GitHub Issue on findings
         if: steps.advisor.outputs.errors != '0' || steps.advisor.outputs.warns != '0'
@@ -121,6 +164,8 @@ jobs:
           ERRORS: ${{ steps.advisor.outputs.errors }}
           WARNS: ${{ steps.advisor.outputs.warns }}
           TOTAL: ${{ steps.advisor.outputs.total }}
+          RAW_TOTAL: ${{ steps.advisor.outputs.raw_total }}
+          ACCEPTED: ${{ steps.advisor.outputs.accepted }}
         run: |
           TITLE="[advisor-audit/${TYPE}] ${ENV} — ${ERRORS} ERROR / ${WARNS} WARN"
 
@@ -130,7 +175,7 @@ jobs:
             elif .lints? then .lints
             elif .data? then .data
             else [] end
-          ' "advisor-${TYPE}.json")
+          ' "advisor-${TYPE}-unsuppressed.json")
 
           TABLE=$(echo "$ITEMS" | jq -r '
             [.[]
@@ -151,7 +196,9 @@ jobs:
 
           - **ERROR**: ${ERRORS}
           - **WARN**: ${WARNS}
-          - **Total findings**: ${TOTAL}
+          - **Unsuppressed findings**: ${TOTAL}
+          - **Accepted findings suppressed**: ${ACCEPTED}
+          - **Raw findings**: ${RAW_TOTAL}
           - **Workflow**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
           | Level | Name | Categories | Description |
@@ -194,7 +241,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: advisor-${{ matrix.type }}-${{ steps.env.outputs.ENV }}
-          path: advisor-${{ matrix.type }}.json
+          path: |
+            advisor-${{ matrix.type }}.json
+            advisor-${{ matrix.type }}-accepted.json
+            advisor-${{ matrix.type }}-unsuppressed.json
           retention-days: 30
           if-no-files-found: ignore
 

--- a/docs/operations/security-advisor.md
+++ b/docs/operations/security-advisor.md
@@ -1,0 +1,44 @@
+# Supabase Security Advisor
+
+Minglit runs `.github/workflows/monitor-security-advisor.yml` against Supabase
+Management API advisor endpoints and opens issues for unsuppressed security or
+performance findings.
+
+## Accepted Findings
+
+Accepted advisor findings are tracked in
+`.github/advisor-accepted-findings.json`. This is a repo-side suppression list;
+Supabase's public docs describe advisor/password-security controls, but do not
+document a source-controlled advisor finding dismiss/suppress API.
+
+Each accepted finding must include:
+
+| Field | Meaning |
+|---|---|
+| `name` | Advisor finding name from Supabase, for example `auth_leaked_password_protection`. |
+| `type` | `security` or `performance`. |
+| `envs` | Environments where the finding is accepted. |
+| `issue` | GitHub issue that records the decision. |
+| `reason` | Short operational rationale. |
+
+## Password Auth Posture
+
+Minglit production auth does not support email/password signup or login.
+Password-backed users are limited to dev/test seed users and simulator flows.
+
+Supabase's leaked password protection checks password values through the
+HaveIBeenPwned Pwned Passwords API and is available on Pro Plan and above. That
+control is not applicable to the production auth model while password auth
+remains unsupported.
+
+The `auth_leaked_password_protection` advisor finding is therefore accepted for
+`dev` and `main` under #2756. If production password auth is introduced later,
+remove that accepted finding, enable leaked-password protection in Supabase Auth
+settings, and verify the advisor finding disappears.
+
+## References
+
+- Supabase password security:
+  https://supabase.com/docs/guides/auth/password-security
+- Supabase Management API reference:
+  https://supabase.com/docs/reference/api/introduction


### PR DESCRIPTION
## Summary
- Add repo-side accepted advisor finding allowlist for `auth_leaked_password_protection` in dev/main.
- Filter accepted Supabase advisor findings before issue creation while preserving raw/accepted/unsuppressed artifacts.
- Document the password-auth posture: production email/password auth is unsupported; password-backed accounts are dev/test seed and simulator only.

## Official Docs Check
- Supabase password security docs describe leaked password protection as an Auth settings control using HaveIBeenPwned Pwned Passwords API and note it is available on Pro Plan and above: https://supabase.com/docs/guides/auth/password-security
- Supabase Management API docs are used by the monitor for advisor retrieval, but no source-controlled advisor finding dismiss/suppress API is documented there: https://supabase.com/docs/reference/api/introduction

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/monitor-security-advisor.yml"); puts "yaml ok"'`
- jq sample: `auth_leaked_password_protection` only => `accepted=1 unsuppressed=0`; mixed finding sample preserves the non-accepted warning.

Closes #2756