### PR TITLE
ci: deploy dev Vercel apps from prebuilt Next builds

### DIFF
--- a/.github/actions/BLUEDOC.md
+++ b/.github/actions/BLUEDOC.md
@@ -8,7 +8,7 @@
 |--------|------|
 | [cut-issue](./cut-issue/action.yml) | cut-gate tracking issue 생성/갱신/닫기 공통 action. `needs-swe` 같은 추가 label 적용 지원 |
 | [deploy-flutter-app](./deploy-flutter-app/action.yml) | Flutter app deploy 공통 action |
-| [deploy-nextjs-app](./deploy-nextjs-app/action.yml) | Next.js app deploy 공통 action |
+| [deploy-nextjs-app](./deploy-nextjs-app/action.yml) | Next.js GitHub build + Vercel prebuilt deploy 공통 action |
 | [ios-deploy](./ios-deploy/action.yml) | iOS deploy 공통 action |
 | [release-bot-token](./release-bot-token/action.yml) | `minglit_env/{stage}/github.env` 우선 로드 + `minglit-release-bot` GitHub App installation token mint |
 

--- a/.github/actions/deploy-nextjs-app/action.yml
+++ b/.github/actions/deploy-nextjs-app/action.yml
@@ -79,13 +79,13 @@ runs:
         fi
 
         if [[ "${{ inputs.deploy-branch }}" == "main" ]]; then
-          npx --yes vercel@latest build --prod --token=$VERCEL_TOKEN
+          npx --yes vercel@latest build --prod --token=$VERCEL_TOKEN --yes
           npx --yes vercel@latest deploy --prebuilt --prod --archive=tgz --token=$VERCEL_TOKEN --yes
           # Fix #389: output the production alias URL for smoke test
           echo "accessible-url=https://${{ inputs.dev-domain-alias }}" >> "$GITHUB_OUTPUT"
         else
           # Fix #372: capture preview URL and assign domain alias so dev.*.minglit.com stays reachable
-          npx --yes vercel@latest build --token=$VERCEL_TOKEN
+          npx --yes vercel@latest build --token=$VERCEL_TOKEN --yes
           DEPLOY_URL=$(npx --yes vercel@latest deploy --prebuilt --archive=tgz --token=$VERCEL_TOKEN --yes)
           echo "✅ Deployed to: $DEPLOY_URL"
           ALIAS_OK=false

--- a/.github/actions/deploy-nextjs-app/action.yml
+++ b/.github/actions/deploy-nextjs-app/action.yml
@@ -16,6 +16,19 @@ inputs:
   deploy-branch:
     description: 'Branch name to determine prod vs preview deployment'
     required: true
+  require-supabase-env:
+    description: 'Require NEXT_PUBLIC_SUPABASE_* values before building.'
+    required: false
+    default: 'false'
+  next-public-supabase-url:
+    description: 'Build-time NEXT_PUBLIC_SUPABASE_URL value.'
+    required: false
+  next-public-supabase-publishable-key:
+    description: 'Build-time NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY value.'
+    required: false
+  next-public-statsig-client-key:
+    description: 'Optional build-time NEXT_PUBLIC_STATSIG_CLIENT_KEY value.'
+    required: false
 
 outputs:
   accessible-url:
@@ -42,14 +55,38 @@ runs:
         VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
         VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
         VERCEL_TOKEN: ${{ inputs.vercel-token }}
+        NEXT_PUBLIC_SUPABASE_URL: ${{ inputs.next-public-supabase-url }}
+        NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ inputs.next-public-supabase-publishable-key }}
+        NEXT_PUBLIC_STATSIG_CLIENT_KEY: ${{ inputs.next-public-statsig-client-key }}
+        REQUIRE_SUPABASE_ENV: ${{ inputs.require-supabase-env }}
       run: |
+        set -euo pipefail
+
+        if [[ "$REQUIRE_SUPABASE_ENV" == "true" ]]; then
+          : "${NEXT_PUBLIC_SUPABASE_URL:?NEXT_PUBLIC_SUPABASE_URL is required}"
+          : "${NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY:?NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY is required}"
+        fi
+
+        mkdir -p .vercel
+        cat > .vercel/project.json <<JSON
+        {"orgId":"${VERCEL_ORG_ID}","projectId":"${VERCEL_PROJECT_ID}"}
+        JSON
+
+        if [ -f package-lock.json ]; then
+          npm ci
+        else
+          npm install
+        fi
+
         if [[ "${{ inputs.deploy-branch }}" == "main" ]]; then
