### PR TITLE
ci(cuj): batch emulator test files

### DIFF
--- a/.github/scripts/check-dev-soak-workflow-contract.py
+++ b/.github/scripts/check-dev-soak-workflow-contract.py
@@ -266,15 +266,24 @@ def assert_cuj_runner_contract() -> None:
         script = path.read_text(encoding="utf-8")
         required_fragments = [
             "DART_DEFINE_FILE=\"${MINGLIT_CUJ_DART_DEFINE_FILE:-",
-            "failed=0",
-            "failures=()",
-            "if ! flutter test",
-            "failures+=(\"$f\")",
-            "printf ' - %s\\n' \"${failures[@]}\"",
+            "cuj_files=()",
+            "cuj_files+=(\"$f\")",
+            '"${#cuj_files[@]}" -eq 0',
+            "Running ${#cuj_files[@]} CUJ files in one Flutter test invocation",
+            "printf ' - %s\\n' \"${cuj_files[@]}\"",
+            "flutter test \"${cuj_files[@]}\"",
+            "--no-pub",
         ]
         for fragment in required_fragments:
             if fragment not in script:
-                fail(f"{path.name} must aggregate CUJ failures; missing fragment: {fragment}")
+                fail(f"{path.name} must batch CUJ files in one flutter test invocation; missing fragment: {fragment}")
+        forbidden_fragments = [
+            'flutter test "$f"',
+            "failures+=(\"$f\")",
+        ]
+        for fragment in forbidden_fragments:
+            if fragment in script:
+                fail(f"{path.name} must not run flutter test once per CUJ file; found fragment: {fragment}")
 
 
 def assert_dev_rc_cut_gate_contract() -> None:

--- a/.github/scripts/run-partner-cuj.sh
+++ b/.github/scripts/run-partner-cuj.sh
@@ -12,28 +12,21 @@ if [ ! -d "$CUJ_DIR" ]; then
   exit 0
 fi
 
-found=0
-failed=0
-failures=()
+cuj_files=()
 while IFS= read -r f; do
   [ -f "$f" ] || continue
-  found=1
-  echo "▶ Running: $f"
-  if ! flutter test "$f" \
-    --flavor dev \
-    --dart-define-from-file="$DART_DEFINE_FILE"; then
-    failed=1
-    failures+=("$f")
-    echo "❌ Failed: $f"
-  fi
+  cuj_files+=("$f")
 done < <(find "$CUJ_DIR" -name "*_test.dart" -not -path "*/_engine/*" | sort)
 
-if [ "$found" -eq 0 ]; then
+if [ "${#cuj_files[@]}" -eq 0 ]; then
   echo "⏭ No CUJ tests found in $CUJ_DIR, skipping."
+  exit 0
 fi
 
-if [ "$failed" -ne 0 ]; then
-  echo "❌ CUJ failures:"
-  printf ' - %s\n' "${failures[@]}"
-  exit 1
-fi
+echo "▶ Running ${#cuj_files[@]} CUJ files in one Flutter test invocation:"
+printf ' - %s\n' "${cuj_files[@]}"
+
+flutter test "${cuj_files[@]}" \
+  --flavor dev \
+  --dart-define-from-file="$DART_DEFINE_FILE" \
+  --no-pub

--- a/.github/scripts/run-user-cuj.sh
+++ b/.github/scripts/run-user-cuj.sh
@@ -12,28 +12,21 @@ if [ ! -d "$CUJ_DIR" ]; then
   exit 0
 fi
 
-found=0
-failed=0
-failures=()
+cuj_files=()
 while IFS= read -r f; do
   [ -f "$f" ] || continue
-  found=1
-  echo "▶ Running: $f"
-  if ! flutter test "$f" \
-    --flavor dev \
-    --dart-define-from-file="$DART_DEFINE_FILE"; then
-    failed=1
-    failures+=("$f")
-    echo "❌ Failed: $f"
-  fi
+  cuj_files+=("$f")
 done < <(find "$CUJ_DIR" -name "*_test.dart" -not -path "*/_engine/*" | sort)
 
-if [ "$found" -eq 0 ]; then
+if [ "${#cuj_files[@]}" -eq 0 ]; then
   echo "⏭ No CUJ tests found in $CUJ_DIR, skipping."
+  exit 0
 fi
 
-if [ "$failed" -ne 0 ]; then
-  echo "❌ CUJ failures:"
-  printf ' - %s\n' "${failures[@]}"
-  exit 1
-fi
+echo "▶ Running ${#cuj_files[@]} CUJ files in one Flutter test invocation:"
+printf ' - %s\n' "${cuj_files[@]}"
+
+flutter test "${cuj_files[@]}" \
+  --flavor dev \
+  --dart-define-from-file="$DART_DEFINE_FILE" \
+  --no-pub


### PR DESCRIPTION
## Summary

- Run each app CUJ suite through one `flutter test` invocation instead of one invocation per CUJ file.
- Keep `_engine` excluded and log the exact CUJ file list before execution.
- Update the dev-soak workflow contract check so the runner cannot regress to per-file Flutter builds.

## Why

The latest `monitor-dev-cuj` logs showed every CUJ file rebuilding and reinstalling the dev APK. User CUJ has 15 files, so the repeated ~55s Gradle assemble cost pushed the job into the 30m timeout before all files completed.

## Verification

- `bash -n .github/scripts/run-user-cuj.sh .github/scripts/run-partner-cuj.sh`
- `python3 .github/scripts/check-dev-soak-workflow-contract.py`
- `python3 -m py_compile .github/scripts/check-dev-soak-workflow-contract.py`
- `git diff --check`
- fake `flutter` dry-run confirmed one invocation for 15 user CUJ files and one invocation for 9 partner CUJ files

Note: `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh` is blocked locally by existing `.claude/worktrees/.../BLUEDOC.md` format issues outside this PR.

No linked issue: CUJ runtime optimization requested during release workflow triage; this should not close the active CUJ signal issue.