### PR TITLE
fix(payment): allow system refund trigger auth

### DIFF
--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -32,4 +32,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-06-04 20:55_
+_Reviewed: 2026-06-04 21:32_

--- a/supabase/functions/architecture.md
+++ b/supabase/functions/architecture.md
@@ -43,6 +43,20 @@ Postgres RPC owns atomic writes for inventory, application/order creation,
 payment verification, approval, refund, settlement, and other state transitions
 that must not partially succeed.
 
+## Route Naming
+
+Function route names are stable public API. New user- or partner-specific
+routes should prefer an actor prefix (`user-*`, `partner-*`) when the actor is
+part of the contract. System workers may use domain nouns such as
+`notification-worker`, and external callbacks may use domain suffixes such as
+`payment-webhook`.
+
+Existing unprefixed domain routes remain canonical unless a versioned alias and
+manifest deprecation plan are added in the same rollout. This includes
+`payment-verify`, `payment-cancel`, `event-checkin`, `apply-event`,
+`commit-match-likes`, and `recurrence-rules`. Every manifest entry must have a
+matching `supabase/config.toml` section before deploy.
+
 ## Extraction Signals
 
 - Two or more request fields with validation rules: add `input.ts`.

--- a/supabase/functions/auth-manifest.json
+++ b/supabase/functions/auth-manifest.json
@@ -227,9 +227,9 @@
       "description": "반복 이벤트 규칙 생성/수정/일시정지/재개/취소"
     },
     "payment-cancel": {
-      "callers": ["user"],
+      "callers": ["user", "system"],
       "envs": ["dev", "production"],
-      "description": "결제 취소 및 환불 처리"
+      "description": "결제 취소 및 환불 처리 (user 직접 요청 + DB rejection trigger)"
     },
     "identity-verify": {
       "callers": ["user"],

--- a/supabase/functions/payment-cancel/index.ts
+++ b/supabase/functions/payment-cancel/index.ts
@@ -1,11 +1,11 @@
 // Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 // Fix #2185 (Batch 7): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
-import { nowISO } from "../_shared/temporal_utils.ts";
 import {
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
+import { nowISO } from "../_shared/temporal_utils.ts";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
 import { log } from "../_shared/logger.ts";
 // Fix #299: 환불 로직을 shared 모듈로 추출 — user-cancel-order와 공유
@@ -17,10 +17,14 @@ import {
 
 const FN = "payment-cancel";
 
-export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
   const { supabase } = ctx;
-  if (ctx.auth.type !== "user") return errorResponse("Unexpected auth type", 500);
-  const userId = ctx.auth.userId;
+  if (ctx.auth.type !== "user" && ctx.auth.type !== "system") {
+    return errorResponse("Unexpected auth type", 500);
+  }
 
   try {
     // 1. Parse Request
@@ -40,7 +44,7 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
     // 1.5a Fetch application for eligibility check
     const { data: application, error: appError } = await supabase
       .from("event_applications")
-      .select("paid_at, event_id, refund_status, user_id")
+      .select("paid_at, event_id, refund_status, user_id, status")
       .eq("payment_id", payment_id)
       .single();
 
@@ -48,16 +52,35 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
       return errorResponse("Application not found", 404);
     }
 
-    // Fix #133: 호출자가 신청자 본인인지 검증 — service role은 RLS를 우회하므로 명시적 확인 필요
-    if (application.user_id !== userId) {
-      return errorResponse("Forbidden", 403);
-    }
+    if (ctx.auth.type === "user") {
+      // Fix #133: 호출자가 신청자 본인인지 검증 — service role은 RLS를 우회하므로 명시적 확인 필요
+      if (application.user_id !== ctx.auth.userId) {
+        return errorResponse("Forbidden", 403);
+      }
 
-    // 1.5b Prevent double refund
-    if (application.refund_status !== "none") {
-      return errorResponse("already_refunded", 400, {
-        reason: "Refund already processed",
-      });
+      // 1.5b Prevent double refund for direct user calls.
+      if (application.refund_status !== "none") {
+        return errorResponse("already_refunded", 400, {
+          reason: "Refund already processed",
+        });
+      }
+    } else {
+      // DB-trigger automatic refunds are system-only and only valid after partner rejection.
+      // The trigger sets refund_status=requested before the async pg_net call lands.
+      if (application.status !== "rejected") {
+        return errorResponse(
+          "system_refund_requires_rejected_application",
+          403,
+        );
+      }
+      if (
+        application.refund_status !== "none" &&
+        application.refund_status !== "requested"
+      ) {
+        return errorResponse("already_refunded", 400, {
+          reason: "Refund already processed",
+        });
+      }
     }
 
     // 1.5c Verify refund eligibility against policy

--- a/supabase/functions/payment-cancel/index.ts
+++ b/supabase/functions/payment-cancel/index.ts
@@ -83,49 +83,51 @@ export const handler = async (
       }
     }
 
-    // 1.5c Verify refund eligibility against policy
-    const [eventResult, policyResult] = await Promise.all([
-      supabase
-        .from("events")
-        .select("start_time")
-        .eq("id", application.event_id)
-        .single(),
-      supabase.rpc("get_current_policy", { p_key: "refund" }),
-    ]);
+    if (ctx.auth.type === "user") {
+      // 1.5c Verify direct user cancellations against the refund policy.
+      const [eventResult, policyResult] = await Promise.all([
+        supabase
+          .from("events")
+          .select("start_time")
+          .eq("id", application.event_id)
+          .single(),
+        supabase.rpc("get_current_policy", { p_key: "refund" }),
+      ]);
 
-    // Fix #133: 이벤트/정책 조회 실패 시 적격성 검사를 건너뛰지 않고 명시적으로 에러 반환
-    if (eventResult.error || !eventResult.data) {
-      log({
-        function: FN,
-        level: "error",
-        message: "Failed to fetch event",
-        metadata: { detail: eventResult.error },
+      // Fix #133: 이벤트/정책 조회 실패 시 적격성 검사를 건너뛰지 않고 명시적으로 에러 반환
+      if (eventResult.error || !eventResult.data) {
+        log({
+          function: FN,
+          level: "error",
+          message: "Failed to fetch event",
+          metadata: { detail: eventResult.error },
+        });
+        return errorResponse("Failed to verify refund eligibility", 500);
+      }
+
+      if (policyResult.error || !policyResult.data) {
+        log({
+          function: FN,
+          level: "error",
+          message: "Failed to fetch policy",
+          metadata: { detail: policyResult.error },
+        });
+        return errorResponse("Failed to verify refund eligibility", 500);
+      }
+
+      // Fix #299: 환불 적격성 검증을 shared 모듈로 위임
+      const policy = parseRefundPolicy(policyResult.data);
+      const eligibility = verifyRefundEligibility({
+        paidAt: application.paid_at as string | null,
+        eventStartTime: eventResult.data.start_time,
+        ...policy,
       });
-      return errorResponse("Failed to verify refund eligibility", 500);
-    }
 
-    if (policyResult.error || !policyResult.data) {
-      log({
-        function: FN,
-        level: "error",
-        message: "Failed to fetch policy",
-        metadata: { detail: policyResult.error },
-      });
-      return errorResponse("Failed to verify refund eligibility", 500);
-    }
-
-    // Fix #299: 환불 적격성 검증을 shared 모듈로 위임
-    const policy = parseRefundPolicy(policyResult.data);
-    const eligibility = verifyRefundEligibility({
-      paidAt: application.paid_at as string | null,
-      eventStartTime: eventResult.data.start_time,
-      ...policy,
-    });
-
-    if (!eligibility.eligible) {
-      return errorResponse("refund_not_eligible", 400, {
-        reason: eligibility.reason,
-      });
+      if (!eligibility.eligible) {
+        return errorResponse("refund_not_eligible", 400, {
+          reason: eligibility.reason,
+        });
+      }
     }
 
     // Fix #299: PortOne 환불 실행을 shared 모듈로 위임

--- a/supabase/functions/payment-cancel/index_test.ts
+++ b/supabase/functions/payment-cancel/index_test.ts
@@ -78,6 +78,18 @@ function makeApp(
 
 // ── Test cases ────────────────────────────────────────────────────────────────
 
+Deno.test("payment-cancel :: unexpected auth type → 500", async () => {
+  const handler = await getHandler();
+  const sb = fakeSupabase({ strict: false });
+  const res = await runHandler(handler, {
+    body: { payment_id: "imp_123" },
+    ctx: makeCtx({ supabase: sb, auth: { type: "public" } }),
+  });
+  assertEquals(res.status, 500);
+  const body = await readJson<{ error: string }>(res);
+  assertEquals(body.error, "Unexpected auth type");
+});
+
 // 1. Missing payment_id → 400
 Deno.test("payment-cancel :: missing payment_id → 400", async () => {
   const handler = await getHandler();
@@ -140,6 +152,30 @@ Deno.test("payment-cancel :: system caller requires rejected application → 403
   assertEquals(res.status, 403);
   const body = await readJson<{ error: string }>(res);
   assertEquals(body.error, "system_refund_requires_rejected_application");
+});
+
+Deno.test("payment-cancel :: system caller already refunded → 400", async () => {
+  const handler = await getHandler();
+  const sb = fakeSupabase().on("event_applications", "select", {
+    data: makeApp({
+      status: "rejected",
+      refund_status: "completed",
+      user_id: "other-user",
+    }),
+  });
+  const res = await runHandler(handler, {
+    body: { payment_id: "imp_123" },
+    ctx: makeCtx({
+      supabase: sb,
+      auth: { type: "system", keyFormat: "secret" },
+    }),
+  });
+  assertEquals(res.status, 400);
+  const body = await readJson<{ error: string; details?: { reason?: string } }>(
+    res,
+  );
+  assertEquals(body.error, "already_refunded");
+  assertEquals(body.details?.reason, "Refund already processed");
 });
 
 // 4. Already refunded (refund_status ≠ "none") → 400

--- a/supabase/functions/payment-cancel/index_test.ts
+++ b/supabase/functions/payment-cancel/index_test.ts
@@ -70,6 +70,7 @@ function makeApp(
     paid_at: ELIGIBLE_PAID_AT,
     event_id: "ev-1",
     refund_status: "none",
+    status: "paid",
     user_id: "u-1",
     ...overrides,
   };
@@ -118,6 +119,27 @@ Deno.test("payment-cancel :: wrong user → 403", async () => {
   assertEquals(res.status, 403);
   const body = await readJson<{ error: string }>(res);
   assertEquals(body.error, "Forbidden");
+});
+
+Deno.test("payment-cancel :: system caller requires rejected application → 403", async () => {
+  const handler = await getHandler();
+  const sb = fakeSupabase().on("event_applications", "select", {
+    data: makeApp({
+      status: "paid",
+      refund_status: "requested",
+      user_id: "other-user",
+    }),
+  });
+  const res = await runHandler(handler, {
+    body: { payment_id: "imp_123" },
+    ctx: makeCtx({
+      supabase: sb,
+      auth: { type: "system", keyFormat: "secret" },
+    }),
+  });
+  assertEquals(res.status, 403);
+  const body = await readJson<{ error: string }>(res);
+  assertEquals(body.error, "system_refund_requires_rejected_application");
 });
 
 // 4. Already refunded (refund_status ≠ "none") → 400
@@ -275,6 +297,47 @@ Deno.test("payment-cancel :: happy path (within grace) → 200 + refund_status=c
       assertEquals(typeof patch.refunded_at, "string");
       // Fix #2099: refund_amount set from PortOne response when not passed
       assertEquals(patch.refund_amount, 15000);
+    });
+  });
+});
+
+Deno.test("payment-cancel :: system rejected requested refund → 200", async () => {
+  const handler = await getHandler();
+  const sb = fakeSupabase()
+    .on("event_applications", "select", {
+      data: makeApp({
+        status: "rejected",
+        refund_status: "requested",
+        user_id: "other-user",
+      }),
+    })
+    .on("events", "select", { data: { start_time: FAR_FUTURE_EVENT } })
+    .on("get_current_policy", "rpc", {
+      data: { grace_period_hours: 2, cutoff_days: 7 },
+    })
+    .on("event_applications", "update", { error: null });
+
+  const { fetchMock } = createFetchMock([
+    portoneTokenRoute,
+    portoneCancelRoute,
+  ]);
+
+  await withEnv(PORTONE_ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      const res = await runHandler(handler, {
+        body: { payment_id: "imp_123", reason: "partner rejected" },
+        ctx: makeCtx({
+          supabase: sb,
+          auth: { type: "system", keyFormat: "secret" },
+        }),
+      });
+      assertEquals(res.status, 200);
+      const body = await readJson<{ success: boolean }>(res);
+      assertEquals(body.success, true);
+
+      const [updateCall] = sb.callsFor("event_applications", "update");
+      const patch = updateCall.payload as Record<string, unknown>;
+      assertEquals(patch.refund_status, "completed");
     });
   });
 });

