### PR TITLE
docs(admin): add admin console shell MDS

### DIFF
--- a/apps/mds/docs/BLUEDOC.md
+++ b/apps/mds/docs/BLUEDOC.md
@@ -8,6 +8,7 @@ Minglit Design System 의 **시각 SSOT + 문서 사이트**. 화면 spec, 컴�
 |---|---|
 | [`src/app/`](./src/app/) | Next.js route pages (`/`, `/tokens`, `/components`, `/screens`, `/icons`, `/flows`) |
 | [`src/lib/components.ts`](./src/lib/components.ts) | MDS 컴포넌트 manifest SSOT |
+| [`src/lib/screen-definitions.ts`](./src/lib/screen-definitions.ts) | `/screens` surface별 screen registry (`app_user`, `app_partner`, `web_admin`) |
 | [`src/components/specs/`](./src/components/specs/) | 컴포넌트별 inline visual playground |
 | [`public/specs/BLUEDOC.md`](./public/specs/BLUEDOC.md) | 화면 spec source HTML + generated MD/PNG |
 | [`reports/BLUEDOC.md`](./reports/BLUEDOC.md) | MDS 정합성 audit report + weekly FRESH_DOC job |
@@ -47,4 +48,4 @@ npm run tokens:sync && npm run icons:sync && npm run icons:sync-data
 - [`../../../scripts/mds_render_coverage.dart`](../../../scripts/mds_render_coverage.dart) — MDS spec ↔ emulator render coverage
 
 ---
-_Reviewed: 2026-06-04 21:20_
+_Reviewed: 2026-06-04 22:31_

--- a/apps/mds/docs/public/specs/BLUEDOC.md
+++ b/apps/mds/docs/public/specs/BLUEDOC.md
@@ -12,6 +12,7 @@ MDS 화면 spec 의 **source HTML + 자동 산출물 디렉터리**. Flutter 화
 | [`<screen>/index.html`](./event_detail_page/index.html) | 화면별 spec source. 직접 수정 대상 |
 | [`ticket_selection_sheet/index.html`](./ticket_selection_sheet/index.html) | 이벤트 상세 하단 티켓 선택 시트 화면 spec |
 | [`ongoing_event_list_page/index.html`](./ongoing_event_list_page/index.html) | 파트너 LIVE 이벤트 참가자 명단/운영 dashboard spec |
+| [`admin_console_dashboard/index.html`](./admin_console_dashboard/index.html) | web_admin 로그인 / admin guard / shell screen spec |
 | [`<screen>/index.md`](./event_detail_page/index.md) | HTML 에서 생성되는 markdown 산출물 |
 | [`<screen>/state_*.png`](./event_detail_page/state_1.png) | HTML 에서 생성되는 state screenshot 산출물 |
 | [`<screen>/blueprint*.png`](./event_detail_page/blueprint_1.png) | HTML 에서 생성되는 blueprint screenshot 산출물 |
@@ -40,4 +41,4 @@ MDS 화면 spec 의 **source HTML + 자동 산출물 디렉터리**. Flutter 화
 - [`../../src/lib/flow-data.ts`](../../src/lib/flow-data.ts) — route/spec 매핑
 
 ---
-_Reviewed: 2026-06-04 21:20_
+_Reviewed: 2026-06-04 22:31_