-          npx --yes vercel@latest deploy --prod --token=$VERCEL_TOKEN --yes
+          npx --yes vercel@latest build --prod --token=$VERCEL_TOKEN
+          npx --yes vercel@latest deploy --prebuilt --prod --archive=tgz --token=$VERCEL_TOKEN --yes
           # Fix #389: output the production alias URL for smoke test
           echo "accessible-url=https://${{ inputs.dev-domain-alias }}" >> "$GITHUB_OUTPUT"
         else
           # Fix #372: capture preview URL and assign domain alias so dev.*.minglit.com stays reachable
-          DEPLOY_URL=$(npx --yes vercel@latest deploy --token=$VERCEL_TOKEN --yes)
+          npx --yes vercel@latest build --token=$VERCEL_TOKEN
+          DEPLOY_URL=$(npx --yes vercel@latest deploy --prebuilt --archive=tgz --token=$VERCEL_TOKEN --yes)
           echo "✅ Deployed to: $DEPLOY_URL"
           ALIAS_OK=false
           if [[ -n "${{ inputs.dev-domain-alias }}" ]]; then

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -81,4 +81,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — branch별 required check / auto-merge 흐름
 
 ---
-_Reviewed: 2026-06-09 01:42_
+_Reviewed: 2026-06-09 01:53_

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -13,7 +13,7 @@
 | `pr-gate-` | **머지 못 함** (required check — static PR 메시지 검사 + Gitleaks 시크릿 검사 포함) | `pr-gate.yml`, `pr-gate-fresh-doc.yml` |
 | `pr-setup-` | PR push 마다 PR 브랜치를 mutate 하는 자동화 (포맷 등) | (현재 없음 — `pr-setup-format` 은 #2627 에서 `pr-gate-format-check` 잡으로 대체) |
 | `pr-review-setup-` | PR 의 "리뷰 준비" 자동화 — auto-merge enable + 조건 충족 시 `needs-review` 라벨 부여 | `pr-review-setup` |
-| `deploy-` | 사용자·dev 환경에 코드·스키마·시드가 안 갔음 | `dev-deploy`, `main-deploy`, `deploy-vercel`, `deploy-supabase`, `deploy-dev-event-flow-cron`, `deploy-android-user`, `deploy-ios-user`, `deploy-dev-seed` |
+| `deploy-` | 사용자·dev 환경에 코드·스키마·시드가 안 갔음 | `dev-deploy`, `main-deploy`, `deploy-vercel-apps`, `deploy-vercel`, `deploy-supabase`, `deploy-dev-event-flow-cron`, `deploy-android-user`, `deploy-ios-user`, `deploy-dev-seed` |
 | `monitor-` | 운영·테스트 시스템 헬스 이상 / 스케줄 유지보수 | `monitor-dev-staging-health`, `monitor-dev-cuj`, `monitor-db-invariants`, `monitor-event-flow-distributed`, `monitor-event-flow-hourly`, `monitor-event-flow-daily`, `monitor-mds-render-coverage`, `monitor-patrol-e2e`, `monitor-allure`, `monitor-build-retention`, `monitor-security-advisor`, `monitor-doc-freshness` |
 | `sync-` | repo 에 자동 commit/push 가 실패함 (dev-staging push 또는 merge 기반) | `sync-graphify`, `sync-mds-mockups`, `sync-mds-render-snapshot`, `sync-pr-branches`, `sync-test-coverage` |
 | `set-` | GitHub status/metadata 를 쓰는 수동·자동 API entrypoint 실패 | `set-dev-soak-status`, `set-rc-soak-status` |
@@ -52,6 +52,7 @@
 - `shared-ios-deploy` 는 App Store Connect 업로드 SDK 요구사항 때문에 `macos-26` runner 에 고정한다. 회귀 검사는 `.github/scripts/check-ios-deploy-branch-conditions.sh` 가 담당한다.
 - `shared-promo-tag` 는 `promo/rc-*`, `promo/main-*` tag 생성의 공통 release-bot 구현이다. Concrete workflow 는 target ref, tag name, commit SHA 만 넘긴다.
 - `deploy-dev-event-flow-cron` 은 `dev` push 에서만 dev Supabase `dev-event-flow-simulator` pg_cron 을 설치한다. `monitor-event-flow-distributed` 는 `--ref dev` 수동 smoke 전용이고, hourly/daily 는 legacy manual smoke 다.
+- `deploy-vercel-apps` 는 dev web apps(MDS docs, user landing, partner landing) 를 GitHub build + Vercel prebuilt deploy 로 배포한다.
 - `deploy-android-*`, `deploy-ios-*`, `deploy-vercel` 은 branch-level deploy 에서 호출하는 concrete adapter 다. 직접 push/schedule 로 실행하지 않는다.
 - 실제 build/upload/notify 로직은 각각 `shared-android-deploy`, `shared-ios-deploy`, `shared-vercel-deploy` 에 둔다.
 - 모바일 배포 산출물(APK/AAB/IPA)은 GitHub Release asset 으로 보관한다. Actions artifact 는 테스트/디버깅 산출물용이며, deploy archive 의 source-of-truth 로 쓰지 않는다.

--- a/.github/workflows/deploy-vercel-apps.yml
+++ b/.github/workflows/deploy-vercel-apps.yml
@@ -1,0 +1,150 @@
+name: deploy-vercel-apps
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-vercel-apps-dev
+  cancel-in-progress: true
+
+jobs:
+  deploy_mds_docs:
+    uses: ./.github/workflows/shared-vercel-deploy.yml
+    with:
+      app-type: nextjs
+      working-directory: ./apps/mds/docs
+      dev-domain-alias: dev.mds.minglit.com
+      deploy-branch: dev
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_MDS_DOCS_PROJECT_ID }}
+
+  deploy_landing_user:
+    uses: ./.github/workflows/shared-vercel-deploy.yml
+    with:
+      app-type: nextjs
+      working-directory: ./apps/landing_user
+      dev-domain-alias: dev.minglit.com
+      deploy-branch: dev
+      require-nextjs-supabase-env: true
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING_USER }}
+      SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
+      SUPABASE_DEV_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+      STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
+
+  deploy_landing_partner:
+    uses: ./.github/workflows/shared-vercel-deploy.yml
+    with:
+      app-type: nextjs
+      working-directory: ./apps/landing_partner
+      dev-domain-alias: dev.partner.minglit.com
+      deploy-branch: dev
+      require-nextjs-supabase-env: true
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING_PARTNER }}
+      SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
+      SUPABASE_DEV_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+      STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
+
+  smoke_test:
+    needs: [deploy_mds_docs, deploy_landing_user, deploy_landing_partner]
+    if: success()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Checkout minglit_env
+        uses: ./.github/actions/release-bot-token
+        with:
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Load Vercel bypass tokens
+        id: bypass
+        run: |
+          set -euo pipefail
+
+          write_bypass() {
+            local output_name="$1"
+            local key="$2"
+            local value
+            value="$(awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' minglit_env/dev/supabase.env)"
+            if [ -n "$value" ]; then
+              echo "::add-mask::$value"
+            fi
+            echo "${output_name}=${value}" >> "$GITHUB_OUTPUT"
+          }
+
+          write_bypass mds_docs VERCEL_BYPASS_MDS_DOCS
+          write_bypass landing_user VERCEL_BYPASS_LANDING_USER
+          write_bypass landing_partner VERCEL_BYPASS_LANDING_PARTNER
+
+      - name: Smoke test dev Vercel app aliases
+        env:
+          MDS_URL: ${{ needs.deploy_mds_docs.outputs.accessible-url }}
+          LANDING_USER_URL: ${{ needs.deploy_landing_user.outputs.accessible-url }}
+          LANDING_PARTNER_URL: ${{ needs.deploy_landing_partner.outputs.accessible-url }}
+          BYPASS_MDS_DOCS: ${{ steps.bypass.outputs.mds_docs }}
+          BYPASS_LANDING_USER: ${{ steps.bypass.outputs.landing_user }}
+          BYPASS_LANDING_PARTNER: ${{ steps.bypass.outputs.landing_partner }}
+        run: |
+          set -euo pipefail
+
+          check_url() {
+            local label="$1"
+            local url="$2"
+            local bypass="$3"
+            local status
+
+            printf "Checking %s (%s) ... " "$label" "$url"
+            if [ -n "$bypass" ]; then
+              status=$(curl -sL -o /dev/null -w "%{http_code}" \
+                -H "x-vercel-protection-bypass: $bypass" \
+                --max-time 15 "$url") || status="000"
+            else
+              status=$(curl -sL -o /dev/null -w "%{http_code}" \
+                --max-time 15 "$url") || status="000"
+            fi
+
+            if [ "$status" = "200" ]; then
+              echo "OK ($status)"
+              return 0
+            fi
+
+            echo "FAILED ($status)"
+            return 1
+          }
+
+          failed=0
+          check_url "mds-docs" "$MDS_URL" "$BYPASS_MDS_DOCS" || failed=1
+          check_url "landing-user" "$LANDING_USER_URL" "$BYPASS_LANDING_USER" || failed=1
+          check_url "landing-partner" "$LANDING_PARTNER_URL" "$BYPASS_LANDING_PARTNER" || failed=1
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::One or more dev Vercel app aliases failed smoke test"
+            exit 1
+          fi
+
+  notify_failure:
+    needs: [deploy_mds_docs, deploy_landing_user, deploy_landing_partner, smoke_test]
+    if: always()
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      statuses: write
+    uses: ./.github/workflows/shared-notify.yml
+    with:
+      failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      workflow_name: 'Vercel Apps Deploy'
+      severity: 'P1-high'
+      job_results: '{"mds-docs":"${{ needs.deploy_mds_docs.result }}","landing-user":"${{ needs.deploy_landing_user.result }}","landing-partner":"${{ needs.deploy_landing_partner.result }}","smoke":"${{ needs.smoke_test.result }}"}'

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -52,10 +52,16 @@ jobs:
       working-directory: ./apps/landing_user
       dev-domain-alias: dev.minglit.com
       deploy-branch: ${{ inputs.deploy_branch || github.ref_name }}
