### PR TITLE
docs(admin): clarify dashboard implementation status

### DIFF
--- a/apps/BLUEDOC.md
+++ b/apps/BLUEDOC.md
@@ -17,6 +17,7 @@ Minglit 의 **사용자 대면 애플리케이션** 폴더. Flutter 모바일 �
 
 - **Feature-first 구조** — 모든 코드는 `lib/src/features/<feature>/` 아래로 응집. 기술적 폴더 (`screens/`, `widgets/`) 금지.
 - **공용 로직은 `minglit_kit`** — 두 앱 모두 쓰는 Repository·Provider·UI 는 `shared/packages/minglit_kit/` 에. 앱 레포에는 앱 고유 로직만.
+- **Admin Next.js console 은 미스캐폴드 상태** — canonical target 은 `apps/admin_web/`; 현재 목록의 `app_* admin/` 기능은 제품 admin-dashboard 구현이 아님.
 - **Coordinator 가 routing 을 담당** — UI 위젯은 "어디로 갈지" 모름. `ref.read(<feature>CoordinatorProvider).goTo...()` 만 호출.
 - **Cross-feature import 금지** — `pr-gate.check-cross-feature-imports` job 이 차단 (Fix #1872).
 - **Type-safe routing** — `go_router_builder` 로 컴파일 타임 검증. URL 문자열 직접 입력 금지.
@@ -30,4 +31,4 @@ Minglit 의 **사용자 대면 애플리케이션** 폴더. Flutter 모바일 �
 - [CLAUDE.md `## Build Defaults`](../CLAUDE.md) — flutter build 명령 / Java 17 설정
 
 ---
-_Reviewed: 2026-05-27 21:56_
+_Reviewed: 2026-06-04 22:19_

--- a/apps/BLUEDOC.md
+++ b/apps/BLUEDOC.md
@@ -17,7 +17,7 @@ Minglit 의 **사용자 대면 애플리케이션** 폴더. Flutter 모바일 �
 
 - **Feature-first 구조** — 모든 코드는 `lib/src/features/<feature>/` 아래로 응집. 기술적 폴더 (`screens/`, `widgets/`) 금지.
 - **공용 로직은 `minglit_kit`** — 두 앱 모두 쓰는 Repository·Provider·UI 는 `shared/packages/minglit_kit/` 에. 앱 레포에는 앱 고유 로직만.
-- **Admin Next.js console 은 미스캐폴드 상태** — canonical target 은 `apps/admin_web/`; 현재 목록의 `app_* admin/` 기능은 제품 admin-dashboard 구현이 아님.
+- **Admin Next.js console 은 미스캐폴드 상태** — canonical target 은 `apps/admin_web/`; 현재 `app_partner/admin/` 기능은 제품 admin-dashboard 구현이 아님.
 - **Coordinator 가 routing 을 담당** — UI 위젯은 "어디로 갈지" 모름. `ref.read(<feature>CoordinatorProvider).goTo...()` 만 호출.
 - **Cross-feature import 금지** — `pr-gate.check-cross-feature-imports` job 이 차단 (Fix #1872).
 - **Type-safe routing** — `go_router_builder` 로 컴파일 타임 검증. URL 문자열 직접 입력 금지.

--- a/apps/app_user/BLUEDOC.md
+++ b/apps/app_user/BLUEDOC.md
@@ -32,7 +32,6 @@ Minglit 의 **일반 사용자 Flutter 앱**. 파티 탐색·참여 신청·결�
 | `account_deletion/` | 회원 탈퇴 플로우 |
 | `consent/` | 이용약관 동의 |
 | `dev/` | 개발 유틸리티 (DevMap 화면 등) |
-| `admin/` | 운영/통계 계약 하네스 UI (CUJ contract test 지원) |
 
 ## 핵심 컨벤션
 
@@ -47,6 +46,5 @@ Minglit 의 **일반 사용자 Flutter 앱**. 파티 탐색·참여 신청·결�
 - [apps/architecture.md](../architecture.md) — Flutter 공통 아키텍처
 - [minglit_kit/BLUEDOC.md](../../shared/packages/minglit_kit/BLUEDOC.md) — 공용 패키지
 - [README.md](./README.md) — 빌드·실행 / [integration_test](./integration_test/BLUEDOC.md) — 통합 테스트
-
 ---
-_Reviewed: 2026-06-04 22:19_
+_Reviewed: 2026-06-04 22:35_

--- a/apps/mds/docs/BLUEDOC.md
+++ b/apps/mds/docs/BLUEDOC.md
@@ -46,6 +46,5 @@ npm run tokens:sync && npm run icons:sync && npm run icons:sync-data
 - [`../../../shared/packages/mds/tokens/README.md`](../../../shared/packages/mds/tokens/README.md) — token codegen
 - [`../../../shared/packages/mds/icons/README.md`](../../../shared/packages/mds/icons/README.md) — icon codegen
 - [`../../../scripts/mds_render_coverage.dart`](../../../scripts/mds_render_coverage.dart) — MDS spec ↔ emulator render coverage
-
 ---
 _Reviewed: 2026-06-04 23:11_

--- a/apps/mds/docs/public/specs/admin_console_dashboard/index.html
+++ b/apps/mds/docs/public/specs/admin_console_dashboard/index.html
@@ -127,7 +127,7 @@
         <tr><th>App</th><td><code>web_admin</code></td></tr>
         <tr><th>Category</th><td>admin · auth · shell</td></tr>
         <tr><th>Route / Surface</th><td><code>/admin</code> · admin entry route</td></tr>
-        <tr><th>Path</th><td><code>apps/admin/</code> planned · implementation root TBD</td></tr>
+        <tr><th>Path</th><td><code>apps/admin_web/</code> planned · implementation root TBD</td></tr>
         <tr>
           <th>Hierarchy</th>
           <td>
@@ -315,7 +315,7 @@
           <tr><th>Deferred child screens</th><td>Users, Partners, Payments, System, operation dashboards — separate specs TBD.</td></tr>
           <tr><th>Feature PRD</th><td><code>docs/features/admin/admin-dashboard/prd.md</code></td></tr>
           <tr><th>Feature spec</th><td><code>docs/features/admin/admin-dashboard/spec.md</code></td></tr>
-          <tr><th>Planned app</th><td><code>apps/admin/</code></td></tr>
+          <tr><th>Planned app</th><td><code>apps/admin_web/</code></td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/mds/docs/src/lib/screen-definitions.ts
+++ b/apps/mds/docs/src/lib/screen-definitions.ts
@@ -53,7 +53,7 @@ export const SCREEN_SURFACES: ScreenSurface[] = [
   {
     id: 'web_admin',
     label: 'web_admin',
-    description: 'Desktop web admin console screens. Defined manually until apps/admin exists.',
+    description: 'Desktop web admin console screens. Defined manually until apps/admin_web exists.',
   },
 ];
 
@@ -66,7 +66,7 @@ const WEB_ADMIN_SCREENS: ScreenDefinition[] = [
     screen: 'AdminConsoleDashboard',
     route: '/admin',
     specBasename: 'admin_console_dashboard',
-    codeSourcePath: 'apps/admin/',
+    codeSourcePath: 'apps/admin_web/',
     codeSourceExists: false,
     note: 'P0 shell/entry: Supabase Google OAuth login, admin guard, extensible menu frame.',
   },

--- a/docs/features/admin/BLUEDOC.md
+++ b/docs/features/admin/BLUEDOC.md
@@ -2,6 +2,11 @@
 
 관리자 도메인 — 내부 운영 도구. Flutter user/partner 앱이 아니라 향후 별도 Next.js admin console 에서 구현한다.
 
+## 구현 상태
+
+- 전용 Next.js admin app 은 아직 없다. canonical target 은 `apps/admin_web/` 이며, scaffold 전 상태다.
+- 현재 구현된 `apps/app_partner/lib/src/features/admin/` 은 파트너 신청 심사 보조 화면이며, admin-dashboard PRD 의 대체 구현이 아니다.
+
 ## 포함된 피쳐
 
 - [admin-dashboard](./admin-dashboard/) — 관리자 대시보드
@@ -16,4 +21,4 @@
 - [features BLUEDOC](../BLUEDOC.md) — feature 정의 및 분류 기준
 
 ---
-_Reviewed: 2026-05-31 17:45_
+_Reviewed: 2026-06-04 22:19_

--- a/docs/features/admin/admin-dashboard/prd.md
+++ b/docs/features/admin/admin-dashboard/prd.md
@@ -4,6 +4,15 @@
 
 Minglit 내부 운영자가 Supabase Google 로그인으로 본인 확인을 마친 뒤, 서버에서 검증된 admin 권한에 따라 관리자 메뉴를 사용하는 웹 기반 admin console. 현재 출시 범위는 admin 로그인, 권한 확인, 확장 가능한 shell/menu 구조까지다. 기능 dashboard 는 후속 메뉴로 분리하고, 이번 범위에서는 별도 board/spec 를 만들지 않는다.
 
+## Implementation Status
+
+> Issue #2559 기준 현황 정리.
+
+- 전용 Next.js admin dashboard 앱은 아직 모노레포에 없다. `apps/admin_web/` 이 canonical target 이지만 scaffold 전 상태다.
+- `apps/app_partner/lib/src/features/admin/` 은 파트너 앱 내부의 입점 신청 심사 보조 화면이다. 이 PRD 의 Next.js admin console 구현으로 간주하지 않는다.
+- `apps/app_user/lib/src/features/admin/` 은 운영/통계 계약 하네스 성격이며, admin-dashboard 제품 구현 대상이 아니다.
+- 따라서 이 PRD 의 구현 상태는 **planned / unscaffolded** 이다. 구현 착수 PR 은 `apps/admin_web/` scaffold, `apps/BLUEDOC.md` 갱신, 배포/CI 엔트리 정의를 함께 포함해야 한다.
+
 ## Motivation / Problem to Solve
 
 - admin 기능을 메뉴별로 추가할 기준 shell 이 없어, 기능이 늘수록 인증/권한/네비게이션/에러 UX 가 중복될 위험이 있다.

--- a/docs/features/admin/admin-dashboard/prd.md
+++ b/docs/features/admin/admin-dashboard/prd.md
@@ -10,7 +10,6 @@ Minglit 내부 운영자가 Supabase Google 로그인으로 본인 확인을 마
 
 - 전용 Next.js admin dashboard 앱은 아직 모노레포에 없다. `apps/admin_web/` 이 canonical target 이지만 scaffold 전 상태다.
 - `apps/app_partner/lib/src/features/admin/` 은 파트너 앱 내부의 입점 신청 심사 보조 화면이다. 이 PRD 의 Next.js admin console 구현으로 간주하지 않는다.
-- `apps/app_user/lib/src/features/admin/` 은 운영/통계 계약 하네스 성격이며, admin-dashboard 제품 구현 대상이 아니다.
 - 따라서 이 PRD 의 구현 상태는 **planned / unscaffolded** 이다. 구현 착수 PR 은 `apps/admin_web/` scaffold, `apps/BLUEDOC.md` 갱신, 배포/CI 엔트리 정의를 함께 포함해야 한다.
 
 ## Motivation / Problem to Solve

--- a/docs/features/admin/admin-dashboard/prd.md
+++ b/docs/features/admin/admin-dashboard/prd.md
@@ -51,7 +51,7 @@ Minglit 내부 운영자가 Supabase Google 로그인으로 본인 확인을 마
 
 ## Technical Approach
 
-- **앱**: 별도 Next.js admin app (`apps/admin` 예정). desktop-first admin UI.
+- **앱**: 별도 Next.js admin app (`apps/admin_web/` 예정). desktop-first admin UI.
 - **인증**: Supabase Auth Google OAuth 로그인. 서버에서 현재 세션의 user 를 확인하고 admin membership / role claim 을 조회한다.
 - **인가**: 메뉴 및 route 는 capability 기반으로 가드한다. 예: `admin.users.read`, `admin.partners.review`, `admin.system.read`.
 - **메뉴 registry**: 각 메뉴는 `id`, `label`, `route`, `requiredCapability`, `status`, `loader/error/empty` contract 를 가진다.

--- a/docs/features/admin/admin-dashboard/spec.md
+++ b/docs/features/admin/admin-dashboard/spec.md
@@ -11,6 +11,18 @@
 > - CUJ tests:
 >   - 계획: `apps/admin/e2e/cuj/admin_dashboard.spec.ts`
 
+## Implementation Status
+
+Issue #2559 확인 결과, 이 spec 의 Next.js admin dashboard 는 아직 구현되지 않았다.
+
+| 항목 | 상태 |
+|------|------|
+| Canonical app path | `apps/admin_web/` |
+| Current repo status | 디렉터리/Next.js app 미존재 |
+| Existing Flutter admin screens | `apps/app_partner/lib/src/features/admin/` 의 파트너 신청 심사 보조 화면. 이 spec 구현으로 보지 않음 |
+| Existing user-app admin harness | `apps/app_user/lib/src/features/admin/` 의 운영/통계 계약 하네스. 이 spec 구현으로 보지 않음 |
+| Next implementation step | `apps/admin_web/` scaffold + auth/MFA skeleton + CI/deploy entry 정의 |
+
 ## CUJs
 
 | ID  | Priority | CUJ Name | Details | FR | NFR |

--- a/docs/features/admin/admin-dashboard/spec.md
+++ b/docs/features/admin/admin-dashboard/spec.md
@@ -20,7 +20,6 @@ Issue #2559 확인 결과, 이 spec 의 Next.js admin dashboard 는 아직 구�
 | Canonical app path | `apps/admin_web/` |
 | Current repo status | 디렉터리/Next.js app 미존재 |
 | Existing Flutter admin screens | `apps/app_partner/lib/src/features/admin/` 의 파트너 신청 심사 보조 화면. 이 spec 구현으로 보지 않음 |
-| Existing user-app admin harness | `apps/app_user/lib/src/features/admin/` 의 운영/통계 계약 하네스. 이 spec 구현으로 보지 않음 |
 | Next implementation step | `apps/admin_web/` scaffold + auth/MFA skeleton + CI/deploy entry 정의 |
 
 ## CUJs

--- a/docs/features/admin/admin-dashboard/spec.md
+++ b/docs/features/admin/admin-dashboard/spec.md
@@ -5,11 +5,11 @@
 > - MDS specs:
 >   - `apps/mds/docs/public/specs/admin_console_dashboard/` — Supabase Google OAuth login, admin guard, extensible admin shell
 > - Apps:
->   - 계획: `apps/admin/` — Next.js admin console
+>   - 계획: `apps/admin_web/` — Next.js admin console
 > - Backend EFs:
 >   - P0: 해당 없음 — 서버 route/API 에서 Supabase 세션과 admin membership/capability 검증
 > - CUJ tests:
->   - 계획: `apps/admin/e2e/cuj/admin_dashboard.spec.ts`
+>   - 계획: `apps/admin_web/e2e/cuj/admin_dashboard.spec.ts`
 
 ## Implementation Status
 
@@ -71,7 +71,7 @@ Issue #2559 확인 결과, 이 spec 의 Next.js admin dashboard 는 아직 구�
 
 ## Open Questions
 
-- [ ] Admin app 위치를 `apps/admin` 으로 확정할지, 기존 landing/admin path 에 얹을지 결정.
+- [x] Admin app 위치는 `apps/admin_web/` 으로 확정. 아직 scaffold 전 상태.
 - [ ] Supabase admin membership source: JWT custom claim, `admin_members` 테이블, 또는 둘의 조합 중 선택.
 - [ ] P1 보안 강화에서 Supabase MFA(TOTP / phone factor)를 언제 켤지 결정.
 - [ ] 첫 후속 운영 메뉴를 무엇으로 둘지 결정.


### PR DESCRIPTION
## Summary
- document that the Next.js admin dashboard is planned but not scaffolded in this monorepo yet
- set `apps/admin_web/` as the canonical future app path
- distinguish existing Flutter admin/helper screens from the admin-dashboard product implementation

## Verification
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`

Closes #2559