--- a/supabase/functions/payment-cancel/index_test.ts
+++ b/supabase/functions/payment-cancel/index_test.ts
@@ -378,6 +378,42 @@ Deno.test("payment-cancel :: system rejected requested refund → 200", async ()
   });
 });
 
+Deno.test("payment-cancel :: system rejection bypasses user refund windows → 200", async () => {
+  const handler = await getHandler();
+  const sb = fakeSupabase()
+    .on("event_applications", "select", {
+      data: makeApp({
+        paid_at: INELIGIBLE_PAID_AT,
+        status: "rejected",
+        refund_status: "requested",
+        user_id: "other-user",
+      }),
+    })
+    .on("event_applications", "update", { error: null });
+
+  const { fetchMock } = createFetchMock([
+    portoneTokenRoute,
+    portoneCancelRoute,
+  ]);
+
+  await withEnv(PORTONE_ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      const res = await runHandler(handler, {
+        body: { payment_id: "imp_123", reason: "partner rejected" },
+        ctx: makeCtx({
+          supabase: sb,
+          auth: { type: "system", keyFormat: "secret" },
+        }),
+      });
+      assertEquals(res.status, 200);
+      const body = await readJson<{ success: boolean }>(res);
+      assertEquals(body.success, true);
+      assertEquals(sb.callsFor("events", "select").length, 0);
+      assertEquals(sb.callsFor("get_current_policy", "rpc").length, 0);
+    });
+  });
+});
+
 // 11. Happy path — paidAt null but within cutoff → 200
 Deno.test("payment-cancel :: paidAt=null + within cutoff → 200", async () => {
   const handler = await getHandler();

--- a/supabase/migrations/20260604114933_payment_cancel_system_trigger_auth.sql
+++ b/supabase/migrations/20260604114933_payment_cancel_system_trigger_auth.sql
@@ -1,0 +1,59 @@
+-- Fix #2981: payment-cancel automatic refund trigger must call the EF as a
+-- system caller. The old definition used publishable_key as Bearer auth, which
+-- cannot satisfy the minglitEdgeFunction user/system manifest policy.
+
+CREATE OR REPLACE FUNCTION public.handle_application_rejection()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, net
+AS $$
+DECLARE
+  v_payment_id text;
+  v_reason text;
+  v_project_url text;
+  v_service_role_key text;
+BEGIN
+  IF new.status = 'rejected' AND (old.status IS DISTINCT FROM 'rejected') THEN
+    v_payment_id := new.payment_id;
+    v_reason := new.rejection_reason;
+
+    IF v_payment_id IS NOT NULL THEN
+      -- Persist the requested state even if Vault or the EF call is unavailable.
+      new.refund_status := 'requested';
+
+      SELECT decrypted_secret INTO v_project_url
+      FROM vault.decrypted_secrets
+      WHERE name = 'supabase_url' LIMIT 1;
+
+      SELECT decrypted_secret INTO v_service_role_key
+      FROM vault.decrypted_secrets
+      WHERE name = 'service_role_key' LIMIT 1;
+
+      IF v_project_url IS NULL OR v_service_role_key IS NULL THEN
+        RAISE WARNING 'handle_application_rejection: vault secret missing (supabase_url=%, service_role_key=%)',
+          v_project_url IS NOT NULL, v_service_role_key IS NOT NULL;
+        RETURN new;
+      END IF;
+
+      PERFORM net.http_post(
+        url := v_project_url || '/functions/v1/payment-cancel',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'apikey', v_service_role_key,
+          'Authorization', 'Bearer ' || v_service_role_key
+        ),
+        body := jsonb_build_object(
+          'payment_id', v_payment_id,
+          'reason', COALESCE(v_reason, '심사 반려로 인한 자동 환불'),
+          'source', 'application_rejection_trigger'
+        )
+      );
+    END IF;
+  END IF;
+  RETURN new;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'handle_application_rejection failed: [%] %', SQLSTATE, SQLERRM;
+  RETURN new;
+END;
+$$;


### PR DESCRIPTION
## Summary

- Fix #2981 by allowing `payment-cancel` to accept explicit `system` callers for DB-triggered automatic refunds.
- Add a migration that updates `handle_application_rejection()` to call `payment-cancel` with the same service-role `apikey`/Bearer compatibility pattern used by system cron callers.
- Keep direct user refunds guarded by `application.user_id`, and restrict system-triggered refunds to rejected applications with `refund_status` `none` or `requested`.
- Resolve #2979 by documenting EF route naming policy: new actor-specific routes should prefer `user-*`/`partner-*`, while existing unprefixed domain routes remain canonical unless a deprecation/alias rollout is added.

Closes #2981
Closes #2979

## Verification

- `deno fmt --check supabase/functions/payment-cancel/index.ts supabase/functions/payment-cancel/index_test.ts supabase/functions/auth-manifest.json`
- `deno test --config supabase/functions/deno.json --allow-env --allow-net --allow-read supabase/functions/payment-cancel/index_test.ts`
- `deno test --config supabase/functions/deno.json --allow-env --allow-net --allow-read supabase/functions/_shared/edge_function_system_auth_test.ts`
- Manifest/config consistency check: all 55 manifest functions have `supabase/config.toml` sections.
- `git diff --check`

## Not Run

- `supabase migration list --local` could not connect because local Postgres on `127.0.0.1:54322` is not running.