+      require-nextjs-supabase-env: true
     secrets:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING_USER }}
+      SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
+      SUPABASE_DEV_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+      SUPABASE_MAIN_URL: ${{ secrets.SUPABASE_MAIN_URL }}
+      SUPABASE_MAIN_KEY: ${{ secrets.SUPABASE_MAIN_PUBLISHABLE_KEY }}
+      STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
 
   deploy-landing_partner:
     uses: ./.github/workflows/shared-vercel-deploy.yml
@@ -64,10 +70,16 @@ jobs:
       working-directory: ./apps/landing_partner
       dev-domain-alias: dev.partner.minglit.com
       deploy-branch: ${{ inputs.deploy_branch || github.ref_name }}
+      require-nextjs-supabase-env: true
     secrets:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING_PARTNER }}
+      SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
+      SUPABASE_DEV_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+      SUPABASE_MAIN_URL: ${{ secrets.SUPABASE_MAIN_URL }}
+      SUPABASE_MAIN_KEY: ${{ secrets.SUPABASE_MAIN_PUBLISHABLE_KEY }}
+      STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
 
   deploy-app_partner:
     uses: ./.github/workflows/shared-vercel-deploy.yml

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -28,16 +28,14 @@ jobs:
             echo "|---|---|"
             echo "| dry_run | ${{ inputs.dry_run || false }} |"
             echo "| target_ref | dev |"
