### PR TITLE
fix(app): defer Supabase-bound startup paths

### DIFF
--- a/apps/app_partner/lib/main.dart
+++ b/apps/app_partner/lib/main.dart
@@ -93,17 +93,50 @@ class _AppView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final startupState = ref.watch(appStartupProvider);
-    final goRouter = ref.watch(goRouterProvider);
-    if (startupState is AsyncData<void>) {
-      // Activate notification initializer only after critical startup succeeds.
-      ref.watch(notificationInitializerProvider);
-    }
     // Remove native splash when startup completes (or fails).
     ref.listen(appStartupProvider, (prev, next) {
       if (next is! AsyncLoading) FlutterNativeSplash.remove();
     });
 
+    if (startupState is! AsyncLoading) {
+      FlutterNativeSplash.remove();
+    }
+
+    if (startupState is AsyncData<void>) {
+      return const _ReadyAppView();
+    }
+
     // ignore: use_minglit_async_value_widget - This is the app entry point, MaterialApp is not yet available.
+    return MaterialApp(
+      title: 'Minglit Partner',
+      debugShowCheckedModeBanner: false,
+      theme: MinglitTheme.partnerTheme,
+      darkTheme: MinglitTheme.partnerThemeDark,
+      themeMode: ref.watch(themeControllerProvider),
+      localizationsDelegates: kPartnerLocalizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: startupState.when(
+        data: (_) => const SizedBox.shrink(),
+        loading: () => const SizedBox.shrink(),
+        error: (e, st) => StartupFatalErrorView(
+          error: e,
+          onRetry: () => ref.invalidate(appStartupProvider),
+        ),
+      ),
+    );
+  }
+}
+
+class _ReadyAppView extends ConsumerWidget {
+  const _ReadyAppView();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final goRouter = ref.watch(goRouterProvider);
+
+    // Activate notification initializer only after critical startup succeeds.
+    ref.watch(notificationInitializerProvider);
+
     return MaterialApp.router(
       title: 'Minglit Partner',
       debugShowCheckedModeBanner: false,
@@ -114,22 +147,13 @@ class _AppView extends ConsumerWidget {
       localizationsDelegates: kPartnerLocalizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       builder: (context, child) {
-        return MinglitAsyncValueWidget(
-          value: startupState,
-          data: (_) => BugReporterWrapper(
-            navigatorKey: rootNavigatorKey,
-            // Fix #382: child 강제 언래핑 제거 — nullable child에 fallback 추가
-            child: PendingDeletionRecoveryListener(
-              child: MinglitGlobalLoadingOverlay(
-                child: child ?? const SizedBox.shrink(),
-              ),
+        return BugReporterWrapper(
+          navigatorKey: rootNavigatorKey,
+          // Fix #382: child 강제 언래핑 제거 — nullable child에 fallback 추가
+          child: PendingDeletionRecoveryListener(
+            child: MinglitGlobalLoadingOverlay(
+              child: child ?? const SizedBox.shrink(),
             ),
-          ),
-          // Hidden behind native splash — show nothing.
-          loading: () => const SizedBox.shrink(),
-          error: (e, st) => StartupFatalErrorView(
-            error: e,
-            onRetry: () => ref.invalidate(appStartupProvider),
           ),
         );
       },

--- a/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_controller.dart
+++ b/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_controller.dart
@@ -13,6 +13,8 @@ part 'manual_checkin_controller.g.dart';
 class ManualCheckinController extends _$ManualCheckinController {
   @override
   Future<List<CheckinParticipant>> build(String eventId) async {
+    if (EnvKeyStore.isDemo) return const [];
+
     final supabase = ref.watch(supabaseClientProvider);
     return _fetchParticipants(supabase, eventId);
   }
@@ -35,6 +37,8 @@ class ManualCheckinController extends _$ManualCheckinController {
   ///
   /// 반환값: 'success' | 'already_checked_in' | 'not_found'
   Future<String> checkin(String ticketId) async {
+    if (EnvKeyStore.isDemo) return 'success';
+
     final supabase = ref.read(supabaseClientProvider);
 
     // Optimistic 업데이트: 즉시 UI 반영

--- a/apps/app_partner/lib/src/features/checkin/stats/checkin_stats_controller.dart
+++ b/apps/app_partner/lib/src/features/checkin/stats/checkin_stats_controller.dart
@@ -35,6 +35,8 @@ class CheckinStatsController extends _$CheckinStatsController {
 
   @override
   Future<CheckinStats> build(String eventId) async {
+    if (EnvKeyStore.isDemo) return CheckinStats.empty;
+
     final supabase = ref.watch(supabaseClientProvider);
     final stats = await _fetchStats(supabase, eventId);
 
@@ -64,6 +66,8 @@ class CheckinStatsController extends _$CheckinStatsController {
   // Extracted for testability — called by realtime callback and polling.
   // Subclasses (fakes) can override to supply test data without real Supabase.
   Future<void> applyFetchedStats(String eventId) async {
+    if (EnvKeyStore.isDemo) return;
+
     final supabase = ref.read(supabaseClientProvider);
     try {
       final newStats = await _fetchStats(supabase, eventId);

--- a/apps/app_partner/lib/src/features/checkin/stats/entry_group_checkin_stats_controller.dart
+++ b/apps/app_partner/lib/src/features/checkin/stats/entry_group_checkin_stats_controller.dart
@@ -43,6 +43,8 @@ class EntryGroupCheckinStatsController
 
   @override
   Future<List<EntryGroupCheckinStats>> build(String eventId) async {
+    if (EnvKeyStore.isDemo) return const [];
+
     final supabase = ref.watch(supabaseClientProvider);
     final groups = await _fetchGroupStats(supabase, eventId);
 

--- a/apps/app_partner/lib/src/features/party/event/edit/event_edit_controller.dart
+++ b/apps/app_partner/lib/src/features/party/event/edit/event_edit_controller.dart
@@ -91,9 +91,10 @@ class EventEditController extends _$EventEditController {
   Future<EventEditState> build(String eventId) async {
     final eventRepository = ref.watch(eventRepositoryProvider);
     final event = await eventRepository.getEventById(eventId);
-    // Fix #2110: Use event.currentParticipants as authoritative confirmed count.
-    // getApplicationsByEventId() may return paginated/incomplete results, causing
-    // under-counting that could bypass lock policy and min-participant guards.
+    // Fix #2110: Use event.currentParticipants as authoritative confirmed
+    // count. getApplicationsByEventId() may return paginated/incomplete
+    // results, causing under-counting that could bypass lock policy and
+    // min-participant guards.
     // Mirrors event_detail_page.dart which already uses the same source.
     final confirmedCount = event.currentParticipants;
 
@@ -149,7 +150,8 @@ class EventEditController extends _$EventEditController {
   // Fix #2110: submit via partner-manage-event EF (action=update) instead of
   // direct client write — EF enforces PARTY_MANAGE/EVENT_MANAGE permission and
   // service_role writes, preventing RLS policy bypass.
-  // `reason` is required when confirmedCount >= 1 and schedule changed (UI enforces via dialog).
+  // `reason` is required when confirmedCount >= 1 and schedule changed.
+  // The UI enforces this via a dialog.
   Future<void> submit({String? reason}) async {
     final current = state.asData?.value;
     if (current == null || !current.isDirty || current.isLoading) return;
@@ -157,20 +159,29 @@ class EventEditController extends _$EventEditController {
     state = AsyncValue.data(current.copyWith(isLoading: true));
 
     try {
+      if (EnvKeyStore.isDemo) {
+        state = AsyncValue.data(
+          current.copyWith(isDirty: false, isLoading: false),
+        );
+        return;
+      }
+
+      final body = <String, Object?>{
+        'action': 'update',
+        'event_id': current.event.id,
+        'event': {
+          'title': current.title,
+          'start_time': current.startTime.toUtc().toIso8601String(),
+          'end_time': current.endTime.toUtc().toIso8601String(),
+          'max_participants': current.maxParticipants,
+        },
+      };
+      if (reason != null) body['reason'] = reason;
+
       final supabase = ref.read(supabaseClientProvider);
       final response = await supabase.functions.invoke(
         'partner-manage-event',
-        body: {
-          'action': 'update',
-          'event_id': current.event.id,
-          'event': {
-            'title': current.title,
-            'start_time': current.startTime.toUtc().toIso8601String(),
-            'end_time': current.endTime.toUtc().toIso8601String(),
-            'max_participants': current.maxParticipants,
-          },
-          if (reason != null) 'reason': reason,
-        },
+        body: body,
       );
 
       if (response.status != 200) {

--- a/apps/app_user/lib/main.dart
+++ b/apps/app_user/lib/main.dart
@@ -82,11 +82,6 @@ class _AppView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final startupState = ref.watch(appStartupProvider);
-    final goRouter = ref.watch(goRouterProvider);
-    if (startupState is AsyncData<void>) {
-      // Activate notification initializer only after critical startup succeeds.
-      ref.watch(notificationInitializerProvider);
-    }
     // Fix #1746: guard with ref.watch to handle the case where startup
     // already completed before this listener was registered (listener only
     // fires on transitions, not on the current state).
@@ -99,7 +94,46 @@ class _AppView extends ConsumerWidget {
       FlutterNativeSplash.remove();
     }
 
+    if (startupState is AsyncData<void>) {
+      return const _ReadyAppView();
+    }
+
     // ignore: use_minglit_async_value_widget - This is the app entry point, MaterialApp is not yet available.
+    return MaterialApp(
+      title: 'Minglit User',
+      debugShowCheckedModeBanner: false,
+      theme: MinglitTheme.materialTheme,
+      darkTheme: MinglitTheme.materialThemeDark,
+      themeMode: ref.watch(themeControllerProvider),
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: startupState.when(
+        data: (_) => const SizedBox.shrink(),
+        loading: () => const SizedBox.shrink(),
+        error: (e, st) => StartupFatalErrorView(
+          error: e,
+          onRetry: () => ref.invalidate(appStartupProvider),
+        ),
+      ),
+    );
+  }
+}
+
+class _ReadyAppView extends ConsumerWidget {
+  const _ReadyAppView();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final goRouter = ref.watch(goRouterProvider);
+
+    // Activate notification initializer only after critical startup succeeds.
+    ref.watch(notificationInitializerProvider);
+
     return MaterialApp.router(
       title: 'Minglit User',
       debugShowCheckedModeBanner: false,
@@ -115,22 +149,13 @@ class _AppView extends ConsumerWidget {
       ],
       supportedLocales: AppLocalizations.supportedLocales,
       builder: (context, child) {
-        return MinglitAsyncValueWidget(
-          value: startupState,
-          data: (_) => BugReporterWrapper(
-            navigatorKey: rootNavigatorKey,
-            // Fix #382: child 강제 언래핑 제거 — nullable child에 fallback 추가
-            child: PendingDeletionRecoveryListener(
-              child: MinglitGlobalLoadingOverlay(
-                child: child ?? const SizedBox.shrink(),
-              ),
+        return BugReporterWrapper(
+          navigatorKey: rootNavigatorKey,
+          // Fix #382: child 강제 언래핑 제거 — nullable child에 fallback 추가
+          child: PendingDeletionRecoveryListener(
+            child: MinglitGlobalLoadingOverlay(
+              child: child ?? const SizedBox.shrink(),
             ),
-          ),
-          // Hidden behind native splash — show nothing.
-          loading: () => const SizedBox.shrink(),
-          error: (e, st) => StartupFatalErrorView(
-            error: e,
-            onRetry: () => ref.invalidate(appStartupProvider),
           ),
         );
       },

--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.dart
@@ -134,7 +134,8 @@ class EventNowBarStateNotifier extends _$EventNowBarStateNotifier {
       }
     } on Exception catch (e, st) {
       Log.e(
-        '⚠️ [EventNowBar] matchCandidates unavailable, degrading to lower state',
+        '⚠️ [EventNowBar] matchCandidates unavailable, '
+        'degrading to lower state',
         e,
         st,
       );
@@ -177,6 +178,8 @@ class EventRealtime extends _$EventRealtime {
 
   @override
   void build(String eventId) {
+    if (EnvKeyStore.isDemo) return;
+
     final supabase = ref.watch(supabaseClientProvider);
 
     _channel = supabase.channel('event-now-$eventId');

--- a/apps/app_user/lib/src/features/ticket/data/ticket_token_service.dart
+++ b/apps/app_user/lib/src/features/ticket/data/ticket_token_service.dart
@@ -9,7 +9,7 @@ part 'ticket_token_service.g.dart';
 TicketTokenService ticketTokenService(Ref ref) {
   return TicketTokenService(
     wallet: ref.watch(ticketWalletRepositoryProvider),
-    supabase: ref.watch(supabaseClientProvider),
+    supabase: EnvKeyStore.isDemo ? null : ref.watch(supabaseClientProvider),
   );
 }
 
@@ -19,11 +19,11 @@ TicketTokenService ticketTokenService(Ref ref) {
 ///
 /// Fix #1206: Fetches token from Edge Function when not in local wallet
 class TicketTokenService {
-  TicketTokenService({required this.wallet, required SupabaseClient supabase})
+  TicketTokenService({required this.wallet, required SupabaseClient? supabase})
     : _supabase = supabase;
 
   final TicketWalletRepository wallet;
-  final SupabaseClient _supabase;
+  final SupabaseClient? _supabase;
 
   Future<TicketToken?> getToken(String ticketId) async {
     // 1. Check local wallet first
@@ -32,9 +32,14 @@ class TicketTokenService {
       return cached;
     }
 
+    if (EnvKeyStore.isDemo) return null;
+
     // 2. Fetch from Edge Function
     try {
-      final response = await _supabase.functions.invoke(
+      final supabase = _supabase;
+      if (supabase == null) return null;
+
+      final response = await supabase.functions.invoke(
         'user-get-ticket-token',
         body: {'ticket_id': ticketId},
       );

--- a/apps/app_user/lib/src/features/tickets/active_event_banners_provider.dart
+++ b/apps/app_user/lib/src/features/tickets/active_event_banners_provider.dart
@@ -22,32 +22,34 @@ final activeEventBannersProvider = FutureProvider<List<ActiveEventBannerItem>>((
   // Fix #2123: Realtime subscription for event_participants changes (check-in,
   // no-show) so lifecycle cards update without user interaction.
   // Mirrors EventRealtime in event_now_bar_controller.dart.
-  final supabase = ref.watch(supabaseClientProvider);
   Timer? pollingTimer;
-  final channel = supabase.channel('active-banners-${user.id}')
-    ..onPostgresChanges(
-      event: PostgresChangeEvent.all,
-      schema: 'public',
-      table: 'event_participants',
-      filter: PostgresChangeFilter(
-        type: PostgresChangeFilterType.eq,
-        column: 'user_id',
-        value: user.id,
-      ),
-      callback: (_) => ref.invalidateSelf(),
-    )
-    ..subscribe((status, [error]) {
-      if (status == RealtimeSubscribeStatus.closed) {
-        pollingTimer = Timer.periodic(
-          const Duration(seconds: 30),
-          (_) => ref.invalidateSelf(),
-        );
-      }
+  if (!EnvKeyStore.isDemo) {
+    final supabase = ref.watch(supabaseClientProvider);
+    final channel = supabase.channel('active-banners-${user.id}')
+      ..onPostgresChanges(
+        event: PostgresChangeEvent.all,
+        schema: 'public',
+        table: 'event_participants',
+        filter: PostgresChangeFilter(
+          type: PostgresChangeFilterType.eq,
+          column: 'user_id',
+          value: user.id,
+        ),
+        callback: (_) => ref.invalidateSelf(),
+      )
+      ..subscribe((status, [error]) {
+        if (status == RealtimeSubscribeStatus.closed) {
+          pollingTimer = Timer.periodic(
+            const Duration(seconds: 30),
+            (_) => ref.invalidateSelf(),
+          );
+        }
+      });
+    ref.onDispose(() {
+      pollingTimer?.cancel();
+      unawaited(channel.unsubscribe());
     });
-  ref.onDispose(() {
-    pollingTimer?.cancel();
-    unawaited(channel.unsubscribe());
-  });
+  }
 
   final eventRepository = ref.watch(eventRepositoryProvider);
   final matchingRepository = ref.watch(matchingRepositoryProvider);
@@ -66,10 +68,7 @@ final activeEventBannersProvider = FutureProvider<List<ActiveEventBannerItem>>((
     applications.map((application) async {
       final event = application.event;
       if (event == null) {
-        return (
-          application: application,
-          phase: EventLifecyclePhase.ended,
-        );
+        return (application: application, phase: EventLifecyclePhase.ended);
       }
 
       final participantStatus = participantStatusByEventId[event.id];
@@ -83,7 +82,8 @@ final activeEventBannersProvider = FutureProvider<List<ActiveEventBannerItem>>((
       final matches = await matchingRepository.getMyMatches(event.id);
       hasMatchResults = matches.isNotEmpty;
       // Only fetch matching state when checked-in to avoid unnecessary calls.
-      // Fix #2123: matchingReady → matching requires at least one submitted vote.
+      // Fix #2123: matchingReady → matching requires at least one submitted
+      // vote.
       if (isCheckedIn) {
         try {
           final (candidates, voteCount) = await (
@@ -94,7 +94,8 @@ final activeEventBannersProvider = FutureProvider<List<ActiveEventBannerItem>>((
           hasSubmittedVotes = voteCount > 0;
         } on Object catch (e) {
           Log.w(
-            '⚠️ [ActiveBanners] matching state fetch failed for ${event.id}: $e',
+            '⚠️ [ActiveBanners] matching state fetch failed '
+            'for ${event.id}: $e',
           );
         }
       }
@@ -162,8 +163,8 @@ EventLifecyclePhase resolveEventLifecyclePhase({
   }
 
   if (isCheckedIn && event.status == 'ongoing') {
-    // Fix #2123: matchingReady → matching only after user submits at least one
-    // vote. Candidate availability alone does not indicate the user took action.
+    // Fix #2123: matchingReady → matching only after the user submits at least
+    // one vote. Candidate availability alone does not indicate action.
     if (hasSubmittedVotes) return EventLifecyclePhase.matching;
     if (hasMatchingCandidates) return EventLifecyclePhase.matchingReady;
   }


### PR DESCRIPTION
## Summary
- Split user/partner app startup shells from ready router trees so `goRouterProvider` is not created before `Supabase.initialize` completes.
- Keep demo flavor server-free by skipping app-local Supabase realtime/RPC paths that bypass demo repository overrides.
- Make user ticket token service avoid constructing a Supabase client in demo before checking local wallet/cache behavior.

## Issue Lifecycle
No linked issue: runtime red screens were found during direct Galaxy S24 APK verification in this session, before a tracker existed.

## Verification
- `flutter analyze` focused user startup/demo Supabase paths
- `flutter analyze` focused partner startup/check-in/event edit paths
- Built and installed on Galaxy S24: user dev, user demo, partner dev, partner demo debug APKs
- Launched user dev/user demo/partner demo and checked logcat for `Supabase.instance`, `PoisonSupabaseClient`, Flutter red-screen exception keywords
- Confirmed user dev and user demo render home screens without red screen