### PR TITLE
docs(mds): define application tab surface ownership

### DIFF
--- a/apps/mds/docs/BLUEDOC.md
+++ b/apps/mds/docs/BLUEDOC.md
@@ -47,4 +47,4 @@ npm run tokens:sync && npm run icons:sync && npm run icons:sync-data
 - [`../../../scripts/mds_render_coverage.dart`](../../../scripts/mds_render_coverage.dart) — MDS spec ↔ emulator render coverage
 
 ---
-_Reviewed: 2026-06-03 12:18_
+_Reviewed: 2026-06-04 21:20_

--- a/apps/mds/docs/public/specs/BLUEDOC.md
+++ b/apps/mds/docs/public/specs/BLUEDOC.md
@@ -40,4 +40,4 @@ MDS 화면 spec 의 **source HTML + 자동 산출물 디렉터리**. Flutter 화
 - [`../../src/lib/flow-data.ts`](../../src/lib/flow-data.ts) — route/spec 매핑
 
 ---
-_Reviewed: 2026-06-04 20:50_
+_Reviewed: 2026-06-04 21:20_

--- a/apps/mds/docs/public/specs/event_application_detail_page/index.html
+++ b/apps/mds/docs/public/specs/event_application_detail_page/index.html
@@ -351,7 +351,7 @@ body.dark-mode .viewport {
       <tr>
         <th>Hierarchy</th>
         <td>
-          <strong>Parent</strong>: <a href="/specs/event_application_manage_page/index.html"><code>EventApplicationManagePage</code></a> (탭 목록에서 행 탭으로 진입)<br>
+          <strong>Parent</strong>: <a href="/specs/event_application_manage_page/index.html"><code>EventApplicationManagePage</code></a> (top-level 승인됨/거절됨/결제완료 이력 row) 또는 <a href="/specs/event_application_list_page/index.html"><code>EventApplicationListPage</code></a> (단일 이벤트 처리 완료 row)<br>
           <strong>Children</strong>: <em>— (거절 사유 다이얼로그는 state 5로 이 spec 안에서 다룸)</em>
         </td>
       </tr>
@@ -365,7 +365,7 @@ body.dark-mode .viewport {
       <tr>
         <th>User journey</th>
         <td>
-          <strong>Entry points</strong>: <a href="/specs/event_application_manage_page/index.html">신청 관리</a>의 "승인됨"/"거절됨" 탭에서 신청 행 탭.<br>
+          <strong>Entry points</strong>: <a href="/specs/event_application_manage_page/index.html">신청관리</a>의 "승인됨"/"거절됨" 탭에서 신청 행 탭, 또는 <a href="/specs/event_application_list_page/index.html">단일 이벤트 참가 현황</a>의 처리 완료 카드 탭.<br>
           <strong>Exit points</strong>: 승인/거절 처리 성공 → "처리가 완료되었습니다." 안내와 함께 자동으로 목록으로 복귀. 뒤로 가기 → 신청 목록. 처리 실패 시 에러 다이얼로그 (화면은 유지).
         </td>
       </tr>
@@ -398,6 +398,12 @@ body.dark-mode .viewport {
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td>2026-06-04</td>
+        <td>1.1</td>
+        <td>codex</td>
+        <td>#3000: parent/entry relation을 top-level cross-event <code>EventApplicationManagePage</code>와 단일 이벤트 <code>EventApplicationListPage</code> 양쪽에서 진입 가능한 read-only detail로 정리.</td>
+      </tr>
       <tr>
         <td>2026-05-01</td>
         <td>1.0</td>
@@ -1223,7 +1229,11 @@ body.dark-mode .viewport {
       <tbody>
         <tr>
           <td><a href="/specs/event_application_manage_page/index.html"><code>EventApplicationManagePage</code></a></td>
-          <td>부모 화면. "승인됨" / "거절됨" 탭의 신청 행 탭으로 이 detail 진입 (Fix #1860).</td>
+          <td>Top-level cross-event 신청관리 owner. "승인됨" / "거절됨" / "결제완료" 이력 row 탭으로 이 detail 진입 (Fix #1860).</td>
+        </tr>
+        <tr>
+          <td><a href="/specs/event_application_list_page/index.html"><code>EventApplicationListPage</code></a></td>
+          <td>단일 이벤트 참가 현황 owner. 처리 완료 카드 탭 시 이 detail로 진입하며, 입장그룹/refund tab 자체는 list spec이 소유한다.</td>
         </tr>
         <tr>
           <td><a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a></td>

--- a/apps/mds/docs/public/specs/event_application_list_page/index.html
+++ b/apps/mds/docs/public/specs/event_application_list_page/index.html
@@ -637,7 +637,7 @@ body.dark-mode .viewport {
       <tr>
         <th>User journey</th>
         <td>
-          <strong>Entry points</strong>: 이벤트 상세(<a href="/specs/partner_event_detail_page/index.html">EventDetailPage</a>)의 "참가 현황" 섹션 탭. 또는 파트너 메인 nav의 <a href="/specs/event_application_manage_page/index.html">EventApplicationManagePage</a>(전체 이벤트 across)에서 특정 이벤트로 좁혀 진입(향후 — 본 spec 범위 밖).<br>
+          <strong>Entry points</strong>: 이벤트 상세(<a href="/specs/partner_event_detail_page/index.html">EventDetailPage</a>)의 "참가 현황" 섹션 탭. Top-level <a href="/specs/event_application_manage_page/index.html">EventApplicationManagePage</a>는 cross-event hub라 본 화면으로 자동 narrowing하지 않는다.<br>
           <strong>Exit points</strong>: AppBar back → EventDetailPage 복귀 / 심사 대기 카드 탭 → carousel push / 처리 완료 카드 탭 → detail page push / bottom CTA → carousel push (큐 처음부터).<br>
           carousel / confirm 화면에서 최종 확정 후 본 화면으로 복귀하면 리스트가 자동 invalidate되어 카드가 적절한 그룹으로 재배치된다.
         </td>
@@ -671,6 +671,11 @@ body.dark-mode .viewport {
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td>2026-06-04</td>
+        <td>v2.1</td>
+        <td>#3000: 본 화면을 단일 이벤트 참가 현황 owner로 명시. top-level <code>EventApplicationManagePage</code>는 cross-event hub이고, 입장그룹 sub-section / paid-only 확정 참가자 / rejected·refund tab은 본 spec이 소유하도록 경계 정리.</td>
+      </tr>
       <tr>
         <td>2026-05-03</td>
         <td>v2 (redesign)</td>
@@ -1810,8 +1815,17 @@ body.dark-mode .viewport {
     <h2>카드 탭 라우팅 분기</h2>
     <ul>
       <li><strong>심사 대기 카드</strong> → <a href="/specs/event_application_review_carousel_page/index.html"><code>EventApplicationReviewCarouselRoute</code></a> (그 사용자부터 배치 심사).</li>
-      <li><strong>처리 완료 카드</strong> → <a href="/specs/event_application_detail_page/index.html"><code>EventApplicationDetailRoute</code></a> (read-only 회고 + 환불 / 노트 등 후속 액션).</li>
+      <li><strong>처리 완료 카드</strong> → <a href="/specs/event_application_detail_page/index.html"><code>EventApplicationDetailRoute</code></a> (read-only 회고). refund/cancelled tab 자체는 본 리스트 surface가 owner.</li>
       <li>같은 카드 컴포넌트지만 출처 그룹에 따라 도착지가 다르다는 점이 핵심.</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>Top-level 신청관리와의 경계</h2>
+    <ul>
+      <li><a href="/specs/event_application_manage_page/index.html"><code>EventApplicationManagePage</code></a>는 partner shell의 cross-event 신청관리 탭이다. 여러 이벤트를 한 화면에서 훑고 pending을 빠르게 승인/거절하는 것이 목적이다.</li>
+      <li>본 화면은 <strong>한 이벤트</strong>에 좁혀진 참가 현황 surface다. 입장그룹 조건, capacity bar, paid-only 확정 참가자, rejected reason inline, refund/cancelled tab은 본 화면 owner다.</li>
+      <li>Top-level 신청관리에서 특정 이벤트로 "drill down"하는 별도 route는 현재 canonical entry가 아니다. 단일 이벤트 검토는 <code>PartnerEventDetailPage</code>의 "참가 현황"에서 진입한다.</li>
     </ul>
   </section>
 
@@ -1864,8 +1878,8 @@ body.dark-mode .viewport {
         <tr><td><a href="/specs/partner_event_detail_page/index.html"><code>EventDetailPage</code></a></td><td>Parent — 참가 현황 섹션 탭에서 진입.</td></tr>
         <tr><td><a href="/specs/event_application_review_carousel_page/index.html"><code>EventApplicationReviewCarouselPage</code></a></td><td>Child (primary) — 심사 대기 카드 탭 / sticky CTA 탭 시 push되는 배치 심사 carousel.</td></tr>
         <tr><td><a href="/specs/event_application_review_confirm_page/index.html"><code>EventApplicationReviewConfirmPage</code></a></td><td>Grandchild — carousel 큐가 끝나면 push되는 최종 확인 화면(리스트에서 직접 진입은 없음).</td></tr>
-        <tr><td><a href="/specs/event_application_detail_page/index.html"><code>EventApplicationDetailPage</code></a></td><td>Child (secondary) — 처리 완료 카드 탭 시 push. read-only 회고 + 환불 / 노트.</td></tr>
-        <tr><td><a href="/specs/event_application_manage_page/index.html"><code>EventApplicationManagePage</code></a></td><td>Sibling — 파트너 메인 nav의 cross-event 신청 리스트. 본 화면은 <em>단일 이벤트</em>로 좁힌 버전.</td></tr>
+        <tr><td><a href="/specs/event_application_detail_page/index.html"><code>EventApplicationDetailPage</code></a></td><td>Child (secondary) — 처리 완료 카드 탭 시 push. read-only 회고; refund/cancelled grouping은 본 리스트 surface가 유지.</td></tr>
+        <tr><td><a href="/specs/event_application_manage_page/index.html"><code>EventApplicationManagePage</code></a></td><td>Sibling — 파트너 메인 nav의 cross-event 신청관리 hub. 본 화면은 <em>단일 이벤트</em> 참가 현황 owner라 refund/cancelled tab과 입장그룹 review를 이쪽에서 다룬다.</td></tr>
       </tbody>
     </table>
   </section>

--- a/apps/mds/docs/public/specs/event_application_manage_page/index.html
+++ b/apps/mds/docs/public/specs/event_application_manage_page/index.html
@@ -306,7 +306,7 @@ body.dark-mode .viewport {
     <tbody>
       <tr>
         <th style="width: 140px;">Status</th>
-        <td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— 5 state · 파트너 신청관리 entry hub</em></td>
+        <td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— 5 state · canonical top-level 신청관리 hub</em></td>
       </tr>
       <tr>
         <th>App</th>
@@ -329,7 +329,7 @@ body.dark-mode .viewport {
         <td>
           <strong>Parent</strong>: <em>— (top-level partner shell screen — bottom-nav 신청관리 탭)</em><br>
           <strong>Children</strong>:
-          <code>EventApplicationDetailRoute</code> (승인됨/거절됨 항목 탭 시 push) · <code>_EventGroupSection</code> · <code>_ApplicationItem</code> · <code>_StatusBadge</code> · <code>_RejectDialog</code> <em>(internal widgets — no separate spec)</em>
+          <code>EventApplicationDetailRoute</code> (승인됨/거절됨/결제완료 항목 탭 시 read-only push) · <code>_EventGroupSection</code> · <code>_ApplicationItem</code> · <code>_StatusBadge</code> · <code>_RejectDialog</code> <em>(internal widgets — no separate spec)</em>
         </td>
       </tr>
       <tr>
@@ -343,7 +343,7 @@ body.dark-mode .viewport {
       <tr>
         <th>User journey</th>
         <td>
-          <strong>Entry points</strong>: 하단 NavigationBar "신청관리" 탭 / PartnerHomePage TodoSummaryChips "승인 대기" chip 탭 / 푸시 알림(신청 도착) 탭.<br>
+          <strong>Entry points</strong>: 하단 NavigationBar "신청관리" 탭 / PartnerHomePage 오버뷰 "참가예정 고객" stat / 푸시 알림(신청 도착) 탭.<br>
           <strong>Exit points</strong>: 승인/거절 인라인 액션 후 같은 화면 stay (snackbar) · "전체 승인" CTA · 승인됨/거절됨 항목 row 탭 → <code>EventApplicationDetailRoute</code> push · 다른 bottom-nav 탭으로 전환.
         </td>
       </tr>
@@ -358,6 +358,60 @@ body.dark-mode .viewport {
       <tr>
         <th>Frequency</th>
         <td>활성 파트너는 매일 1~수회. 푸시 알림이 trigger인 경우 즉시 진입.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="doc">
+  <h2>Canonical ownership boundary</h2>
+  <p class="intro">
+    #3000 기준 신청 관련 화면의 책임 경계. 이 화면은 <strong>파트너 shell의 top-level cross-event 신청관리</strong>만 소유하고,
+    단일 이벤트 참가 현황/입장그룹 심사/환불 내역은 이벤트 상세 하위 surface가 소유한다.
+  </p>
+  <table class="ref">
+    <thead>
+      <tr>
+        <th style="width: 220px;">Concern</th>
+        <th style="width: 260px;">Canonical owner</th>
+        <th>Rule</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>하단 nav "신청관리" / 홈 "참가예정 고객"</td>
+        <td><code>EventApplicationManagePage</code></td>
+        <td><code>ApplicationListRoute</code>의 단일 owner. 여러 이벤트의 신청을 이벤트별 group으로 묶어 빠르게 처리하는 cross-event hub.</td>
+      </tr>
+      <tr>
+        <td>단일 이벤트 참가 현황</td>
+        <td><a href="/specs/event_application_list_page/index.html"><code>EventApplicationListPage</code></a></td>
+        <td><code>PartnerEventDetailPage</code>의 "참가 현황"에서 진입. 입장그룹 sub-section, 이벤트 capacity, paid-only 확정 참가자, rejected/refund tab은 이쪽 owner.</td>
+      </tr>
+      <tr>
+        <td>대기중 신청 quick 처리</td>
+        <td><code>EventApplicationManagePage</code></td>
+        <td>Top-level에서는 pending/pending_review를 인라인 승인/거절하고, 이벤트별 <code>bulkApproveApplications</code>로 "전체 승인"만 제공한다. pending row 자체는 상세로 push하지 않는다.</td>
+      </tr>
+      <tr>
+        <td>입장그룹 기반 batch review</td>
+        <td><a href="/specs/event_application_review_carousel_page/index.html"><code>EventApplicationReviewCarouselPage</code></a> → <a href="/specs/event_application_review_confirm_page/index.html"><code>EventApplicationReviewConfirmPage</code></a></td>
+        <td>단일 이벤트 안에서 사용자별 제출 정보/입장그룹 조건을 보며 승인·거절을 deferred marking 후 최종 확정한다. preset reject reason chip taxonomy도 이 흐름의 owner다.</td>
+      </tr>
+      <tr>
+        <td>승인/거절/결제완료 이력</td>
+        <td><code>EventApplicationManagePage</code> + <a href="/specs/event_application_detail_page/index.html"><code>EventApplicationDetailPage</code></a></td>
+        <td>Cross-event 탭은 approved/paid를 "승인됨" 이력으로, rejected를 "거절됨" 이력으로 보여준다. 행 탭 후 단일 신청 read-only detail로 진입한다.</td>
+      </tr>
+      <tr>
+        <td>환불/취소 내역</td>
+        <td><a href="/specs/event_application_list_page/index.html"><code>EventApplicationListPage</code></a></td>
+        <td>Top-level 신청관리 탭에는 노출하지 않는다. 단일 이벤트 참가 현황의 refund/cancelled tab과 정산/환불 플로우에서 처리한다.</td>
+      </tr>
+      <tr>
+        <td>거절 사유 입력 방식</td>
+        <td><code>EventApplicationManagePage</code> / <a href="/specs/event_application_detail_page/index.html"><code>EventApplicationDetailPage</code></a> / carousel flow</td>
+        <td>Top-level quick reject와 detail reject는 free-text dialog. preset chip + 자유 입력 조합은 batch carousel reject sheet에서만 정의한다.</td>
       </tr>
     </tbody>
   </table>
@@ -379,6 +433,12 @@ body.dark-mode .viewport {
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td>2026-06-04</td>
+        <td>1.1</td>
+        <td>codex</td>
+        <td>#3000: 이 화면을 partner shell의 canonical cross-event 신청관리 surface로 확정. 단일 이벤트 참가 현황, 입장그룹 batch review, refund/cancelled tab, preset reject reason의 owner를 분리해 문서화.</td>
+      </tr>
       <tr>
         <td>2026-05-01</td>
         <td>1.0</td>
@@ -1210,7 +1270,7 @@ body.dark-mode .viewport {
         <tr><th>Provider</th><td><code>eventApplicationsGroupedProvider</code> (FutureProvider.family.autoDispose · key = (partnerId, statusFilter)) · <code>currentPartnerInfoProvider</code> · <code>eventRepositoryProvider</code></td></tr>
         <tr><th>Repository methods</th><td><code>EventRepository.getPartnerFutureEvents</code> · <code>getApplicationsByEventId</code> · <code>approveApplication</code> · <code>bulkApproveApplications</code> · <code>rejectApplication</code></td></tr>
         <tr><th>Theme</th><td><code>MinglitTheme.partnerTheme</code> — primary <code>MinglitPartnerColors.primary</code>(<code>#6c3ce1</code>). user app(<code>#9900ff</code>)과 다름.</td></tr>
-        <tr><th>Status enum drift</th><td>Pending 탭은 <code>['pending','pending_review']</code>, 승인됨 탭은 <code>['approved','paid']</code>를 합쳐 표시(visual에서는 동일 '승인' badge), 거절됨 탭은 <code>['rejected']</code>만. <em>refunded / canceled 등은 이 화면에서 노출되지 않음 — 정산/환불 플로우에서 처리.</em></td></tr>
+        <tr><th>Status owner boundary</th><td>Pending 탭은 <code>['pending','pending_review']</code>, 승인됨 탭은 <code>['approved','paid']</code>를 합쳐 표시(visual에서는 동일 '승인' badge), 거절됨 탭은 <code>['rejected']</code>만. <em>cancelled/refund 내역은 top-level 신청관리 owner가 아니며, 단일 이벤트 <a href="/specs/event_application_list_page/index.html"><code>EventApplicationListPage</code></a>와 정산/환불 플로우에서 처리한다.</em></td></tr>
         <tr><th>⚠️ 알려진 drift</th><td>Empty/Loading/Error state에서는 RefreshIndicator가 미동작 — 빈 상태에서 새로고침하려면 탭을 다시 선택. chunk fetch가 직렬이라 large partner는 시간 큼. row 탭 onTap은 showActions에 따라 분기되는데, 이게 Approved 탭에서 한 차례 사라졌다가 #1860에서 복구된 regression 사례 — 변경 시 주의.</td></tr>
       </tbody>
     </table>
@@ -1223,11 +1283,23 @@ body.dark-mode .viewport {
       <tbody>
         <tr>
           <td><a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a></td>
-          <td>홈 TodoSummaryChips "승인 대기" chip이 이 화면 대기중 탭으로 진입하는 가장 일반적 entry. <code>pendingReviewCount</code>는 같은 데이터의 카운트.</td>
+          <td>오버뷰 "참가예정 고객" stat 및 하단 nav "신청관리"가 이 화면으로 진입한다. <code>pendingReviewCount</code>는 같은 cross-event 데이터의 카운트.</td>
         </tr>
         <tr>
-          <td><a href="/specs/event_detail_page/index.html"><code>EventDetailPage</code></a></td>
-          <td>이벤트별 그룹 헤더에 노출되는 이벤트는 EventDetail에서 정의된 동일 이벤트 객체. detail에서 capacity / 시작 시간 변경 시 본 화면 group sub("N건 · A/B명")도 영향.</td>
+          <td><a href="/specs/event_application_list_page/index.html"><code>EventApplicationListPage</code></a></td>
+          <td>Sibling — 단일 이벤트 참가 현황. 입장그룹 sub-section, paid-only 확정 참가자, rejected/refund tab은 이쪽 owner다.</td>
+        </tr>
+        <tr>
+          <td><a href="/specs/event_application_detail_page/index.html"><code>EventApplicationDetailPage</code></a></td>
+          <td>Child — 승인됨/거절됨/결제완료 이력 row 탭 시 read-only detail로 push. 대기중 row는 top-level에서 inline 처리하고 detail로 push하지 않는다.</td>
+        </tr>
+        <tr>
+          <td><a href="/specs/event_application_review_carousel_page/index.html"><code>EventApplicationReviewCarouselPage</code></a></td>
+          <td>Batch review sibling. 단일 이벤트 안에서 입장그룹 조건과 제출 정보를 보며 preset reject reason + deferred marking을 처리한다.</td>
+        </tr>
+        <tr>
+          <td><a href="/specs/partner_event_detail_page/index.html"><code>EventDetailPage</code> (partner)</a></td>
+          <td>단일 이벤트 참가 현황의 parent. 이벤트별 group header에 노출되는 이벤트 객체와 capacity/source data를 공유한다.</td>
         </tr>
         <tr>
           <td><a href="/specs/party_detail_page/index.html"><code>PartyDetailPage</code></a></td>

--- a/apps/mds/docs/public/specs/partner_home_page/index.html
+++ b/apps/mds/docs/public/specs/partner_home_page/index.html
@@ -969,6 +969,12 @@ body.dark-mode .viewport {
     <tbody>
       <tr>
         <td>2026-06-04</td>
+        <td>2.4</td>
+        <td>codex</td>
+        <td>#3000: 신청관리 탭과 오버뷰 "참가예정 고객" destination을 <code>EventApplicationManagePage</code> cross-event hub로 확정. 단일 이벤트 참가 현황은 <code>EventApplicationListPage</code> owner로 분리.</td>
+      </tr>
+      <tr>
+        <td>2026-06-04</td>
         <td>2.3</td>
         <td>codex</td>
         <td>#3004: Subpages map의 남은 TBD를 실제 spec link / follow-up issue / intentional deferred로 분류. 신청관리·계좌·첫 이벤트·정산은 기존 partner spec으로 연결하고, partner 활성 이벤트 리스트는 app_user <code>PartnerEventsPage</code> 오용을 피하기 위해 #3040으로 분리.</td>
@@ -3423,7 +3429,7 @@ body.dark-mode .viewport {
           <td>운영 현황 — "참가예정 고객"</td>
           <td><a href="/specs/event_application_manage_page/index.html"><code>EventApplicationManagePage</code></a></td>
           <td>✅</td>
-          <td>하단 nav 신청관리와 동일 <code>ApplicationListRoute</code> · cross-event 신청관리 boundary 강화는 #3000</td>
+          <td>하단 nav 신청관리와 동일 <code>ApplicationListRoute</code> · canonical cross-event 신청관리 hub (#3000)</td>
         </tr>
         <tr>
           <td>Welcome 카드 "도움말 보기"</td>
@@ -3501,7 +3507,7 @@ body.dark-mode .viewport {
           <td>하단 nav — 신청관리</td>
           <td><a href="/specs/event_application_manage_page/index.html"><code>EventApplicationManagePage</code></a></td>
           <td>✅</td>
-          <td>모든 이벤트의 신청 통합 리스트 · canonical boundary follow-up #3000</td>
+          <td>모든 이벤트의 신청 통합 리스트 · 단일 이벤트 참가 현황은 <code>EventApplicationListPage</code> owner (#3000)</td>
         </tr>
         <tr>
           <td>하단 nav — 체크인</td>
@@ -3558,7 +3564,7 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td><a href="/specs/event_application_manage_page/index.html"><code>EventApplicationManagePage</code></a></td>
-          <td>오버뷰 "참가예정 고객" stat 및 하단 nav 신청관리의 공통 도착지.</td>
+          <td>오버뷰 "참가예정 고객" stat 및 하단 nav 신청관리의 공통 도착지. 여러 이벤트를 묶어 보여주는 cross-event hub.</td>
         </tr>
         <tr>
           <td><a href="/specs/event_application_list_page/index.html"><code>EventApplicationListPage</code></a></td>

--- a/apps/mds/docs/src/lib/flow-data.ts
+++ b/apps/mds/docs/src/lib/flow-data.ts
@@ -117,9 +117,8 @@ const APP_PARTNER_MAIN_FLOW = `flowchart TB
   HomeRoute -->|"view guide hub"| PartnerGuideRoute
   HomeRoute -->|"view location guide"| LocationGuideRoute
   HomeRoute -->|"tap notifications"| NotificationCenterRoute
-  HomeRoute -->|"bottom nav"| ApplicationListRoute
-  ApplicationListRoute -->|"tap event application"| EventApplicationDetailRoute
-  ApplicationListRoute -->|"tap partner application"| ApplicationDetailRoute
+  HomeRoute -->|"bottom nav 신청관리 / overview 참가예정 고객"| ApplicationListRoute
+  ApplicationListRoute -->|"tap approved/rejected/paid row"| EventApplicationDetailRoute
   HomeRoute -->|"bottom nav"| CheckinRoute
   HomeRoute -->|"bottom nav (SETTLEMENT_VIEW role required)"| SettlementRoute
   SettlementRoute -->|"tap settlement item"| SettlementDetailRoute
@@ -134,8 +133,8 @@ const APP_PARTNER_MAIN_FLOW = `flowchart TB
   PartyDetailRoute -->|"create event"| EventCreateRoute
   PartyDetailRoute -->|"tap event"| EventDetailRoute
   EventDetailRoute -->|"tap hero (일정)"| EventEditRoute
-  EventDetailRoute -->|"tap 참가 현황"| EventApplicationListRoute
-  EventApplicationListRoute -->|"tap application card"| EventApplicationDetailRoute
+  EventDetailRoute -->|"tap 참가 현황 (single event)"| EventApplicationListRoute
+  EventApplicationListRoute -->|"tap completed/rejected/refund card"| EventApplicationDetailRoute
   EventApplicationListRoute -->|"tap pending review card"| EventApplicationReviewCarouselRoute
   EventApplicationReviewCarouselRoute -->|"complete review queue"| EventApplicationReviewConfirmRoute
   EventDetailRoute -->|"create ticket"| TicketCreateRoute


### PR DESCRIPTION
## Summary

- Define `EventApplicationManagePage` as the canonical top-level cross-event 신청관리 surface for `ApplicationListRoute`.
- Clarify ownership between cross-event 신청관리, single-event 참가 현황, batch review carousel/confirm, detail, and refund/cancelled states.
- Update PartnerHome subpages map wording and MDS flow diagram so 신청관리 no longer mixes partner application review with event application management.

## Verification

- `git diff --check`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- `npm run lint --workspace=apps/mds/docs`
- `npm run build --workspace=apps/mds/docs`

Closes #3000
Refs #2222