-            echo "| web | deploy-vercel(dev) |"
+            echo "| web | deploy-vercel-apps(dev: mds, landing-user, landing-partner) |"
             echo "| mobile | frozen (web MVP pivot; deploy-android-*/deploy-ios-* not called) |"
           } >> "$GITHUB_STEP_SUMMARY"
 
   web:
     needs: [plan]
     if: inputs.dry_run != true
-    uses: ./.github/workflows/deploy-vercel.yml
-    with:
-      deploy_branch: dev
+    uses: ./.github/workflows/deploy-vercel-apps.yml
     secrets: inherit
 
   # Mobile (android/ios) deploy jobs removed: Flutter mobile apps are frozen

--- a/.github/workflows/shared-vercel-deploy.yml
+++ b/.github/workflows/shared-vercel-deploy.yml
@@ -94,9 +94,9 @@ jobs:
           SENTRY_DSN_FLUTTER: ${{ secrets.SENTRY_DSN_FLUTTER }}
           STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
 
-      - name: Deploy Next.js app
-        if: ${{ inputs.app-type == 'nextjs' }}
-        id: deploy_nextjs
+      - name: Deploy Next.js app (preview)
+        if: ${{ inputs.app-type == 'nextjs' && inputs.deploy-branch != 'main' }}
+        id: deploy_nextjs_preview
         uses: ./.github/actions/deploy-nextjs-app
         with:
           working-directory: ${{ inputs.working-directory }}
@@ -106,8 +106,24 @@ jobs:
           dev-domain-alias: ${{ inputs.dev-domain-alias }}
           deploy-branch: ${{ inputs.deploy-branch }}
           require-supabase-env: ${{ inputs.require-nextjs-supabase-env && 'true' || 'false' }}