--- a/apps/mds/docs/public/specs/admin_console_dashboard/index.html
+++ b/apps/mds/docs/public/specs/admin_console_dashboard/index.html
@@ -1,0 +1,332 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="features" content="admin/admin-dashboard">
+<title>Spec — AdminConsoleDashboard (web_admin · /admin)</title>
+<link rel="stylesheet" href="/specs/_spec.css">
+<style>
+/* Top-level web_admin shell/entry spec. Feature screens are deferred and render
+   inside this shell outlet only after each menu receives its own spec. */
+:root {
+  --spec-viewport-w: 720px;
+  --spec-viewport-h: 420px;
+  --spec-blueprint-rgb: 34, 148, 122;
+}
+.page { max-width: 1120px; }
+.viewport {
+  background: #f5f7fa;
+  color: #202736;
+  border-radius: 0;
+}
+.acs-login {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: #f5f7fa;
+}
+.acs-login__panel {
+  width: 340px;
+  background: #fff;
+  border: 1px solid #dce3ed;
+  border-radius: 8px;
+  padding: 26px;
+  box-shadow: 0 18px 36px rgba(23,32,51,.12);
+}
+.acs-brand { font-size: 14px; font-weight: 800; margin-bottom: 18px; }
+.acs-title { font-size: 22px; font-weight: 800; margin-bottom: 8px; }
+.acs-copy { font-size: 12px; line-height: 1.55; color: #657084; margin-bottom: 18px; }
+.acs-google {
+  height: 42px;
+  border-radius: 6px;
+  border: 1px solid #dce3ed;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-size: 13px;
+  font-weight: 800;
+}
+.acs-shell {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: 176px 1fr;
+  background: #f5f7fa;
+}
+.acs-sidebar {
+  background: #172033;
+  color: #fff;
+  padding: 18px 14px;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 18px;
+}
+.acs-menu { display: grid; align-content: start; gap: 6px; }
+.acs-menu__item {
+  height: 34px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 700;
+  color: rgba(255,255,255,.62);
+}
+.acs-menu__item--active {
+  background: rgba(34,148,122,.24);
+  color: #fff;
+}
+.acs-main {
+  display: grid;
+  grid-template-rows: 52px 1fr;
+  min-width: 0;
+}
+.acs-topbar {
+  background: #fff;
+  border-bottom: 1px solid #dce3ed;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  font-size: 12px;
+  color: #657084;
+}
+.acs-outlet {
+  margin: 18px;
+  border: 1px dashed #b8c3d3;
+  border-radius: 8px;
+  background: #fff;
+  display: grid;
+  place-items: center;
+  color: #657084;
+  font-size: 13px;
+  text-align: center;
+  padding: 24px;
+}
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>
+  <label><input type="checkbox" id="dark-toggle"> Dark mode (viewports flip dark)</label>
+</div>
+
+<div class="page">
+  <header>
+    <h1>Admin Console Dashboard</h1>
+  </header>
+
+  <section class="doc">
+    <h2>Overview</h2>
+    <table class="ref">
+      <tbody>
+        <tr><th style="width: 140px;">Status</th><td><strong>🚧 정의중</strong> — web_admin entry/shell screen</td></tr>
+        <tr><th>App</th><td><code>web_admin</code></td></tr>
+        <tr><th>Category</th><td>admin · auth · shell</td></tr>
+        <tr><th>Route / Surface</th><td><code>/admin</code> · admin entry route</td></tr>
+        <tr><th>Path</th><td><code>apps/admin/</code> planned · implementation root TBD</td></tr>
+        <tr>
+          <th>Hierarchy</th>
+          <td>
+            <strong>Parent</strong>: <em>— (top-level web_admin entry)</em><br>
+            <strong>Children</strong>: future menu screens only. Users, Partners, Payments, System, and operation dashboard specs are deferred.
+          </td>
+        </tr>
+        <tr>
+          <th>Purpose</th>
+          <td>
+            Supabase Google OAuth 로그인, 서버 admin 권한 확인, extensible admin shell 을 소유한다.
+            기능 화면은 별도 screen/spec 가 생긴 뒤 이 shell 의 outlet 에 연결한다.
+          </td>
+        </tr>
+        <tr>
+          <th>User journey</th>
+          <td>
+            <strong>Entry points</strong>: <code>/admin</code> 직접 접근 · 기능 deep-link 진입 전 공통 guard.<br>
+            <strong>Exit points</strong>: 권한 통과 후 admin shell/no-menu state · 비관리자 403 · sign out.
+          </td>
+        </tr>
+        <tr><th>Frequency</th><td>모든 web_admin session 의 첫 진입점. 기능 메뉴보다 더 자주 실행되는 공통 gate.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>History</h2>
+    <table class="ref">
+      <thead>
+        <tr><th style="width: 110px;">Date</th><th style="width: 80px;">Version</th><th style="width: 120px;">Author</th><th>Changes</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>2026-06-04</td>
+          <td>1.3</td>
+          <td>Codex</td>
+          <td>기능 board 를 후속 범위로 이동. 현재 spec 은 login, admin guard, shell/no-menu 상태만 유지.</td>
+        </tr>
+        <tr>
+          <td>2026-06-04</td>
+          <td>1.2</td>
+          <td>Codex</td>
+          <td><code>/admin</code> entry/shell 로 재정의. 로그인과 admin guard 를 이 spec 에 포함.</td>
+        </tr>
+        <tr>
+          <td>2026-06-04</td>
+          <td>1.1</td>
+          <td>Codex</td>
+          <td>상세 dashboard mockup 을 제거하고 screen-definition level 로 축소.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <nav class="perspective-nav">
+    <a href="#definition"><span class="glyph">🧭</span> Definition</a>
+    <a href="#states"><span class="glyph">🎨</span> States</a>
+    <a href="#layout"><span class="glyph">🧱</span> Layout</a>
+    <a href="#reference"><span class="glyph">📖</span> Reference</a>
+  </nav>
+
+  <div class="perspective" id="definition">
+    <div class="perspective__header">
+      <span class="glyph">🧭</span>
+      <h2>Definition</h2>
+      <span class="lede">Entry, auth, and shell contract. Feature screens are children.</span>
+    </div>
+    <section class="doc">
+      <h2>Screen contract</h2>
+      <table class="ref">
+        <thead><tr><th style="width: 220px;">Field</th><th>Value</th></tr></thead>
+        <tbody>
+          <tr><td>Surface</td><td><code>web_admin</code></td></tr>
+          <tr><td>Screen</td><td><code>AdminConsoleDashboard</code></td></tr>
+          <tr><td>Route</td><td><code>/admin</code></td></tr>
+          <tr><td>Feature</td><td><code>admin/admin-dashboard</code></td></tr>
+          <tr><td>P0 scope</td><td>Google login, session callback handling, server admin check, 403/session-expired/no-menu state, menu registry, shell outlet.</td></tr>
+          <tr><td>Out of this file</td><td>Feature menu screens. Users, Partners, Payments, System, and operation dashboards are deferred until each menu has a separate spec.</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </div>
+
+  <div class="perspective" id="states">
+    <div class="perspective__header">
+      <span class="glyph">🎨</span>
+      <h2>States</h2>
+      <span class="lede">Only shell-level states. Child menu states are separate specs.</span>
+    </div>
+    <section class="doc">
+      <h2>State summary</h2>
+      <table class="ref">
+        <thead><tr><th style="width: 220px;">State</th><th>Condition</th><th>Next surface</th></tr></thead>
+        <tbody>
+          <tr><td>Login</td><td>No Supabase session</td><td>Google OAuth callback then admin check</td></tr>
+          <tr><td>Checking admin</td><td>Session exists, admin membership/capability loading</td><td>Shell or 403</td></tr>
+          <tr><td>403</td><td>Session exists, no admin capability</td><td>Sign out / other account</td></tr>
+          <tr><td>Shell ready</td><td>Admin capability exists</td><td>First available menu or no-menu empty state</td></tr>
+          <tr><td>Session expired</td><td>Auth error while using shell/child screen</td><td>Hide admin data, return to Login</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </div>
+
+  <div class="perspective" id="layout">
+    <div class="perspective__header">
+      <span class="glyph">🧱</span>
+      <h2>Layout</h2>
+      <span class="lede">Login panel and shell frame only.</span>
+    </div>
+    <section class="doc">
+      <h2>Login reference</h2>
+      <div class="viewport">
+        <div class="acs-login">
+          <div class="acs-login__panel">
+            <div class="acs-brand">Minglit Admin</div>
+            <div class="acs-title">관리자 로그인</div>
+            <div class="acs-copy">Google 계정으로 로그인한 뒤 서버에서 관리자 권한을 확인합니다.</div>
+            <div class="acs-google">G · Google로 로그인</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="doc">
+      <h2>Shell frame</h2>
+      <div class="layout-grid">
+        <div class="blueprint">
+          <div class="blueprint__region blueprint__region--shaded" style="top:0;left:0;bottom:0;width:176px;">
+            <span class="blueprint__region-label">① Sidebar · menu registry</span>
+          </div>
+          <div class="blueprint__region blueprint__region--shaded" style="top:0;left:176px;right:0;height:52px;">
+            <span class="blueprint__region-label">② Topbar · account/refresh slots</span>
+          </div>
+          <div class="blueprint__region blueprint__region--shaded" style="top:70px;left:194px;right:18px;bottom:18px;">
+            <span class="blueprint__region-label">③ Child screen outlet</span>
+          </div>
+        </div>
+        <div class="layout-tree"><b>AdminConsoleDashboard</b>
+├─ AuthGuard(Supabase session)
+├─ AdminCapabilityGuard(server verified)
+├─ Login / Checking / 403 states
+└─ AdminShell
+   ├─ Sidebar(menu registry)
+   ├─ Topbar(account + global filters)
+   └─ Outlet
+      └─ active menu screen or no-menu empty state</div>
+      </div>
+    </section>
+
+    <section class="doc">
+      <h2>Shell reference</h2>
+      <div class="viewport">
+        <div class="acs-shell">
+          <aside class="acs-sidebar">
+            <div class="acs-brand">Minglit Admin</div>
+            <div class="acs-menu">
+              <div class="acs-menu__item acs-menu__item--active">Console shell</div>
+              <div class="acs-menu__item">Users · later</div>
+              <div class="acs-menu__item">Partners · later</div>
+            </div>
+            <div class="acs-menu__item">admin shell</div>
+          </aside>
+          <main class="acs-main">
+            <div class="acs-topbar"><span>Admin</span><span>Google admin · sign out</span></div>
+            <div class="acs-outlet">Menu screen outlet<br>No active child screen yet.</div>
+          </main>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <div class="perspective" id="reference">
+    <div class="perspective__header">
+      <span class="glyph">📖</span>
+      <h2>Reference</h2>
+      <span class="lede">Registry and feature docs.</span>
+    </div>
+    <section class="doc">
+      <h2>Sources</h2>
+      <table class="ref">
+        <tbody>
+          <tr><th style="width: 200px;">Screen registry</th><td><code>apps/mds/docs/src/lib/screen-definitions.ts</code></td></tr>
+          <tr><th>Deferred child screens</th><td>Users, Partners, Payments, System, operation dashboards — separate specs TBD.</td></tr>
+          <tr><th>Feature PRD</th><td><code>docs/features/admin/admin-dashboard/prd.md</code></td></tr>
+          <tr><th>Feature spec</th><td><code>docs/features/admin/admin-dashboard/spec.md</code></td></tr>
+          <tr><th>Planned app</th><td><code>apps/admin/</code></td></tr>
+        </tbody>
+      </table>
+    </section>
+  </div>
+</div>
+
+<script>
+const specToggle = document.getElementById('spec-toggle');
+const darkToggle = document.getElementById('dark-toggle');
+specToggle.addEventListener('change', () => document.body.classList.toggle('spec-mode', specToggle.checked));
+darkToggle.addEventListener('change', () => document.body.classList.toggle('dark-mode', darkToggle.checked));
+</script>
+</body>
+</html>

--- a/apps/mds/docs/src/app/screens/page.tsx
+++ b/apps/mds/docs/src/app/screens/page.tsx
@@ -5,14 +5,15 @@ export default function ScreensPage() {
     <div className="max-w-5xl space-y-8">
       <div>
         <p className="text-xs font-bold uppercase tracking-widest text-[var(--color-text-secondary)] mb-2">
-          Route → Screen Index
+          Screen Registry
         </p>
         <h1 className="text-3xl font-bold text-[var(--color-text-primary)] mb-3">Screens</h1>
         <p className="text-[var(--color-text-secondary)]">
-          Every GoRouter route mapped to its screen widget, route declaration, and Dart source.
-          Click a page name to open its MDS spec; use{' '}
+          Screen definitions grouped by surface: app_user, app_partner, and web_admin.
+          Flutter app rows are derived from GoRouter route maps; web_admin starts as a
+          manual registry until its app root exists. Click a screen name to open its MDS spec; use{' '}
           <code className="text-xs bg-[var(--color-surface)] px-1 rounded">code ↗</code>{' '}
-          for the widget source.
+          for implementation source when it exists.
         </p>
       </div>
       <RouteScreenIndex />

--- a/apps/mds/docs/src/components/RouteScreenIndex.tsx
+++ b/apps/mds/docs/src/components/RouteScreenIndex.tsx
@@ -1,102 +1,151 @@
-import { Fragment } from 'react';
-import {
-  getRoutesByApp,
-  widgetNameFor,
-  screenSourceFor,
-  hasDesignFor,
-  designUrlFor,
-  subComponentsFor,
-  standaloneSpecsFor,
-  type SubComponentSpec,
-  type StandaloneSpec,
-} from '@/lib/flow-data';
+import { getScreenGroups, type ScreenDefinition, type ScreenKind } from '@/lib/screen-definitions';
 
-const APP_LABELS = { user: 'app_user', partner: 'app_partner' } as const;
+const KIND_LABELS: Record<ScreenKind, string> = {
+  route: 'route',
+  'sub-component': 'sub',
+  'spec-only': 'spec',
+  'web-route': 'web',
+};
 
-function SubComponentRow({ sub, parentRoute }: { sub: SubComponentSpec; parentRoute: string }) {
-  const sourceUrl = `https://github.com/Mark-Yun/minglit/blob/dev/${sub.filePath}`;
-  const specUrl = `/specs/${sub.specBasename}/index.html`;
+const KIND_CLASS: Record<ScreenKind, string> = {
+  route: 'bg-[var(--color-surface)] text-[var(--color-text-secondary)]',
+  'sub-component': 'bg-[var(--color-primary)]/10 text-[var(--color-primary)]',
+  'spec-only': 'bg-amber-50 text-amber-700',
+  'web-route': 'bg-emerald-50 text-emerald-700',
+};
+
+function githubUrl(path: string): string {
+  return `https://github.com/Mark-Yun/minglit/blob/dev/${path}`;
+}
+
+function KindBadge({ kind }: { kind: ScreenKind }) {
   return (
-    <tr className="hover:bg-[var(--color-surface)] bg-[var(--color-surface)]/30">
-      <td className="px-4 py-2 pl-10">
-        <span className="text-[var(--color-text-secondary)] mr-1">↳</span>
-        <a
-          href={specUrl}
-          className="font-mono text-xs text-[var(--color-primary)] hover:underline"
-          title="Open sub-component spec"
-        >
-          {sub.widget}
-        </a>
-      </td>
-      <td className="px-4 py-2">
-        <span className="font-mono text-xs text-[var(--color-text-secondary)] italic">
-          (sub of {parentRoute})
-        </span>
-      </td>
-      <td className="px-4 py-2">
-        <a
-          href={sourceUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs font-mono text-[var(--color-primary)] hover:underline"
-          title={sub.filePath}
-        >
-          code ↗
-        </a>
-      </td>
-    </tr>
+    <span
+      className={`inline-flex h-5 items-center rounded-full px-2 text-[10px] font-bold uppercase ${KIND_CLASS[kind]}`}
+    >
+      {KIND_LABELS[kind]}
+    </span>
   );
 }
 
-function StandaloneSpecRow({ spec }: { spec: StandaloneSpec }) {
-  const specUrl = `/specs/${spec.specBasename}/index.html`;
+function ScreenNameCell({ screen }: { screen: ScreenDefinition }) {
+  const specUrl = screen.specBasename ? `/specs/${screen.specBasename}/index.html` : null;
+  const name = screen.screen ?? '—';
+
   return (
-    <tr className="hover:bg-[var(--color-surface)] bg-[var(--color-surface)]/30">
-      <td className="px-4 py-2">
+    <div className={screen.kind === 'sub-component' ? 'pl-6' : undefined}>
+      {screen.kind === 'sub-component' ? (
+        <span className="mr-1 text-[var(--color-text-secondary)]">↳</span>
+      ) : null}
+      {specUrl ? (
         <a
           href={specUrl}
           className="font-mono text-xs text-[var(--color-primary)] hover:underline"
-          title="Open spec"
+          title="Open MDS spec"
         >
-          {spec.widget}
+          {name}
         </a>
+      ) : (
+        <span className="font-mono text-xs text-[var(--color-text-secondary)]">{name}</span>
+      )}
+      {screen.note ? (
+        <div className="mt-1 text-xs text-[var(--color-text-secondary)]">{screen.note}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function RouteCell({ screen }: { screen: ScreenDefinition }) {
+  if (screen.routeSourcePath) {
+    return (
+      <a
+        href={githubUrl(screen.routeSourcePath)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-mono text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-primary)] hover:underline"
+        title={screen.routeSourcePath}
+      >
+        {screen.route} ↗
+      </a>
+    );
+  }
+
+  return <span className="font-mono text-xs text-[var(--color-text-secondary)]">{screen.route}</span>;
+}
+
+function CodeCell({ screen }: { screen: ScreenDefinition }) {
+  if (!screen.codeSourcePath) {
+    return <span className="text-xs text-[var(--color-divider)]">—</span>;
+  }
+
+  if (screen.codeSourceExists) {
+    return (
+      <a
+        href={githubUrl(screen.codeSourcePath)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs font-mono text-[var(--color-primary)] hover:underline"
+        title={screen.codeSourcePath}
+      >
+        code ↗
+      </a>
+    );
+  }
+
+  return (
+    <span className="font-mono text-xs text-[var(--color-text-secondary)]">
+      planned: {screen.codeSourcePath}
+    </span>
+  );
+}
+
+function ScreenRow({ screen }: { screen: ScreenDefinition }) {
+  const isSecondary = screen.kind === 'sub-component' || screen.kind === 'spec-only';
+
+  return (
+    <tr className={isSecondary ? 'bg-[var(--color-surface)]/30 hover:bg-[var(--color-surface)]' : 'hover:bg-[var(--color-surface)]'}>
+      <td className="px-4 py-2">
+        <ScreenNameCell screen={screen} />
       </td>
       <td className="px-4 py-2">
-        <span className="font-mono text-xs text-[var(--color-text-secondary)] italic">
-          {spec.note}
-        </span>
+        <RouteCell screen={screen} />
       </td>
       <td className="px-4 py-2">
-        <span className="text-xs text-[var(--color-divider)]">—</span>
+        <KindBadge kind={screen.kind} />
+      </td>
+      <td className="px-4 py-2">
+        <CodeCell screen={screen} />
       </td>
     </tr>
   );
 }
 
 export default function RouteScreenIndex() {
-  const routesByApp = getRoutesByApp();
+  const groups = getScreenGroups();
 
   return (
     <div className="space-y-8">
-      {(['user', 'partner'] as const).map((app) => (
-        <div key={app} className="space-y-3" data-app={app}>
-          <div className="flex items-baseline gap-2">
-            <h3 className="text-lg font-bold text-[var(--color-text-primary)]">
-              {APP_LABELS[app]}
-            </h3>
-            <span className="text-xs text-[var(--color-text-secondary)]">
-              {routesByApp[app].length} routes
+      {groups.map(({ surface, screens }) => (
+        <div key={surface.id} className="space-y-3" data-app={surface.id}>
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <h3 className="text-lg font-bold text-[var(--color-text-primary)]">{surface.label}</h3>
+            <span className="text-xs text-[var(--color-text-secondary)]">{screens.length} screens</span>
+            <span className="basis-full text-xs text-[var(--color-text-secondary)]">
+              {surface.description}
             </span>
           </div>
-          <div className="bg-white rounded-xl border border-[var(--color-divider)] overflow-hidden">
+          <div className="overflow-hidden rounded-xl border border-[var(--color-divider)] bg-white">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-[var(--color-divider)] bg-[var(--color-surface)]">
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[var(--color-text-primary)]">
-                    Screen Widget
+                    Screen
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[var(--color-text-primary)]">
-                    Route
+                    Route / Surface
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[var(--color-text-primary)]">
+                    Kind
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[var(--color-text-primary)]">
                     Code
@@ -104,68 +153,8 @@ export default function RouteScreenIndex() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-[var(--color-divider)]">
-                {routesByApp[app].map((route) => {
-                  const widget = widgetNameFor(app, route);
-                  const screen = screenSourceFor(app, route);
-                  const routesPath = `apps/app_${app}/lib/src/routing/app_routes.dart`;
-                  const routesUrl = `https://github.com/Mark-Yun/minglit/blob/dev/${routesPath}`;
-                  const designUrl = designUrlFor(app, route);
-                  // Sub-components nested under this route — rendered as
-                  // indented rows immediately after the parent row.
-                  const subs = subComponentsFor(app).filter((s) => s.parentRoute === route);
-                  return (
-                    <Fragment key={route}>
-                      <tr className="hover:bg-[var(--color-surface)]">
-                        <td className="px-4 py-2">
-                          {widget && hasDesignFor(app, route) && designUrl ? (
-                            <a
-                              href={designUrl}
-                              className="font-mono text-xs text-[var(--color-primary)] hover:underline"
-                              title="Open design spec"
-                            >
-                              {widget}
-                            </a>
-                          ) : (
-                            <span className="font-mono text-xs text-[var(--color-text-secondary)]">
-                              {widget ?? '—'}
-                            </span>
-                          )}
-                        </td>
-                        <td className="px-4 py-2">
-                          <a
-                            href={routesUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="font-mono text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-primary)] hover:underline"
-                            title={routesPath}
-                          >
-                            {route} ↗
-                          </a>
-                        </td>
-                        <td className="px-4 py-2">
-                          {screen.isWidget ? (
-                            <a
-                              href={screen.url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-xs font-mono text-[var(--color-primary)] hover:underline"
-                              title={screen.filePath}
-                            >
-                              code ↗
-                            </a>
-                          ) : (
-                            <span className="text-xs text-[var(--color-divider)]">—</span>
-                          )}
-                        </td>
-                      </tr>
-                      {subs.map((sub) => (
-                        <SubComponentRow key={sub.widget} sub={sub} parentRoute={route} />
-                      ))}
-                    </Fragment>
-                  );
-                })}
-                {standaloneSpecsFor(app).map((spec) => (
-                  <StandaloneSpecRow key={spec.specBasename} spec={spec} />
+                {screens.map((screen) => (
+                  <ScreenRow key={screen.id} screen={screen} />
                 ))}
               </tbody>
             </table>

--- a/apps/mds/docs/src/lib/screen-definitions.ts
+++ b/apps/mds/docs/src/lib/screen-definitions.ts
@@ -1,0 +1,147 @@
+import {
+  designUrlFor,
+  getRoutesByApp,
+  screenSourceFor,
+  standaloneSpecsFor,
+  subComponentsFor,
+  widgetNameFor,
+} from './flow-data';
+
+export type ScreenSurfaceId = 'user' | 'partner' | 'web_admin';
+
+export type ScreenKind = 'route' | 'sub-component' | 'spec-only' | 'web-route';
+
+export type ScreenStatus = 'specified' | 'missing-spec' | 'planned';
+
+export interface ScreenSurface {
+  id: ScreenSurfaceId;
+  label: string;
+  description: string;
+}
+
+export interface ScreenDefinition {
+  id: string;
+  surface: ScreenSurfaceId;
+  kind: ScreenKind;
+  status: ScreenStatus;
+  screen: string | null;
+  route: string;
+  specBasename?: string;
+  routeSourcePath?: string;
+  codeSourcePath?: string;
+  codeSourceExists?: boolean;
+  parentRoute?: string;
+  note?: string;
+}
+
+export interface ScreenGroup {
+  surface: ScreenSurface;
+  screens: ScreenDefinition[];
+}
+
+export const SCREEN_SURFACES: ScreenSurface[] = [
+  {
+    id: 'user',
+    label: 'app_user',
+    description: 'Consumer Flutter app routes and embedded user-facing screen specs.',
+  },
+  {
+    id: 'partner',
+    label: 'app_partner',
+    description: 'Partner Flutter app routes, operations screens, and partner admin surfaces.',
+  },
+  {
+    id: 'web_admin',
+    label: 'web_admin',
+    description: 'Desktop web admin console screens. Defined manually until apps/admin exists.',
+  },
+];
+
+const WEB_ADMIN_SCREENS: ScreenDefinition[] = [
+  {
+    id: 'web_admin:admin-console-dashboard',
+    surface: 'web_admin',
+    kind: 'web-route',
+    status: 'planned',
+    screen: 'AdminConsoleDashboard',
+    route: '/admin',
+    specBasename: 'admin_console_dashboard',
+    codeSourcePath: 'apps/admin/',
+    codeSourceExists: false,
+    note: 'P0 shell/entry: Supabase Google OAuth login, admin guard, extensible menu frame.',
+  },
+];
+
+function appPathSegment(app: 'user' | 'partner'): 'app_user' | 'app_partner' {
+  return app === 'user' ? 'app_user' : 'app_partner';
+}
+
+function specBasenameFromUrl(url: string | null): string | undefined {
+  const match = url?.match(/^\/specs\/([^/]+)\/index\.html$/);
+  return match?.[1];
+}
+
+function flutterRouteScreens(app: 'user' | 'partner'): ScreenDefinition[] {
+  const routes = getRoutesByApp()[app];
+  const routeSourcePath = `apps/${appPathSegment(app)}/lib/src/routing/app_routes.dart`;
+  const rows: ScreenDefinition[] = [];
+
+  for (const route of routes) {
+    const designUrl = designUrlFor(app, route);
+    const screenSource = screenSourceFor(app, route);
+    const specBasename = specBasenameFromUrl(designUrl);
+
+    rows.push({
+      id: `${app}:${route}`,
+      surface: app,
+      kind: 'route',
+      status: specBasename ? 'specified' : 'missing-spec',
+      screen: widgetNameFor(app, route),
+      route,
+      specBasename,
+      routeSourcePath,
+      codeSourcePath: screenSource.isWidget ? screenSource.filePath : undefined,
+      codeSourceExists: screenSource.isWidget,
+    });
+
+    for (const sub of subComponentsFor(app).filter((s) => s.parentRoute === route)) {
+      rows.push({
+        id: `${app}:${route}:sub:${sub.widget}`,
+        surface: app,
+        kind: 'sub-component',
+        status: 'specified',
+        screen: sub.widget,
+        route: `(sub of ${route})`,
+        specBasename: sub.specBasename,
+        codeSourcePath: sub.filePath,
+        codeSourceExists: true,
+        parentRoute: route,
+      });
+    }
+  }
+
+  for (const spec of standaloneSpecsFor(app)) {
+    rows.push({
+      id: `${app}:standalone:${spec.specBasename}`,
+      surface: app,
+      kind: 'spec-only',
+      status: 'specified',
+      screen: spec.widget,
+      route: 'spec-only',
+      specBasename: spec.specBasename,
+      note: spec.note,
+    });
+  }
+
+  return rows;
+}
+
+export function getScreenGroups(): ScreenGroup[] {
+  return SCREEN_SURFACES.map((surface) => {
+    if (surface.id === 'web_admin') {
+      return { surface, screens: WEB_ADMIN_SCREENS };
+    }
+
+    return { surface, screens: flutterRouteScreens(surface.id) };
+  });
+}

--- a/docs/features/admin/admin-dashboard/prd.md
+++ b/docs/features/admin/admin-dashboard/prd.md
@@ -1,141 +1,109 @@
-# PRD: Admin Dashboard
+# PRD: Admin Console Dashboard
 
 ## Summary
 
-운영팀이 유저·파트너·이벤트·결제·정산을 하나의 웹 대시보드에서 관리할 수 있게 하는 신규 admin 콘솔. 기존 DB 직접 쿼리 / 수동 EF 호출 / Metabase(조회 전용) 의존을 제거하고, 모든 운영 액션을 감사 로그로 추적 가능한 단일 운영 도구를 제공.
+Minglit 내부 운영자가 Supabase Google 로그인으로 본인 확인을 마친 뒤, 서버에서 검증된 admin 권한에 따라 관리자 메뉴를 사용하는 웹 기반 admin console. 현재 출시 범위는 admin 로그인, 권한 확인, 확장 가능한 shell/menu 구조까지다. 기능 dashboard 는 후속 메뉴로 분리하고, 이번 범위에서는 별도 board/spec 를 만들지 않는다.
 
 ## Motivation / Problem to Solve
 
-- 파트너 입점 심사 / 유저 정지 / 환불 처리 등 운영 액션이 DB 직접 접근 또는 수동 EF 호출에 의존
-- Metabase 는 조회 전용 — 운영 "액션" 수행 불가
-- 운영자 액션 감사 로그 부재 — "누가 언제 무엇을 했는지" 추적 불가
-- 출시 전 운영 체계 미비 시 유저 CS 대응 불가 — 출시 필수 인프라
-- 신뢰(Trust) 가치는 운영 효율 향상으로 강화됨 — 빠른 심사 = 파트너 신뢰, 신속한 환불 = 유저 신뢰
+- admin 기능을 메뉴별로 추가할 기준 shell 이 없어, 기능이 늘수록 인증/권한/네비게이션/에러 UX 가 중복될 위험이 있다.
+- admin 접근은 일반 앱 로그인과 분리하지 않되, Supabase Auth 세션과 서버 admin 권한 확인을 모두 통과해야 한다.
+- 첫 메뉴가 무엇이든 동일한 shell contract, route guard, empty/403/session-expired state 를 재사용할 수 있어야 한다.
 
 ## Goals
 
 ### Target Users
 
-- **Super Admin (운영 관리자)**: 서비스 전체 관리. 유저 CS / 파트너 심사 / 결제·정산 / KPI 모니터링.
-- **Moderator (콘텐츠 모더레이터)**: 파트너 심사 + 유저 신고 처리. 결제·정산·시스템 설정 접근 불가.
-- **Finance Admin (재무 담당자, P1)**: 정산·환불 전담. P1 단계에서 역할 분리.
+- **Super Admin**: 모든 admin 메뉴 접근 가능. 향후 유저/파트너/정산/시스템 메뉴까지 관리.
+- **Read-only Admin**: 부여된 메뉴를 조회하지만 destructive action 은 수행하지 않음.
+- **Ops Admin**: 향후 운영 현황, 배포, 심사, 정산 같은 메뉴를 필요 권한에 따라 사용.
 
 ### Key Goals
 
-- **P0**: 로그인 + MFA (TOTP) + 역할 기반 사이드바 렌더링
-- **P0**: 대시보드 홈 — KPI 카드 4개 + 차트 2개 + 액션 큐 2개
-- **P0**: 유저 관리 — 목록 / 검색 / 필터 + 상세 드로어 + 정지 / 해제 액션
-- **P0**: 파트너 심사 — 심사 큐 + 서류 뷰어 + 승인 / 거절 / 보완 요청
-- **P0**: 이벤트 관리 — 목록 / 검색 / 필터 + 강제 취소 / 숨김
-- **P0**: 결제·환불 — 거래 내역 + 수동 환불 (PortOne 연동)
-- **P0**: 정산 관리 — 상태 조회 / 전환 + 지급 처리
-- **P0**: 감사 로그 — 모든 관리 액션 불변 기록 + 조회 UI
-- **P1**: 신고 처리 / 시스템 설정 (정책·약관) / 인증 서류 미리보기 / 일괄 처리 / IP 화이트리스트
+- **P0**: Supabase Auth Google OAuth 로그인 후 admin 권한 확인. 비로그인 / 비관리자는 admin shell 진입 차단.
+- **P0**: 확장 가능한 admin shell. 사이드바 메뉴는 registry 기반으로 추가 가능하고, 각 메뉴는 role / capability 로 노출 여부를 결정한다.
+- **P0**: admin shell 은 메뉴 추가 시 인증/권한/레이아웃/로딩/빈 상태/에러 패턴을 재사용한다.
+- **P0**: 아직 활성 메뉴가 없거나 사용자가 접근 가능한 메뉴가 없을 때 명확한 empty / no-menu 상태를 제공한다.
+- **P1**: 운영 메뉴 추가: 유저 관리, 파트너 심사, 환불/정산, 감사 로그, 시스템 설정.
 
 ### Non-Goals
 
-- **Metabase 대체**: Admin 은 운영 "액션" 도구. 분석 / BI 는 Metabase 유지.
-- **유저·파트너 앱 기능 복제**: 앱에서 가능한 것은 앱에서. Admin 은 운영자 전용 액션만.
-- **자동 심사**: AI 기반 자동 승인 / 거절은 범위 밖. 사람이 판단하고 도구가 실행.
-- **모바일 최적화**: Admin 은 데스크톱 웹 전용. 태블릿은 반응형으로 최소 지원.
-- **다국어**: 초기 버전은 한국어 단일.
+- P0 에서 기능별 운영 dashboard 를 구현하지 않는다.
+- P0 에서 GitHub Actions UI, Vercel UI, Supabase console 을 대체하지 않는다.
+- Supabase service_role key 를 클라이언트에 노출하지 않는다. admin 권한 확인과 외부 API proxy 는 서버에서만 수행한다.
+- 모바일 admin 앱을 만들지 않는다. 데스크톱 웹 우선, 태블릿은 최소 반응형만 지원한다.
 
 ## Product Principles
 
-1. **운영 액션 single source**: 모든 운영 액션은 Admin 을 통해서만 실행. DB 직접 접근 / EF 수동 호출 deprecated.
-2. **모든 액션은 감사 로그**: 누가 / 언제 / 무엇을 / 어떻게 했는지 불변 기록. UPDATE / DELETE 불가.
-3. **역할 분리 (least privilege)**: super_admin / moderator / (P1) finance_admin 별로 가시성 + 액션 권한 분리.
-4. **목록 → 상세 드로어 패턴**: 목록 컨텍스트를 유지한 채 사이드 드로어로 상세 진입. 풀스크린 라우트 이동 최소화.
-5. **확인 다이얼로그 + 감사 코멘트**: 파괴적 액션(정지 / 환불 / 강제 취소 / 정산 지급)은 확인 다이얼로그 필수 + 코멘트 권장.
+1. **Auth first**: 모든 `/admin` route 는 Supabase 세션 확인 후 admin 권한 확인을 통과해야 한다.
+2. **Extensible shell**: 새 기능은 메뉴 모듈로 추가한다. shell 은 nav, page header, permission guard, loading/error, empty state 를 공통 제공한다.
+3. **Server-verified admin**: 클라이언트 role 문자열만으로 admin 권한을 신뢰하지 않는다.
+4. **No leaked menu data**: 권한이 없는 사용자는 메뉴명, route detail, 내부 데이터, 원본 토큰을 보지 못한다.
+5. **Deferred feature screens**: 기능 화면은 별도 screen/spec 로 정의되는 시점에 shell outlet 에 연결한다.
 
 ## Technical Approach
 
-- **신규 웹앱**: Next.js + Shadcn/UI + TanStack Table + Recharts + Supabase Auth (TOTP MFA) + Vercel 배포
-- **데이터 (기존 재사용)**: 유저 프로필 / 파트너 신청 / 파트너 / 파티 / 이벤트 / 이벤트 신청 / 티켓 / 정산 항목 / 지급 / 정산 이력 / 조정 항목 / 일일 대사 / 시스템 설정 / 정책·약관 / 인증 제출 / 시스템 알람 / analytics 일별 집계 테이블
-- **데이터 (신규 1개)**: 관리 액션 감사 로그 테이블 (불변 — UPDATE / DELETE 차단, RLS super_admin SELECT only)
-- **외부 의존성**: PortOne (환불 처리), Supabase Auth Admin (MFA / 세션 관리)
-- **가드 / 정책**: 역할 기반 RLS 정책 + 미들웨어. 세션 타임아웃 유휴 30분 / 절대 8시간
+- **앱**: 별도 Next.js admin app (`apps/admin` 예정). desktop-first admin UI.
+- **인증**: Supabase Auth Google OAuth 로그인. 서버에서 현재 세션의 user 를 확인하고 admin membership / role claim 을 조회한다.
+- **인가**: 메뉴 및 route 는 capability 기반으로 가드한다. 예: `admin.users.read`, `admin.partners.review`, `admin.system.read`.
+- **메뉴 registry**: 각 메뉴는 `id`, `label`, `route`, `requiredCapability`, `status`, `loader/error/empty` contract 를 가진다.
+- **보안 정책**: 클라이언트는 publishable anon key 와 session 만 사용. service_role, GitHub, Vercel token 은 서버 런타임에서만 사용한다.
+- **후속 데이터 소스**: user management, partner review, system operations 등 feature menu 가 확정될 때 각 메뉴의 server loader 에서 별도 정의한다.
 
 ## User Journey
 
-### Scenario 1: 파트너 입점 심사 (CUJ 1-x)
+### Scenario 1: Admin 로그인과 권한 확인 (CUJ 1-x)
 
-운영자가 admin 로그인 후 심사 큐 → 대기 중 신청 진입 → 서류 검토 → 코멘트 입력 → 승인 / 거절 / 보완 요청 처리. 파트너에게 결과 통보.
+운영자가 `/admin` 접속 → Supabase Google 로그인 → 서버가 admin 권한 확인 → 권한 있으면 admin shell 진입, 권한 없으면 403 화면.
 
-### Scenario 2: 유저 정지 / 해제 (CUJ 2-x)
+### Scenario 2: Admin shell 과 메뉴 확장 구조 확인 (CUJ 2-x)
 
-운영자가 유저 관리 → 신고 / 정지 탭에서 대상 유저 검색 → 상세 드로어 → 활동 로그 / 신고 이력 확인 → 정지 / 해제 처리.
+운영자가 admin shell 에 진입 → 서버가 capability set 생성 → 사이드바는 권한 있는 메뉴만 표시 → 아직 활성 메뉴가 없으면 shell empty state 를 표시 → 향후 메뉴가 같은 레이아웃과 route guard 로 추가됨.
 
-### Scenario 3: 결제 / 환불 처리 (CUJ 3-x)
+### Scenario 3: 권한 없는 메뉴 접근 차단 (CUJ 3-x)
 
-운영자가 결제 / 환불 → 환불 요청 큐 진입 → 원결제 정보 / 환불 사유 확인 → 환불 금액 입력 → PortOne 으로 환불 처리.
-
-### Scenario 4: 정산 관리 (CUJ 4-x)
-
-운영자가 정산 관리 → 미정산 건 필터링 → 일괄 선택 → 일괄 확정 / 지급 처리 → 정산 이력 확인.
-
-### Scenario 5: 대시보드 홈 + KPI 모니터링 (CUJ 5-x)
-
-운영자가 로그인 직후 대시보드 홈 진입 → KPI 카드 (활성 유저 / 대기 심사 / 오늘 매출 / 미정산) 확인 → 액션 큐에서 최신 대기 건 진입.
-
-### Scenario 6: 감사 로그 검수 (CUJ 6-x)
-
-운영자 / 감사 담당자가 시스템 → 감사 로그 → 관리자 / 액션 유형 / 대상 / 날짜 범위 필터 → 변경 전·후 값 확인.
+운영자가 직접 route 로 접근하거나 메뉴 권한이 변경됨 → 서버가 route capability 를 재검증 → 권한 없으면 403 또는 접근 가능한 기본 메뉴/no-menu 상태로 전환.
 
 ## Data Flow
 
 ### Scenario 1
 
-대시보드 액션 큐 또는 사이드바 "입점 심사" → 심사 큐 → 신청 카드 탭 → 심사 상세 (서류 뷰어 + 코멘트 + 액션 버튼) → 액션 확정 → 서버에서 신청 상태 변경 + 감사 로그 insert + 파트너 푸시 / 이메일 통보
+`/admin` 진입 → Supabase session 확인 → 없으면 login → Google OAuth callback → 서버에서 admin membership / role 조회 → capability set 생성 → shell 렌더링 또는 403.
 
 ### Scenario 2
 
-유저 관리 → 검색 / 필터 → 유저 row 탭 → 상세 드로어 (프로필 / 이벤트 / 결제 / 인증 / 활동 / 액션) → "정지" 버튼 → 확인 다이얼로그 + 코멘트 → 서버에서 유저 상태 변경 + 감사 로그 insert
+Shell bootstrap → menu registry 로드 → 현재 admin capability 와 매칭 → 노출 가능한 메뉴만 sidebar 에 렌더링 → 활성 메뉴가 없으면 no-menu empty state 표시.
 
 ### Scenario 3
 
-결제·환불 → 환불 처리 → 대기 큐 → 환불 row 탭 → 처리 뷰 (원결제 / 사유 / 환불 금액) → "환불 실행" → PortOne 환불 API 호출 → 성공 시 환불 완료 상태 + 감사 로그 insert
-
-### Scenario 4
-
-정산 관리 → 상태 필터 → 체크박스 선택 → "일괄 확정" 또는 "일괄 지급 처리" → 확인 다이얼로그 → 서버 일괄 처리 + 감사 로그 insert (건별)
-
-### Scenario 5
-
-로그인 → MFA → 홈 진입 → KPI 카드는 analytics 집계 테이블에서 fetch, 액션 큐는 신청 / 신고 최신 5건 fetch
-
-### Scenario 6
-
-시스템 → 감사 로그 → 필터 적용 → 페이지네이션 조회. 모든 행은 read-only.
+Deep-link 또는 메뉴 이동 → route capability 서버 재검증 → 허용 시 해당 menu outlet 렌더링 → 거부 시 민감 데이터 fetch 없이 403/no-menu 처리.
 
 ## KPIs / Success Metrics
 
-- **파트너 심사 완료 시간**: 신청 접수 → 승인 / 거절까지 평균 24시간 이내 (현재: 수일)
-- **환불 처리 시간**: 요청 접수 → 처리 완료까지 평균 1시간 이내
-- **운영자 실수율**: 잘못된 승인 / 거절 / 환불 / 정지 비율 — baseline 측정 후 감시
-- **Admin 페이지 로딩 시간**: 3초 이내 유지 (가드레일)
-- **감사 로그 누락률**: 0% 유지 (가드레일)
+- **권한 차단 정확성**: 비관리자 admin shell 접근 0건.
+- **메뉴 추가 비용**: 새 read-only admin 메뉴 추가 시 shell/auth/permission 코드 재작성 없음.
+- **로그인 성공률**: Google OAuth callback 이후 admin 권한 확인 성공/실패 상태가 100% 명확히 분기.
+- **민감 데이터 노출**: 인증/인가 실패 경로에서 내부 메뉴 데이터 및 server token 노출 0건.
 
 ## Launch Strategy
 
-P0 8개 화면을 단계별 ship — (1) 로그인·MFA·감사로그 인프라 → (2) 대시보드 홈 + 유저 관리 → (3) 파트너 심사 → (4) 이벤트 / 결제·환불 / 정산 → (5) P1 신고 / 시스템 설정 / 일괄 처리. 출시일 2026년 6월 (가상 보도자료 기준).
+1. **P0-A**: admin shell + Supabase Google login/admin guard + 403/expired-session/no-menu state.
+2. **P0-B**: menu registry + capability 기반 sidebar/outlet contract.
+3. **P1**: 첫 후속 운영 메뉴를 별도 spec/board 로 작성.
+4. **P1+**: 유저 관리, 파트너 심사, 환불/정산, 시스템 설정, 감사 로그를 메뉴 모듈로 순차 추가.
 
-## Legal Basis
+## Legal / Security Basis
 
 | 근거 | 내용 |
 |------|------|
-| 개인정보보호법 제29조 | 안전성 확보 조치 — 접근 제어 / 로그 관리 / MFA |
-| 개인정보보호법 제30조 | 처리방침 — 운영자 접근 / 감사 로그 정책 공개 |
-| 전자상거래법 제18조 | 환불 처리 의무 — 자동·수동 환불 모두 영업일 3일 |
-| 정보통신망법 제48조 | 침해 사고 대응 — 감사 로그를 통한 사후 추적 |
+| 개인정보보호법 제29조 | 관리자 접근 제어, 권한 분리, 접속 기록 관리 |
+| 내부 운영 보안 | Supabase Auth 세션 + admin membership 확인 없이는 admin route 접근 금지 |
+| 최소 권한 원칙 | read-only / write capability 분리, 메뉴별 접근 제한 |
+| 감사 가능성 | 후속 write action 부터 수행자 / 시각 / 대상 / 결과 기록 |
 
 ## References
 
-- **Stripe Dashboard**: KPI 카드 + 스파크라인 / 사이드 드로어 상세 / shimmer 로딩
-- **Shopify Admin (Polaris)**: 축소형 사이드바 / 7-item 제한 / 명사형 네비게이션
-- **Linear**: 상태 파이프라인 / 키보드 퍼스트 / 최소 UI — 심사 큐 워크플로우
-- **Retool / Appsmith**: 서버사이드 필터 / 정렬 / 페이지네이션 + 일괄 액션
-- **Airbnb Host Dashboard**: 파트너 퍼포먼스 뷰 + 심사 워크플로우
-- Working Backwards (Ian McAllister / Amazon) — PR/FAQ 프로세스
-- Inspired (Marty Cagan / SVPG)
-- Minglit Architecture — Section 5 (Trust & Verification)
+- `apps/mds/docs/public/specs/admin_console_dashboard/` — admin login + shell MDS spec
+- Supabase Auth Google OAuth docs — admin login provider
+- Supabase Auth MFA docs — 후속 보안 강화 후보
+- `docs/features/admin/statistics-tools/` — 기존 analytics / alert 도구와 후속 연계

--- a/docs/features/admin/admin-dashboard/spec.md
+++ b/docs/features/admin/admin-dashboard/spec.md
@@ -1,239 +1,124 @@
-# Spec: Admin Dashboard
+# Spec: Admin Console Dashboard
 
 > **참조**
-> - PRD: [prd.md](./prd.md)
+> - PRD: `docs/features/admin/admin-dashboard/prd.md`
 > - MDS specs:
->   - Admin 콘솔 화면 — 디자인 TODO (MDS spec 미생성, Stripe / Shopify / Linear 패턴 준용 — Shadcn/UI 라이브러리 컴포넌트로 구성)
+>   - `apps/mds/docs/public/specs/admin_console_dashboard/` — Supabase Google OAuth login, admin guard, extensible admin shell
+> - Apps:
+>   - 계획: `apps/admin/` — Next.js admin console
+> - Backend EFs:
+>   - P0: 해당 없음 — 서버 route/API 에서 Supabase 세션과 admin membership/capability 검증
+> - CUJ tests:
+>   - 계획: `apps/admin/e2e/cuj/admin_dashboard.spec.ts`
 
 ## CUJs
 
-> CUJ ID 컨벤션: `<scenario>-<cuj>` (예: `1-1` = PRD Scenario 1 의 첫 CUJ). 새 CUJ 추가 시 본 테이블 row 추가 + 통합 테스트 cujGroup 블록 추가.
-
 | ID  | Priority | CUJ Name | Details | FR | NFR |
 |-----|----------|----------|---------|----|----|
-| 1-1 | P0 | 운영자가 심사 큐에서 신청 진입 | • 사이드바 "입점 심사" 탭<br>• 심사 큐(대기 / 승인 / 거절 / 보완) summary bar 노출<br>• "대기" 클릭 → 카드 목록 (우선순위 / 업체명 / 사업자번호 / 제출일 / 카테고리) | FR-1, FR-7 | NFR-1, NFR-2 |
-| 1-2 | P0 | 심사 상세에서 서류 검토 + 승인 | • 카드 탭 → 심사 상세 (좌측 서류 뷰어 / 우측 액션)<br>• 사업자등록증 / 신분증 미리보기<br>• 코멘트 입력 → "승인" 탭 → 확인 다이얼로그 → 신청 상태 변경 + 감사 로그 + 파트너 통보 | FR-7, FR-8, FR-9 | NFR-3 |
-| 1-3 | P0 | 거절 / 보완 요청 처리 | • 거절 사유 선택 (드롭다운) + 코멘트<br>• 보완 요청 시 어떤 서류 / 항목 필요한지 명시<br>• 확인 다이얼로그 → 신청 상태 변경 + 파트너 통보 | FR-7, FR-8, FR-9 | NFR-3 |
-| 2-1 | P0 | 유저 검색 + 상세 드로어 진입 | • 사이드바 "유저 관리"<br>• username / phone / email 통합 검색<br>• row 클릭 → 사이드 드로어 (프로필 / 이벤트 / 결제 / 인증 / 활동 로그 / 액션 탭) | FR-10, FR-11 | NFR-1 |
-| 2-2 | P0 | 유저 정지 처리 | • 액션 탭 → "정지" 버튼<br>• 정지 사유 선택 + 코멘트 + 기간(영구 / N일) 입력<br>• 확인 다이얼로그 → 상태 변경 + 감사 로그 + 유저 통보 | FR-12, FR-9 | NFR-3 |
-| 2-3 | P0 | 유저 정지 해제 | • 정지 유저 상세 → "정지 해제"<br>• 해제 사유 + 확인 → 상태 변경 + 감사 로그 | FR-12, FR-9 | NFR-3 |
-| 3-1 | P0 | 환불 요청 큐 진입 + 처리 | • 사이드바 "환불 처리"<br>• 대기 큐 (요청자 / 이벤트 / 금액 / 사유)<br>• row 탭 → 처리 뷰 (원결제 정보 / 사유 / 환불 금액 입력) | FR-13, FR-14 | NFR-1, NFR-4 |
-| 3-2 | P0 | 환불 실행 (PortOne 호출) | • "환불 실행" → 확인 다이얼로그 → PortOne 환불 API 호출<br>• 성공 시 상태 = 환불 완료 + 감사 로그 + 유저 푸시<br>• 실패 시 토스트 + 재시도 가능 | FR-14, FR-15, FR-9 | NFR-4 |
-| 3-3 | P1 | 부분 환불 처리 | • 환불 금액을 결제 금액보다 작게 입력<br>• 사유 필수 입력<br>• PortOne 부분 환불 호출 | FR-14 | NFR-4 |
-| 4-1 | P0 | 미정산 건 일괄 확정 | • 사이드바 "정산 관리"<br>• 상태 필터 = 대기, 정산 기간 필터<br>• 체크박스 다중 선택 → "일괄 확정" | FR-16, FR-17 | NFR-3 |
-| 4-2 | P0 | 일괄 지급 처리 | • 확정 상태 선택 → "일괄 지급 처리"<br>• 확인 다이얼로그 (총 건수 / 총 금액) → 지급 정보 검증 → 일괄 처리<br>• 건별 감사 로그 | FR-17, FR-9 | NFR-3, NFR-5 |
-| 5-1 | P0 | 로그인 + MFA 후 홈 진입 | • 로그인 화면 → 이메일 / 비밀번호 + TOTP 코드<br>• 역할 기반 사이드바 렌더링<br>• 홈에 KPI 카드 4종 + 차트 2종 + 액션 큐 2종 노출 | FR-2, FR-3, FR-18 | NFR-1, NFR-6 |
-| 5-2 | P0 | 액션 큐에서 최신 대기 건 진입 | • 홈 액션 큐 (모더레이션 / 파트너 입점 최신 5건)<br>• row 탭 → 해당 상세 화면 이동 | FR-18 | NFR-1 |
-| 5-3 | P1 | KPI 카드 → 상세 페이지 이동 | • "대기 중 심사 12건" 카드 → 심사 큐 프리필터 진입<br>• "미정산 N건" → 정산 관리 프리필터 진입 | FR-18 | NFR-1 |
-| 6-1 | P0 | 감사 로그 필터 조회 | • 사이드바 "감사 로그"<br>• 관리자 / 액션 유형 / 대상 / 날짜 범위 필터<br>• 페이지네이션으로 조회 (모든 행 read-only) | FR-19, FR-20 | NFR-1, NFR-6 |
-| 6-2 | P0 | 감사 로그 행 상세 — 변경 전/후 값 | • 로그 row 탭 → 사이드 드로어<br>• 변경 전 / 후 값 diff 표시<br>• IP / User-Agent / 시각 정보 | FR-19 | NFR-1 |
-| 7-1 | P0 | 이벤트 강제 취소 | • 이벤트 관리 → 상세 → "강제 취소" 버튼<br>• 사유 입력 + 확인 다이얼로그<br>• 신청자 전원 환불 트리거 + 감사 로그 | FR-21, FR-15, FR-9 | NFR-4 |
-| 7-2 | P1 | 이벤트 숨김 처리 | • 신고 또는 정책 위반 시 "숨김 처리"<br>• 검색 / 추천에서 제외, 기존 신청자에게는 노출 유지 | FR-21 | NFR-3 |
+| 1-1 | P0 | 비로그인 사용자는 admin 로그인으로 이동 | • `/admin` 직접 접근<br>• Supabase session 없음<br>• admin login 화면 표시<br>• shell/menu/data fetch 미실행 | FR-1, FR-2 | NFR-1, NFR-5 |
+| 1-2 | P0 | Supabase Google 로그인 후 admin shell 진입 | • "Google로 로그인" 탭<br>• Supabase OAuth redirect 완료<br>• 서버가 현재 Supabase user 의 admin 권한 확인<br>• 권한 있으면 `/admin` shell 표시 | FR-1, FR-2, FR-3 | NFR-1, NFR-5 |
+| 1-3 | P0 | 로그인했지만 admin 이 아닌 사용자는 403 | • Supabase session 은 있음<br>• admin 권한 없음<br>• 403 화면 노출<br>• sidebar/menu/internal data 미노출 | FR-3, FR-4 | NFR-5 |
+| 1-4 | P0 | 세션 만료 시 재로그인 요구 | • shell 사용 중 session 만료<br>• 다음 fetch 에서 auth error<br>• admin 데이터를 숨기고 재로그인 안내<br>• 재로그인 후 원래 route 복귀 시도 | FR-5 | NFR-1, NFR-5 |
+| 2-1 | P0 | 권한 기반 메뉴 렌더링 | • shell bootstrap<br>• menu registry 와 admin capability 비교<br>• 권한 있는 메뉴만 sidebar 노출<br>• active/coming_soon/hidden 상태 구분 | FR-6, FR-7 | NFR-1, NFR-2 |
+| 2-2 | P0 | 사용 가능한 메뉴가 없으면 no-menu 상태 표시 | • admin 권한은 있음<br>• 현재 capability 에 매칭되는 active 메뉴 없음<br>• shell 은 유지하고 content outlet 에 no-menu empty state 표시 | FR-7, FR-8 | NFR-1 |
+| 2-3 | P0 | 후속 메뉴 placeholder 는 shell 재작성 없이 연결 가능 | • 새 menu item 정의<br>• route/page/outlet 연결<br>• 공통 page header/loading/error/empty 패턴 재사용 | FR-6, FR-8 | NFR-2 |
+| 3-1 | P0 | 권한 없는 메뉴 deep-link 차단 | • `/admin/users` 같은 권한 외 route 직접 접근<br>• capability 재검증<br>• 민감 데이터 fetch 없이 403 또는 no-menu/default 처리 | FR-4, FR-6 | NFR-5 |
+| 3-2 | P0 | 권한 변경 후 메뉴/route 갱신 | • 사용 중 admin capability 회수<br>• 다음 route transition 또는 refresh 시 서버 재검증<br>• 기존 menu data 숨김<br>• 403 또는 no-menu 상태 표시 | FR-4, FR-5, FR-6 | NFR-5 |
 
 ## Functional Requirements
 
-> 제품 행동 정의 — DB schema / 컴포넌트 이름 같은 dev detail 은 제외 (코드가 SSoT).
-
-- **FR-1**: 사이드바는 역할(super_admin / moderator)에 따라 항목 가시성을 제어. moderator 는 결제 / 정산 / 시스템 설정 / 감사 로그 항목 비노출.
-- **FR-2**: 로그인은 이메일 / 비밀번호 + TOTP MFA 필수. TOTP 미설정 사용자는 첫 로그인 시 등록 단계 강제.
-- **FR-3**: 세션은 유휴 30분 / 절대 8시간 후 만료. 만료 시 재로그인.
-- **FR-7**: 심사 큐는 4개 상태(대기 / 승인 / 거절 / 보완 요청)로 분리. summary bar 에 각 상태 건수 노출, 클릭 시 프리필터 적용.
-- **FR-8**: 심사 상세는 좌측 서류 뷰어(이미지 / PDF 인라인 미리보기) + 우측 액션 영역(관리자 코멘트 + 승인 / 거절 드롭다운 / 보완 요청 버튼) 2분할 레이아웃.
-- **FR-9**: 모든 관리 액션(승인 / 거절 / 보완 / 정지 / 해제 / 환불 / 정산 확정 / 지급 / 이벤트 강제 취소 / 시스템 설정 변경)은 감사 로그에 불변 기록 — 관리자 / 액션 유형 / 대상 / 변경 전·후 값 / IP / 시각.
-- **FR-10**: 유저 목록은 username / phone / email 통합 검색 + 인증 상태 / 활성 상태 / 성별 / 가입일 범위 필터 + 서버사이드 페이지네이션(25건) + 모든 컬럼 정렬 토글.
-- **FR-11**: 유저 상세는 사이드 드로어 패턴 — 목록 컨텍스트 유지. 프로필 / 이벤트 / 결제 / 인증 / 활동 로그 / 관리 액션 6개 탭.
-- **FR-12**: 유저 정지는 사유(드롭다운) + 코멘트 + 기간(영구 / N일) 입력. 정지 해제는 사유 + 코멘트.
-- **FR-13**: 환불 처리 화면은 대기 큐 + 처리 뷰 2단계. 대기 큐는 요청 일자 / 금액 / 사유 정렬.
-- **FR-14**: 환불 실행 시 PortOne 환불 API 호출. 부분 환불 지원 (결제 금액 이하 입력 시).
-- **FR-15**: 환불 실패 시 토스트 + 재시도 버튼 + 실패 사유 표시. 실패도 감사 로그 기록.
-- **FR-16**: 정산 관리는 상태(대기 / 확정 / 지급 / 취소) / 정산 기간 / 파트너 필터 + 체크박스 다중 선택.
-- **FR-17**: 일괄 처리(확정 / 지급)는 확인 다이얼로그에 총 건수 + 총 금액 표시. 건별 감사 로그 기록. 부분 실패 시 성공 / 실패 건 분리 표시.
-- **FR-18**: 대시보드 홈은 KPI 카드 4종(활성 유저 7일 / 대기 중 심사 / 오늘 매출 / 미정산 건) + 차트 2종(이벤트 신청 stacked bar 30일 / 매출 line 30일) + 액션 큐 2종(모더레이션 최신 5건 / 입점 심사 최신 5건). 각 카드 / 큐는 클릭 시 해당 상세 화면 이동.
-- **FR-19**: 감사 로그는 관리자 / 액션 유형 / 대상 / 날짜 범위 필터 + 페이지네이션. 모든 행 read-only. 행 탭 시 사이드 드로어로 변경 전 / 후 값 diff + 메타 정보 표시.
-- **FR-20**: 감사 로그는 super_admin 만 SELECT 가능. moderator 등 다른 역할은 접근 불가.
-- **FR-21**: 이벤트 관리는 검색(이벤트명 / 파트너명) + 필터(상태 / 날짜 범위 / 파트너 / 카테고리). 액션은 "강제 취소" / "숨김 처리" 2종 — 모두 확인 다이얼로그 필수.
+- **FR-1**: Admin console 은 Supabase Auth Google OAuth 로그인을 허용한다.
+- **FR-2**: `/admin` 진입 시 Supabase session 이 없으면 login 화면을 표시한다. 이 상태에서는 admin shell, menu registry, 내부 메뉴 데이터 요청이 발생하지 않는다.
+- **FR-3**: 로그인 후 서버가 현재 사용자의 admin membership / role claim 을 확인한다. 클라이언트가 들고 있는 role 문자열만으로 admin 권한을 신뢰하지 않는다.
+- **FR-4**: admin 권한이 없거나 route capability 가 부족하면 403 화면을 표시한다. 권한 없는 메뉴명, 내부 데이터, 원본 토큰은 노출하지 않는다.
+- **FR-5**: 세션 만료 또는 refresh 실패 시 현재 admin 데이터를 숨기고 재로그인을 요구한다. 재로그인 성공 시 원래 route 로 복귀를 시도한다.
+- **FR-6**: 각 admin menu 는 `id`, `label`, `route`, `requiredCapability`, `status`(active / coming_soon / hidden)를 가진다. sidebar 는 capability 와 status 기준으로 렌더링한다.
+- **FR-7**: P0 는 특정 기능 board 를 활성 메뉴로 고정하지 않는다. 사용 가능한 active 메뉴가 없으면 no-menu empty state 를 표시한다.
+- **FR-8**: Shell 은 공통 AppBar, Sidebar, Breadcrumb, PageHeader, Loading, Empty, Error, 403, SessionExpired state 를 제공한다.
 
 ## Non-Functional Requirements
 
-> 측정 가능해야 함 — "빨라야 함" 금지. 환경 + 분위수 명시.
-
-- **NFR-1**: Admin 페이지 first contentful paint 3s 이내 (프로덕션 CDN, p75, 데스크톱 + 광대역). 목록 데이터 fetch 포함.
-- **NFR-2**: 심사 큐 25건 fetch + 렌더링 1.5s 이내 (p95).
-- **NFR-3**: 관리 액션(승인 / 정지 / 환불 / 정산 등) 응답 1.5s 이내 (p95). 응답 후 감사 로그 insert 누락률 0%.
-- **NFR-4**: PortOne 환불 API 성공률 99% 이상 (월간 baseline). 실패 시 재시도 로직 + 운영팀 알림.
-- **NFR-5**: 일괄 처리는 1회 최대 100건. 100건 초과 시 페이지 분할 안내. 처리 시간은 100건 기준 10s 이내 (p95).
-- **NFR-6**: 인증·인가 — 비로그인 사용자가 /admin 경로 접근 시 로그인 화면 redirect. 권한 없는 사용자가 권한 외 라우트 접근 시 403 페이지. 모든 API 호출은 세션 검증.
-- **NFR-7**: 접근성 — 키보드 내비게이션 (탭 순서 / 모달 포커스 트랩) + 색상 대비 4.5:1 이상 + ARIA 라벨.
+- **NFR-1**: Admin shell first contentful paint 2.5s 이내 (프로덕션 CDN, desktop broadband, p75). Supabase session 확인 포함.
+- **NFR-2**: 새 read-only 메뉴 추가 시 shell/auth/permission/layout 공통 코드를 수정하지 않고 menu registry + route/page 추가만으로 연결 가능해야 한다.
+- **NFR-3**: Desktop-first layout 은 1280px 이상에서 sidebar + topbar + content outlet 을 한 화면에 유지하고, tablet width 에서는 sidebar collapse 또는 compact state 를 제공한다.
+- **NFR-4**: 접근성 — sidebar/menu/dialog/empty/403 state 는 키보드 탐색 가능, 포커스 순서 준수, 색상 대비 4.5:1 이상.
+- **NFR-5**: 인증/인가 실패 시 민감 데이터 노출 0건. 서버 API 는 매 요청마다 Supabase session 과 capability 를 검증한다.
 
 ## Edge Cases
 
 | CUJ ID | 케이스 | 기대 동작 |
 |--------|--------|----------|
-| 1-1 | 심사 큐가 0건 | "처리할 심사 건이 없습니다" 빈 상태 메시지 |
-| 1-2 | 승인 도중 다른 운영자가 동일 신청 처리 | 서버에서 충돌 감지 → "이미 처리된 신청입니다" 토스트 + 큐 재조회 |
-| 1-2 | 서류 파일 로딩 실패 | "서류를 불러올 수 없습니다" + 다운로드 링크 fallback |
-| 1-3 | 거절 사유 미선택 시 제출 | 제출 버튼 비활성 |
-| 2-1 | 검색 결과 0건 | 빈 상태 + 필터 초기화 버튼 |
-| 2-2 | 정지 도중 유저가 동시에 결제 시도 | 정지 처리 우선 — 결제는 차단 |
-| 2-2 | 영구 정지 후 해제 | 해제 후 다시 활성 상태로 복귀. 정지 이력은 감사 로그에 영구 보존 |
-| 3-1 | 대기 환불 0건 | 빈 상태 |
-| 3-2 | PortOne 호출 실패 (PG 에러) | 재시도 + 실패 사유 표시. 실패 감사 로그 기록 |
-| 3-2 | 환불 실행 도중 운영자 세션 만료 | 재로그인 후 큐 재진입. 환불 상태는 서버에서 판별 |
-| 3-3 | 부분 환불 금액이 원결제 금액 초과 | 입력 검증 → 제출 차단 |
-| 4-1 | 일괄 선택 100건 초과 | 선택 시점에 경고 + 100건 이하로 자동 잘림 안내 |
-| 4-2 | 지급 정보 검증 실패 (계좌 오류) | 해당 건만 실패 표시. 나머지는 정상 처리 |
-| 5-1 | 처음 로그인 + TOTP 미설정 | TOTP 등록 화면 강제 진입 → QR 스캔 → 코드 검증 후 홈 진입 |
-| 5-2 | 액션 큐 데이터 fetch 실패 | 카드별 에러 표시 + 재시도 버튼 |
-| 6-1 | 필터 조합으로 결과 0건 | 빈 상태 + "조건에 맞는 로그가 없습니다" |
-| 6-1 | 30일 초과 기간 필터 | 성능 보호 — 최대 30일 안내 + 자동 조정 |
-| 7-1 | 강제 취소 도중 일부 환불 PortOne 실패 | 실패 건은 재시도 큐 + 운영팀 알림. 이벤트 상태는 취소로 확정 |
+| 1-1 | `/admin` deep-link 로 비로그인 접근 | login 화면 표시, OAuth 성공 후 원래 route 복귀 시도 |
+| 1-2 | Google OAuth redirect 실패 | login 화면 유지 + "Google 로그인을 완료하지 못했습니다" 에러 |
+| 1-3 | 일반 유저가 로그인한 상태로 `/admin` 접근 | 403 화면. sidebar/menu/internal data 미노출 |
+| 1-4 | shell outlet 사용 중 세션 만료 | outlet 데이터 숨김, 재로그인 요구 |
+| 2-1 | capability 가 하나도 없는 admin role | 403 대신 "사용 가능한 관리자 메뉴가 없습니다" 상태 표시 |
+| 2-2 | coming soon 메뉴 클릭 | "준비 중인 메뉴입니다" empty state, route 는 유지 가능 |
+| 2-3 | 후속 메뉴 route 는 있으나 page module 이 아직 없음 | shell 은 유지하고 해당 menu 의 unavailable/coming soon state 표시 |
+| 3-1 | 숨겨진 route 직접 접근 | 서버 capability 재검증 후 403 |
+| 3-2 | 메뉴를 보는 중 권한이 회수됨 | 다음 fetch/transition 에서 데이터 숨김 + 403/no-menu 처리 |
 
 ## Open Questions
 
-> 결정 못한 항목 — 1주 이상 방치 시 명시적으로 결정 또는 Non-Goal 로 이동.
-
-- [ ] **Finance Admin 역할 분리 시점** — P1 vs P2 (정산 일 + 환불 일이 super_admin 1인에 집중되면 부담)
-- [ ] **IP 화이트리스트 적용 범위** — P1 모든 사용자 강제 vs 선택적
-- [ ] **TOTP 외 백업 코드 발급** — 디바이스 분실 시 복구 절차
-- [ ] **부분 환불 정책** — 금액 자유 입력 vs 결제액의 N% 단위 선택
-- [ ] **일괄 처리 최대 건수** — 100건 적정 vs 200 / 500
-- [ ] **moderator 역할의 환불 / 정산 가시성** — 읽기 권한도 제외 vs 읽기는 허용
-- [ ] **감사 로그 보존 기간** — 영구 vs 5년 (저장 비용 vs 감사 요건)
-- [ ] **세션 타임아웃 30분 적정성** — 운영 현장 패턴 baseline 수집 후 조정
+- [ ] Admin app 위치를 `apps/admin` 으로 확정할지, 기존 landing/admin path 에 얹을지 결정.
+- [ ] Supabase admin membership source: JWT custom claim, `admin_members` 테이블, 또는 둘의 조합 중 선택.
+- [ ] P1 보안 강화에서 Supabase MFA(TOTP / phone factor)를 언제 켤지 결정.
+- [ ] 첫 후속 운영 메뉴를 무엇으로 둘지 결정.
+- [ ] Admin MDS spec 작성 시 web Shadcn 스타일을 MDS 토큰으로 감쌀지, 별도 admin design token 을 둘지 결정.
 
 ---
 
 ## 화면 구성 (참고)
 
-> dev 가 아닌 product/UX detail 만. Stripe / Shopify / Linear 패턴 준용.
+### 정보 구조
 
-### 정보 구조 (사이드바)
-
-```
-Admin Dashboard
-├── 대시보드 (홈)           ← 모든 역할
-├── 유저 관리               ← super_admin
-│   ├── 전체 유저
-│   ├── 인증 완료 유저
-│   └── 신고/정지 유저
-├── 파트너 관리             ← super_admin, moderator
-│   ├── 활성 파트너
-│   ├── 입점 심사            ← 심사 큐
-│   └── 정산 관리            ← super_admin only
-├── 이벤트 관리             ← super_admin
-├── 결제/환불               ← super_admin
-├── 모더레이션              ← super_admin, moderator
-├── 시스템                  ← super_admin only
-│   ├── 감사 로그
-│   ├── 시스템 설정
-│   └── 알림/알람
-└── 설정                    ← super_admin only
-    └── 관리자 계정/역할
+```text
+Admin Console
+├── Login / Admin Guard            P0
+├── Shell                          P0
+│   ├── Sidebar(menu registry)
+│   ├── Topbar(account/sign out)
+│   ├── Page header
+│   ├── Content outlet
+│   └── Shared states
+│       ├── Loading
+│       ├── Empty / no-menu
+│       ├── Error
+│       ├── 403
+│       └── Session expired
+├── Users                          P1 candidate
+├── Partners                       P1 candidate
+├── Payments / Refunds             P1 candidate
+├── Settlements                    P1 candidate
+├── System                         P1 candidate
+└── Audit Logs                     P1 candidate
 ```
 
-> Stripe 3-tier + Shopify 7-item 제한. 역할별 가시성 제어.
+### 화면 1: Login / Admin Guard
 
-### 화면 1: 대시보드 홈
+| State | 조건 | 표시 |
+|-------|------|------|
+| Login | Supabase session 없음 | "Google로 로그인" button |
+| OAuth callback | Google OAuth redirect 완료 | session exchange + redirect |
+| Checking role | session 확보, admin 권한 조회 중 | centered progress + "권한을 확인하고 있습니다" |
+| 403 | session 있음, admin 권한 없음 | 권한 없음 설명 + sign out |
+| Expired | 사용 중 session 만료 | 재로그인 CTA |
 
-| Row | 컨텐츠 |
-|-----|--------|
-| Row 1 (KPI 4 카드) | 활성 유저 7일 + 스파크라인 / 대기 중 심사 + 큐 링크 / 오늘 매출 + 전일 대비 % / 미정산 건 + 총 금액 |
-| Row 2 (차트 2) | 이벤트 신청 stacked bar (승인 / 대기 / 거절) 30일 / 매출 line 30일 |
-| Row 3 (액션 큐 2) | 모더레이션 큐 최신 5건 / 파트너 입점 심사 최신 5건 |
+### 화면 2: Admin Shell
 
-### 화면 2: 유저 관리
+| 영역 | 표시 |
+|------|------|
+| Sidebar | 권한 있는 메뉴만 표시. active/coming soon/hidden 상태 구분 |
+| Top bar | admin account, sign out, global action slot |
+| Page header | title, subtitle, last updated/action slot |
+| Content | 활성 메뉴 page 또는 no-menu empty state |
+| Shared states | loading, empty, error, 403, session expired |
 
-**목록**: 통합 검색 + 필터 바 + 테이블 (프로필 / username / 성별 / 나이 / 인증 뱃지 / 가입일 / 최근 활동 / 이벤트 참여 수) + 서버사이드 페이지네이션.
+### Data Definitions
 
-**상세 (사이드 드로어)**:
-
-| 탭 | 내용 |
-|----|------|
-| 프로필 | 기본 정보, CI/DI 인증 상태, 가입일 |
-| 이벤트 | 참여한 이벤트 목록 |
-| 결제 | 거래 내역, 환불 이력 |
-| 인증 | 파트너별 인증 제출 내역 |
-| 활동 로그 | 조회 / 좋아요 / 구매 등 주요 활동 |
-| 관리 액션 | [정지] [정지 해제] [인증 초기화] — super_admin only |
-
-### 화면 3: 파트너 심사
-
-**심사 큐 (Linear 워크플로우 패턴)**: 상태 파이프라인 (대기 → 승인 / 거절 / 보완) + summary bar ("12건 대기 / 340건 승인 / 5건 거절") + 카드 뷰 (우선순위 / 업체명 / 사업자번호 / 제출일 / 카테고리).
-
-**심사 상세**:
-
-```
-┌─────────────────────────────────────────────────┐
-│ [상태 뱃지: PENDING]  서울라운지                  │
-│ 사업자번호: 123-45-67890 | 제출일: 2026-04-14    │
-├─────────────────────────────────────────────────┤
-│ 좌측: 제출 서류 뷰어                              │
-│ - 사업자등록증 (이미지/PDF 미리보기)               │
-│ - 대표자 신분증                                   │
-│ - 기타 첨부 서류                                  │
-├─────────────────────────────────────────────────┤
-│ 우측: 심사 액션                                   │
-│ - 관리자 코멘트 (텍스트 입력)                      │
-│ - [승인] [거절 ▾ (사유 선택)] [보완 요청]          │
-└─────────────────────────────────────────────────┘
-```
-
-### 화면 4: 이벤트 관리
-
-목록: 검색(이벤트명 / 파트너명) + 필터(상태 / 날짜 / 파트너 / 카테고리) + 테이블 (이벤트명 / 파트너 / 상태 / 날짜 / 신청 수 / 매출).
-액션: [강제 취소] [숨김 처리] — 확인 다이얼로그 필수.
-
-### 화면 5: 결제 / 환불
-
-**거래 내역**: 필터 (상태 / 결제일 범위 / 금액 범위 / 파트너) + 상세 (PortOne 결제 정보 + 환불 이력).
-
-**환불 처리**:
-- 대기 큐: 환불 요청 건 목록
-- 처리 뷰: 원결제 정보 / 환불 사유 / 환불 금액 (부분 환불 지원) / [환불 실행]
-
-### 화면 6: 정산 관리
-
-**목록**: 상태 / 정산 기간 / 파트너 필터 + 테이블 (정산 ID / 파트너 / 총 매출 / 수수료 / 정산액 / 상태 / 정산일) + 체크박스 선택 → [일괄 확정] [일괄 지급 처리].
-
-**상세**: 정산 항목별 거래 내역 / 조정 항목 / 정산 이력 타임라인 / 지급 정보.
-
-### 화면 7: 감사 로그
-
-테이블: 시각 / 관리자 / 액션 유형 / 대상 / 변경 전·후 / IP. 필터: 관리자 / 액션 유형 / 대상 / 날짜 범위.
-
-### 도메인 이벤트 (참고)
-
-| 이벤트 | 설명 |
-|--------|------|
-| `admin.login` | 관리자 로그인 (MFA 포함) |
-| `admin.partner_application.reviewed` | 파트너 심사 완료 (approve / reject) |
-| `admin.user.suspended` | 유저 정지 처리 |
-| `admin.user.unsuspended` | 유저 정지 해제 |
-| `admin.refund.processed` | 환불 처리 완료 |
-| `admin.settlement.status_changed` | 정산 상태 변경 |
-| `admin.system_setting.updated` | 시스템 설정 변경 |
-| `admin.event.force_cancelled` | 이벤트 강제 취소 |
-
-### 에러 / 로딩 상태 (참고)
-
-| 섹션 | 로딩 | 빈 상태 | 에러 |
-|------|------|---------|------|
-| 대시보드 KPI | Shimmer 카드 (Stripe 패턴) | N/A | "데이터를 불러올 수 없습니다. 새로고침해주세요." |
-| 데이터 테이블 | Skeleton rows (5행) | "조건에 맞는 데이터가 없습니다." + 필터 초기화 | "데이터 로딩 실패. 잠시 후 다시 시도해주세요." |
-| 심사 큐 | Skeleton cards | "처리할 심사 건이 없습니다." | 재시도 안내 |
-| 서류 뷰어 | Spinner | "첨부된 서류가 없습니다." | "서류를 불러올 수 없습니다." + 다운로드 링크 |
-| 차트 | Shimmer chart area | "아직 데이터가 충분하지 않습니다." | 차트 영역에 에러 텍스트 |
-| 환불 실행 | 버튼 로딩 스피너 | N/A | Toast: "환불 처리에 실패했습니다. Portone 상태를 확인해주세요." |
-
-### 데이터 정의 (참고)
-
-| 항목 | 키 / 출처 | 설명 |
-|------|----------|------|
-| 관리자 역할 | `app_roles` | super_admin / moderator (P1: finance_admin) |
-| 파트너 신청 | `partner_applications` | 입점 심사 큐 source |
-| 정산 항목 | `settlement_items` | 정산 단위 |
-| 지급 | `payouts` | 정산 지급 |
-| 정책 / 약관 | `policies` | 버전 관리 |
-| 시스템 설정 | `system_settings` | KV |
-| 감사 로그 | 신규 `admin_audit_logs` 테이블 | 관리자 / 액션 / 대상 / 변경 전·후 / IP / UA / 시각 (UPDATE / DELETE 불가, super_admin SELECT only) |
-| analytics 일별 집계 | `analytics.daily_active_users` / `daily_revenue` / `daily_events` / `funnel_daily` | KPI 카드 source |
+| 항목 | 설명 |
+|------|------|
+| Admin identity | Supabase Auth user + server-verified admin membership |
+| Capability | 메뉴/route/action 접근 권한. 예: `admin.users.read`, `admin.system.read` |
+| Menu registry | Admin menu metadata 와 route/page contract 의 source |
+| No-menu state | admin 권한은 있으나 접근 가능한 active 메뉴가 없는 shell empty state |


### PR DESCRIPTION
## Summary

- Add `web_admin` screen registry support to the MDS `/screens` index.
- Add `AdminConsoleDashboard` MDS source spec for Supabase Google login, server-verified admin guard, extensible shell, and no-menu state.
- Rewrite the admin dashboard PRD/spec so P0 is limited to auth + shell/menu registry. Feature boards are deferred and CI/CD board references are removed from the current scope.

## Issue lifecycle

No linked issue: this is admin console shell/MDS groundwork split from the planning discussion and does not resolve the separate privacy revocation tracker (#2377).

## Validation

- `npm run lint` in `apps/mds/docs`
- `dart scripts/cuj_coverage.dart --json`
- `git diff --check`
- `curl http://localhost:3003/screens` -> 200, `AdminCicdDashboard` 0 matches
- `curl http://localhost:3003/specs/admin_cicd_dashboard/index.html` -> 404
- Chrome headless render check for `/specs/admin_console_dashboard/index.html`

## Notes

- This PR intentionally does not implement `apps/admin` yet.
- The CI/CD board MDS child screen is deferred and not included in this PR.