-          next-public-supabase-url: ${{ inputs.deploy-branch == 'main' && secrets.SUPABASE_MAIN_URL || secrets.SUPABASE_DEV_URL }}
-          next-public-supabase-publishable-key: ${{ inputs.deploy-branch == 'main' && secrets.SUPABASE_MAIN_KEY || secrets.SUPABASE_DEV_KEY }}
+          next-public-supabase-url: ${{ secrets.SUPABASE_DEV_URL }}
+          next-public-supabase-publishable-key: ${{ secrets.SUPABASE_DEV_KEY }}
+          next-public-statsig-client-key: ${{ secrets.STATSIG_CLIENT_KEY }}
+
+      - name: Deploy Next.js app (production)
+        if: ${{ inputs.app-type == 'nextjs' && inputs.deploy-branch == 'main' }}
+        id: deploy_nextjs_production
+        uses: ./.github/actions/deploy-nextjs-app
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          dev-domain-alias: ${{ inputs.dev-domain-alias }}
+          deploy-branch: ${{ inputs.deploy-branch }}
+          require-supabase-env: ${{ inputs.require-nextjs-supabase-env && 'true' || 'false' }}
+          next-public-supabase-url: ${{ secrets.SUPABASE_MAIN_URL }}
+          next-public-supabase-publishable-key: ${{ secrets.SUPABASE_MAIN_KEY }}
           next-public-statsig-client-key: ${{ secrets.STATSIG_CLIENT_KEY }}
 
       - name: Export accessible URL
@@ -115,6 +131,8 @@ jobs:
         run: |
           if [ "${{ inputs.app-type }}" = "flutter" ]; then
             echo "accessible-url=${{ steps.deploy_flutter.outputs.accessible-url }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.deploy-branch }}" = "main" ]; then
+            echo "accessible-url=${{ steps.deploy_nextjs_production.outputs.accessible-url }}" >> "$GITHUB_OUTPUT"
           else
-            echo "accessible-url=${{ steps.deploy_nextjs.outputs.accessible-url }}" >> "$GITHUB_OUTPUT"
+            echo "accessible-url=${{ steps.deploy_nextjs_preview.outputs.accessible-url }}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/shared-vercel-deploy.yml
+++ b/.github/workflows/shared-vercel-deploy.yml
@@ -19,6 +19,11 @@ on:
         description: 'Branch name to deploy.'
         required: true
         type: string
+      require-nextjs-supabase-env:
+        description: 'Require NEXT_PUBLIC_SUPABASE_* when deploying a Next.js app.'
+        required: false
+        default: false
+        type: boolean
     outputs:
       accessible-url:
         description: 'URL that passed connectivity fallback selection.'
@@ -100,6 +105,10 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           dev-domain-alias: ${{ inputs.dev-domain-alias }}
           deploy-branch: ${{ inputs.deploy-branch }}
+          require-supabase-env: ${{ inputs.require-nextjs-supabase-env && 'true' || 'false' }}
+          next-public-supabase-url: ${{ inputs.deploy-branch == 'main' && secrets.SUPABASE_MAIN_URL || secrets.SUPABASE_DEV_URL }}
+          next-public-supabase-publishable-key: ${{ inputs.deploy-branch == 'main' && secrets.SUPABASE_MAIN_KEY || secrets.SUPABASE_DEV_KEY }}
+          next-public-statsig-client-key: ${{ secrets.STATSIG_CLIENT_KEY }}
 
       - name: Export accessible URL
         id: deploy


### PR DESCRIPTION
## Summary
- Add `deploy-vercel-apps` for dev-only Vercel app orchestration: MDS docs, user landing, partner landing.
- Build Next.js apps on GitHub Actions with `vercel build`, then deploy via `vercel deploy --prebuilt --archive=tgz`.
- Update `dev-deploy` to call the new dev web app deploy workflow.
- Pass GitHub/Supabase public env into Next.js build time and load Vercel bypass tokens from `minglit_env` for smoke tests.
- Update the `minglit_env` submodule pointer to include `VERCEL_BYPASS_MDS_DOCS`.

## Verification
- `git diff --check`
- YAML parse for `.github/workflows/*.yml` and `.github/actions/*/action.yml`
- `python3 .github/scripts/check-dev-soak-workflow-contract.py`
- `python3 .github/scripts/check-dev-cut-workflow-contract.py`
- `bash .github/scripts/check-ios-deploy-branch-conditions.sh`

No linked issue: dev Vercel deployment workflow refactor requested in chat.