### PR TITLE
docs(mds): define first event wizard contract

### DIFF
--- a/apps/mds/docs/BLUEDOC.md
+++ b/apps/mds/docs/BLUEDOC.md
@@ -48,4 +48,4 @@ npm run tokens:sync && npm run icons:sync && npm run icons:sync-data
 - [`../../../scripts/mds_render_coverage.dart`](../../../scripts/mds_render_coverage.dart) — MDS spec ↔ emulator render coverage
 
 ---
-_Reviewed: 2026-06-04 23:11_
+_Reviewed: 2026-06-04 23:25_

--- a/apps/mds/docs/public/specs/BLUEDOC.md
+++ b/apps/mds/docs/public/specs/BLUEDOC.md
@@ -41,4 +41,4 @@ MDS 화면 spec 의 **source HTML + 자동 산출물 디렉터리**. Flutter 화
 - [`../../src/lib/flow-data.ts`](../../src/lib/flow-data.ts) — route/spec 매핑
 
 ---
-_Reviewed: 2026-06-04 23:11_
+_Reviewed: 2026-06-04 23:25_

--- a/apps/mds/docs/public/specs/event_create_page/index.html
+++ b/apps/mds/docs/public/specs/event_create_page/index.html
@@ -418,7 +418,7 @@ body.dark-mode .viewport {
     <tbody>
       <tr>
         <th style="width: 140px;">Status</th>
-        <td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— 2 tab + recurrence on/off + submit/error/init = 6 state</em></td>
+        <td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— 2 tab + recurrence on/off + submit/error/init = 6 state + first-event onboarding contract</em></td>
       </tr>
       <tr>
         <th>App</th>
@@ -426,11 +426,11 @@ body.dark-mode .viewport {
       </tr>
       <tr>
         <th>Category</th>
-        <td>party · event · create (new occurrence)</td>
+        <td>party · event · create (new occurrence / first-event onboarding)</td>
       </tr>
       <tr>
         <th>Route / Surface</th>
-        <td><code>EventCreateRoute</code> · widget: <code>EventCreatePage</code> + <code>EventCreateOperationTab</code> + <code>EventCreateInfoTab</code> (TabBar 2-tab)</td>
+        <td><code>EventCreateRoute(partyId)</code> · widget: <code>EventCreatePage</code> + <code>EventCreateOperationTab</code> + <code>EventCreateInfoTab</code> (TabBar 2-tab). 첫 이벤트 onboarding도 별도 route 없이 동일 route를 사용한다.</td>
       </tr>
       <tr>
         <th>Path</th>
@@ -439,14 +439,15 @@ body.dark-mode .viewport {
       <tr>
         <th>Hierarchy</th>
         <td>
-          <strong>Parent</strong>: <a href="/specs/party_detail_page/index.html"><code>PartyDetailPage</code></a> (Tab1 "이벤트 관리" → "회차 만들기" 버튼에서 진입)<br>
+          <strong>Parents</strong>: <a href="/specs/party_detail_page/index.html"><code>PartyDetailPage</code></a> (Tab1 "이벤트 관리" → "회차 만들기") · <a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a> (Todo "첫 이벤트 만들기": 파티 1개 auto-select, 2개 이상 <code>MinglitBottomSheet</code> party selector)<br>
           <strong>Children</strong>: <em>—</em> <em style="color: var(--color-text-secondary);">(섹션별 편집은 <code>MaterialPageRoute</code>로 push되는 별도 화면 — <code>PartyBasicInfoEditScreen</code>, <code>PartyCapacityContactEditScreen</code>, <code>PartyLocationEditScreen</code>, <code>TicketTemplateManageScreen</code>. 같은 partyId scope을 공유.)</em>
         </td>
       </tr>
       <tr>
         <th>Purpose</th>
         <td>
-          파트너가 기존 파티에서 새 회차(이벤트)를 생성한다. 진입 시 부모 파티의
+          파트너가 기존 파티에서 새 회차(이벤트)를 생성한다. PartnerHome onboarding의
+          "첫 이벤트 만들기" canonical destination이며, 진입 시 부모 파티의
           기본 정보 / 정원 / 연락처 / 입장 그룹 / 티켓 템플릿이 자동으로 채워져 있으며,
           파트너는 일정·반복 규칙·티켓 등 회차마다 달라지는 운영 정보만 보강하면 된다.
         </td>
@@ -454,8 +455,8 @@ body.dark-mode .viewport {
       <tr>
         <th>User journey</th>
         <td>
-          <strong>Entry points</strong>: 파티 상세의 "이벤트 관리" 탭에서 "회차 만들기" CTA를 탭하면 진입.<br>
-          <strong>Exit points</strong>: 생성 성공 → 화면이 닫히며 파티 상세로 돌아가고, "새로운 회차가 성공적으로 생성되었습니다." 토스트가 잠시 노출.
+          <strong>Entry points</strong>: 파티 상세의 "이벤트 관리" 탭 "회차 만들기" CTA 또는 PartnerHome Todo "첫 이벤트 만들기". PartnerHome에서 파티가 1개면 즉시 <code>EventCreateRoute(partyId)</code>, 2개 이상이면 party selector sheet 후 진입.<br>
+          <strong>Exit points</strong>: 생성 성공 → 파티 상세 진입이면 파티 상세로 pop, Home onboarding 진입이면 Home refresh 후 첫 이벤트 todo가 사라짐. "새로운 회차가 성공적으로 생성되었습니다." 토스트가 잠시 노출.
           실패 → 안내 토스트가 잠시 노출되고 화면은 그대로 유지.
           뒤로가기 → 변경사항 확인 다이얼로그 없이 즉시 닫힘.
         </td>
@@ -497,10 +498,88 @@ body.dark-mode .viewport {
     </thead>
     <tbody>
       <tr>
+        <td>2026-06-04</td>
+        <td>1.1</td>
+        <td>codex</td>
+        <td>#3002: PartnerHome Todo "첫 이벤트 만들기"의 canonical destination을 <code>EventCreatePage</code>로 확정. 파티 1개 auto-select, 2개 이상 party selector sheet, draft/resume, 티켓 템플릿/검토 책임 경계를 명시.</td>
+      </tr>
+      <tr>
         <td>2026-05-01</td>
         <td>1.0</td>
         <td>mark-yun</td>
         <td>v1.4 template으로 작성. 6 state — Tab1 baseline · Tab1 recurrence on · Tab2 info · submitting · error · initial post-frame loading. Partner brand <code>--color-partner-primary</code> viewport-scoped.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="doc">
+  <h2>First-event onboarding contract</h2>
+  <p class="intro">
+    #3002 기준 계약. PartnerHome의 Todo "첫 이벤트 만들기"는 별도 HTML/spec을 만들지 않고 이 화면을 재사용한다.
+    Home은 파티 선택까지만 담당하고, 일정/장소/티켓/검토/게시 책임은 <code>EventCreatePage</code>가 가진다.
+  </p>
+
+  <h3>Home entry selection</h3>
+  <table class="ref">
+    <thead><tr><th style="width: 240px;">조건</th><th style="width: 260px;">Home 동작</th><th>도착 / 상태 전이</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><code>publishedPartyCount == 1</code> · <code>publishedEventCount == 0</code></td>
+        <td>Todo "첫 이벤트 만들기" 탭 시 파티를 자동 선택.</td>
+        <td><code>EventCreateRoute(partyId)</code>로 바로 push. 하단 submit 성공 후 <code>dashboardRefreshProvider</code> invalidate/bump로 Home의 <code>hasAnyEvents</code>가 true가 되고 todo row가 사라진다.</td>
+      </tr>
+      <tr>
+        <td><code>publishedPartyCount &gt;= 2</code> · 첫 이벤트 없음</td>
+        <td><code>showMinglitBottomSheet</code> + <code>MinglitBottomSheet</code> party selector. 각 row는 파티명, 대표 장소/카테고리, draft 여부를 표시하는 single-select list.</td>
+        <td>선택한 party의 <code>EventCreateRoute(partyId)</code>로 push. 시트는 <code>MinglitRadius.card</code>, <code>MinglitColors.scrim</code>, <code>MinglitSpacing.medium/large</code>, 48px 이상 row hit target을 따른다.</td>
+      </tr>
+      <tr>
+        <td><code>draftEventCount &gt;= 1</code></td>
+        <td>Todo row 대신 "작성 중인 이벤트" compact card를 노출. sub는 "임시저장 · YYYY-MM-DD 마지막 수정".</td>
+        <td>카드 탭 시 draft의 <code>partyId</code>로 <code>EventCreateRoute</code>를 열고 draft payload를 restore한다. 게시 성공 시 draft 삭제/archived 후 Home이 일반 feed로 전환.</td>
+      </tr>
+      <tr>
+        <td><code>publishedPartyCount == 0</code></td>
+        <td>첫 이벤트 todo를 숨기고 "첫 파티 만들기" todo를 우선 노출.</td>
+        <td><a href="/specs/party_create_wizard_page/index.html"><code>PartyCreateWizardPage</code></a> 게시 완료 후 이 화면의 첫 이벤트 todo 조건으로 이동.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Wizard responsibility map</h3>
+  <table class="ref">
+    <thead><tr><th style="width: 190px;">체크포인트</th><th style="width: 230px;">Owner</th><th>명세</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>파티 선택</td>
+        <td><code>PartnerHomePage</code></td>
+        <td>Home에서만 수행. <code>EventCreatePage</code> 안에서는 party switching을 제공하지 않는다. route에 들어온 <code>partyId</code>가 event의 parent다.</td>
+      </tr>
+      <tr>
+        <td>날짜 / 시간 / 반복</td>
+        <td><code>EventCreateOperationTab</code></td>
+        <td><code>EventDateTimeInput</code>과 <code>RecurrenceSettingsSection</code>. 기본값은 다음 주 같은 요일 19:00~22:00. 시작이 종료 이후로 이동하면 종료를 시작 + 3시간으로 보정.</td>
+      </tr>
+      <tr>
+        <td>정원 / 연락 / 장소</td>
+        <td><code>EventCreateInfoTab</code></td>
+        <td>부모 파티 template에서 prefill하고 <code>MinglitEditableSection</code>으로 수정. 장소가 없거나 새 장소가 필요하면 <code>PartyLocationEditScreen</code> 경유.</td>
+      </tr>
+      <tr>
+        <td>가격 / 티켓</td>
+        <td><code>TicketTemplateManageScreen</code> within event create</td>
+        <td>첫 이벤트 작성 중에는 party-level ticket template을 instance ticket으로 복사한다. <a href="/specs/ticket_create_page/index.html"><code>TicketCreatePage</code></a>는 이미 생성된 event에 ticket을 추가하는 별도 child라 첫 이벤트 wizard의 owner가 아니다.</td>
+      </tr>
+      <tr>
+        <td>검토 / 게시</td>
+        <td><code>EventCreateInfoTab</code> summary + bottom submit</td>
+        <td>별도 review route를 만들지 않는다. Tab2의 요약 섹션(기본 정보, 정원/연락, 장소, 입장 조건, 공개 설정)과 Tab1 티켓 요약이 게시 전 검토 surface다. 하단 <code>ElevatedButton</code>이 publish/submit gate.</td>
+      </tr>
+      <tr>
+        <td>자동 임시저장 / resume</td>
+        <td><code>EventCreateController</code> target contract</td>
+        <td>form dirty 후 debounce save. 저장 payload는 <code>partyId</code>, draft id, current tab/checkpoint, start/end, recurrence, tickets, info overrides, updatedAt을 포함. 앱 구현은 아직 완전하지 않아 #3053에서 추적한다.</td>
       </tr>
     </tbody>
   </table>
@@ -1265,6 +1344,14 @@ body.dark-mode .viewport {
       <thead><tr><th style="width: 220px;">Trigger</th><th>Effect</th></tr></thead>
       <tbody>
         <tr>
+          <td>PartnerHome Todo "첫 이벤트 만들기" 탭</td>
+          <td>파티가 1개면 <code>EventCreateRoute(partyId)</code>를 즉시 push. 파티가 2개 이상이면 <code>showMinglitBottomSheet</code>로 party selector를 먼저 표시하고, 선택 후 같은 route로 진입.</td>
+        </tr>
+        <tr>
+          <td>Party selector row 탭</td>
+          <td><code>MinglitBottomSheet</code>를 닫고 선택한 party scope으로 form을 초기화. 시트 dismiss/scrim tap/system back은 선택 취소이며 Home todo 상태는 유지.</td>
+        </tr>
+        <tr>
           <td>탭 헤더 탭 또는 좌우 스와이프</td>
           <td>본문이 새 탭으로 부드럽게 슬라이드. 양쪽 탭의 입력값은 그대로 유지.</td>
         </tr>
@@ -1278,7 +1365,15 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td>"회차 생성 완료" 탭</td>
-          <td>저장이 진행되는 동안 버튼 라벨이 "회차 생성 중..."으로 바뀌며 비활성화. 성공하면 화면이 닫히고 부모 화면(파티 상세)으로 복귀, 부모 화면의 이벤트 목록과 대시보드 요약이 자동으로 갱신. 실패하면 안내 토스트가 잠시 노출되고 화면은 그대로 유지.</td>
+          <td>저장이 진행되는 동안 버튼 라벨이 "회차 생성 중..."으로 바뀌며 비활성화. 성공하면 화면이 닫히고 진입 부모(파티 상세 또는 Home) 데이터가 자동 갱신된다. Home onboarding에서 진입했다면 <code>hasAnyEvents</code>가 true가 되어 첫 이벤트 todo가 사라진다. 실패하면 안내 토스트가 잠시 노출되고 화면은 그대로 유지.</td>
+        </tr>
+        <tr>
+          <td>자동 임시저장 tick</td>
+          <td>form dirty 상태에서 debounce save. 성공하면 Home의 "첫 이벤트 만들기" row가 "작성 중인 이벤트" resume card로 대체될 수 있다. 실패해도 현재 입력값은 화면 메모리에 유지하고 다음 tick에서 재시도.</td>
+        </tr>
+        <tr>
+          <td>Home "작성 중인 이벤트" 카드 탭</td>
+          <td>저장된 <code>partyId</code>와 draft payload로 <code>EventCreateRoute</code>를 restore. 게시 성공 시 draft를 삭제/archived 처리하고 Home 일반 feed로 전환.</td>
         </tr>
         <tr>
           <td>뒤로가기</td>
@@ -1311,6 +1406,8 @@ body.dark-mode .viewport {
     <h2>Global edge cases</h2>
     <ul class="notes">
       <li><strong>부모 파티 정보를 가져오지 못한 경우</strong> — 화면이 빈 상태로 머무르며 사용자에게 명시적인 안내가 노출되지 않는 약점이 있음 — 후속 정리 후보.</li>
+      <li><strong>PartnerHome 다중 파티 선택</strong> — selector는 단일 선택만 제공한다. 파티가 많아져 검색이 필요해지면 full-screen party picker로 분리하고, 이 화면은 여전히 <code>partyId</code>가 고정된 상태로 시작한다.</li>
+      <li><strong>자동 임시저장 실패</strong> — 저장 실패 시 Home resume card로 승격하지 않는다. 사용자가 화면을 유지하는 동안 입력값은 메모리에 남고, 뒤로가기로 나가면 마지막 성공 draft까지만 복구된다.</li>
       <li><strong>저장 진행 중 뒤로가기</strong> — 사용자가 화면을 빠져나가더라도 저장은 백그라운드에서 그대로 진행되며, 이미 만들어진 회차는 서버에 그대로 남는다.</li>
       <li><strong>새 장소 + 반복 일정 동시 저장</strong> — 새 장소 만들기에 실패하면 회차 자체도 만들어지지 않음. 다만 회차는 만들어졌는데 반복 규칙이 만들어지지 못해 부분 성공이 발생할 가능성이 있고, 이때 사용자에겐 일반 안내 토스트만 표기 — 후속 정리 후보.</li>
       <li><strong>"입장 조건" 섹션</strong> — 현재는 읽기 전용으로 동작해 탭해도 다음 화면으로 이동하지 않으나, 헤더에 펜 아이콘이 그대로 보여 혼동을 줄 수 있음 — 후속 정리 후보.</li>
@@ -1343,7 +1440,10 @@ body.dark-mode .viewport {
         <tr><th>Provider</th><td><code>partyDetailProvider(partyId)</code> · <code>partyTicketsProvider(partyId)</code> · <code>locationDetailProvider(locationId)</code> · <code>recurrenceSettingsControllerProvider</code> · <code>dashboardRefreshProvider</code></td></tr>
         <tr><th>Repository</th><td><code>partyRepository.createEvent</code> · <code>locationRepository.createLocation</code> · <code>recurrenceRuleRepository.create</code></td></tr>
         <tr><th>Theme</th><td><code>MinglitTheme.partnerTheme</code> — primary = <code>MinglitPartnerColors.primary</code> (#6c3ce1) · spec var: <code>--color-partner-primary</code></td></tr>
+        <tr><th>Onboarding owner</th><td><a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a> Todo "첫 이벤트 만들기" → 1 party auto-select 또는 <code>MinglitBottomSheet</code> party selector → <code>EventCreateRoute(partyId)</code>. 별도 <code>FirstEventWizardPage</code> spec 없음.</td></tr>
         <tr><th>⚠️ 알려진 drift / 의문점</th><td>
+          · #3002 target 중 event draft/resume persistence는 현재 Flutter에 완전 구현되어 있지 않음 — #3053에서 구현 추적.<br>
+          · PartnerHome의 다중 파티 선택은 현재 Material <code>showModalBottomSheet</code> 직접 사용 — target은 <code>showMinglitBottomSheet</code> + <code>MinglitBottomSheet</code> 표준화.<br>
           · 입장 조건 EditableSection의 onTap이 빈 함수임에도 isEditable 미지정 → edit 아이콘 노출. <code>isEditable: false</code> 권장.<br>
           · 공개 설정 Container만 horizontal margin 0 → 다른 섹션과 정렬 어긋남.<br>
           · Tab1 라벨 "운영 및 티켓"은 하드코딩, Tab2는 l10n 참조 — 일관성 부족.<br>
@@ -1366,8 +1466,16 @@ body.dark-mode .viewport {
           <td>이 화면의 부모 — 이벤트 관리 탭의 "회차 만들기" CTA가 진입점. 저장 성공 시 화면이 닫히면 부모의 이벤트 목록이 자동으로 갱신.</td>
         </tr>
         <tr>
+          <td><a href="/specs/partner_home_page/index.html"><code>PartnerHomePage</code></a></td>
+          <td>Onboarding Todo "첫 이벤트 만들기"의 부모. 첫 published event가 없을 때 이 화면을 canonical destination으로 사용한다.</td>
+        </tr>
+        <tr>
           <td><a href="/specs/party_create_wizard_page/index.html"><code>PartyCreateWizardPage</code></a></td>
           <td>같은 partner 앱의 sibling — 파티(template) 자체를 만드는 6-step wizard. 이 화면은 그 template의 event(instance)를 만든다.</td>
+        </tr>
+        <tr>
+          <td><a href="/specs/ticket_create_page/index.html"><code>TicketCreatePage</code></a></td>
+          <td>생성된 event에 티켓을 추가하는 child. 첫 이벤트 작성 중 가격/수량은 party ticket template을 이 화면 안에서 편집/복사하며, <code>TicketCreatePage</code>로 분기하지 않는다.</td>
         </tr>
         <tr>
           <td><a href="/specs/event_application_wizard_page/index.html"><code>EventApplicationWizardPage</code></a></td>

--- a/apps/mds/docs/public/specs/partner_home_page/index.html
+++ b/apps/mds/docs/public/specs/partner_home_page/index.html
@@ -969,6 +969,12 @@ body.dark-mode .viewport {
     <tbody>
       <tr>
         <td>2026-06-04</td>
+        <td>2.6</td>
+        <td>codex</td>
+        <td>#3002: Todo "첫 이벤트 만들기" destination을 <code>EventCreatePage</code>로 확정. 파티 1개 auto-select, 2개 이상 <code>MinglitBottomSheet</code> party selector, 작성 중 이벤트 resume card, 게시 완료 후 Home todo 소멸 조건을 명시.</td>
+      </tr>
+      <tr>
+        <td>2026-06-04</td>
         <td>2.5</td>
         <td>codex</td>
         <td>#3001: Todo "계좌 등록" destination을 <code>BankAccountPage</code> onboarding owner로 확정. verified/manual approved 때 todo가 사라지고 failed/manual review pending은 todo가 유지되는 state transition을 명시.</td>
@@ -2180,12 +2186,12 @@ body.dark-mode .viewport {
             </div>
           </td>
           <td class="state-mini__aspect">조건</td>
-          <td>파티 1+ (게시 완료) + <code>publishedEventCount === 0 &amp;&amp; draftEventCount === 0</code> — 파티는 만들었지만 첫 회차(이벤트)를 아직 안 만든 상태. 운영 현황 "등록된 파티" = 1. <strong>계좌 등록과 독립</strong> — 계좌 미등록이어도 이벤트 작성 가능 (게시 시점에 계좌 필요할 수 있음).</td>
+          <td>게시 완료 파티 1+ + <code>publishedEventCount === 0 &amp;&amp; draftEventCount === 0</code> — 파티는 만들었지만 첫 회차(이벤트)를 아직 안 만든 상태. 운영 현황 "등록된 파티" = published party count. <strong>계좌 등록과 독립</strong> — 계좌 미등록이어도 이벤트 작성 가능 (게시 시점에 계좌 필요할 수 있음). 도착지는 <a href="/specs/event_create_page/index.html"><code>EventCreatePage</code></a>.</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>
           <td>
-            ① <strong>"첫 이벤트 만들기" todo 탭</strong> → 이벤트 생성 위저드 (날짜 / 시간 / 정원 / 가격 / 장소 등). 파티가 1개면 자동 선택 — 2개 이상이면 파티 선택 시트 먼저.<br>
+            ① <strong>"첫 이벤트 만들기" todo 탭</strong> → 파티가 1개면 즉시 <code>EventCreateRoute(partyId)</code>. 2개 이상이면 <code>MinglitBottomSheet</code> party selector를 먼저 띄우고 선택 후 <code>EventCreatePage</code>로 진입.<br>
             ② 운영 현황 "등록된 파티" 1 탭 → 파티 리스트 (자기 파티 1개).<br>
             ③ ⓘ 도움말 → 첫 이벤트 만들기 가이드 시트 (날짜 / 정원 정하는 팁).
           </td>
@@ -2193,9 +2199,9 @@ body.dark-mode .viewport {
         <tr>
           <td class="state-mini__aspect">에지케이스</td>
           <td>
-            · 이벤트 위저드 도중 "임시저장" 시 → todo 카드가 <strong>"작성 중인 이벤트" 카드</strong>로 교체 (sub = "임시저장 · 마지막 수정일", 아이콘 = 펜).<br>
-            · 이벤트 게시 완료 시 자동으로 일반 dashboard (State 1 또는 한가한 날 State 3)로 전환.<br>
-            · 다중 파티 보유 시: todo 카드 sub에 "어떤 파티의 이벤트인지" 명시 또는 위저드 진입 시 파티 선택 시트.<br>
+            · 이벤트 위저드 도중 "임시저장" 시 → todo 카드가 <strong>"작성 중인 이벤트" 카드</strong>로 교체 (sub = "임시저장 · 마지막 수정일", 아이콘 = 펜)되고, 탭 시 같은 <code>EventCreateRoute</code>를 draft payload로 restore.<br>
+            · 이벤트 게시 완료 시 <code>hasAnyEvents</code>/<code>publishedEventCount</code>가 갱신되어 자동으로 일반 dashboard (State 1 또는 한가한 날 State 3)로 전환.<br>
+            · 다중 파티 보유 시: Home 카드 자체에는 파티명을 고정하지 않고 selector에서 파티를 결정. selector dismiss는 아무 상태 변화 없음.<br>
             · 파티가 임시저장 (작성 중)이고 게시 안 됐다면 State 5(첫 파티)로 다시 분기.
           </td>
         </tr>
@@ -2204,6 +2210,7 @@ body.dark-mode .viewport {
           <td>
             · 운영 현황 (1/0/0) — 파티만 1개<br>
             · "지금 할 일" 섹션 + 첫 이벤트 만들기 todo 카드 (mint 아이콘 박스 + 달력 아이콘)<br>
+            · 파티 2개 이상일 때 <code>MinglitBottomSheet</code> party selector (title + single-select ListTile row)<br>
             · 작성 중 이벤트 있을 시 → todo 카드 자리에 작성 중 카드 sub-state
           </td>
         </tr>
@@ -2213,7 +2220,7 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td class="state-mini__aspect">노트</td>
-          <td>📝 파티는 만들었지만 첫 이벤트 없으면 사용자에게 노출되지 않음 — 첫 이벤트 게시가 모집 시작 트리거. ⓘ 도움말에서 "이벤트 = 회차" 개념 + 날짜/정원 설정 팁 안내.</td>
+          <td>📝 파티는 만들었지만 첫 이벤트 없으면 사용자에게 노출되지 않음 — 첫 이벤트 게시가 모집 시작 트리거. Home은 party selection까지만 담당하고, 날짜/시간/정원/가격/장소/티켓/검토는 <code>EventCreatePage</code>가 담당.</td>
         </tr>
       </tbody>
     </table>
@@ -3212,7 +3219,8 @@ body.dark-mode .viewport {
             · <code>bankAccountReady == false</code> → 계좌 등록/확인 row (<code>bankVerificationStatus in [not_started, failed, manual_review_pending]</code>)<br>
             · <code>publishedParty 0 &amp;&amp; draftParty 0</code> → 첫 파티 만들기 row<br>
             · <code>publishedEvent 0 &amp;&amp; draftEvent 0 &amp;&amp; publishedParty &gt;= 1</code> → 첫 이벤트 만들기 row<br><br>
-            <strong>Drafts 변형</strong>: 작성 중 파티/이벤트 있으면 todo 자리에 작성 중 카드 (회색 펜 아이콘)로 sub-state 교체 → 카드별 명세 ⑦ 참고<br><br>
+            <strong>Tap destinations</strong>: 계좌 row → <code>BankAccountPage</code>, 파티 row → <code>PartyCreateWizardPage</code>, 이벤트 row → <code>EventCreatePage</code>. 이벤트 row는 published party 1개면 auto-select, 2개 이상이면 <code>MinglitBottomSheet</code> party selector 후 이동.<br><br>
+            <strong>Drafts 변형</strong>: 작성 중 파티/이벤트 있으면 todo 자리에 작성 중 카드 (회색 펜 아이콘)로 sub-state 교체 → 카드별 명세 ⑦ 참고. 작성 중 이벤트는 같은 <code>EventCreateRoute</code>를 draft payload로 restore.<br><br>
             <strong>완료 시 자동 소멸</strong>: prerequisite 충족 시 row 사라짐. 계좌 row는 <code>verified</code> 또는 운영 승인 완료 때만 사라지고, failed/manual review pending은 유지. 모두 충족 시 "지금 할 일" 섹션 자체 hide.
           </td>
         </tr>
@@ -3502,13 +3510,19 @@ body.dark-mode .viewport {
           <td>Todo "첫 이벤트 만들기"</td>
           <td><a href="/specs/event_create_page/index.html"><code>EventCreatePage</code></a></td>
           <td>✅</td>
-          <td>날짜 / 시간 / 정원 / 가격 / 장소 · 첫 이벤트 wizard/파티 선택·resume 강화는 #3002</td>
+          <td>날짜 / 시간 / 정원 / 가격 / 장소 / 티켓 / 검토. 파티 1개 auto-select, 2개 이상 party selector, 작성 중 이벤트 resume contract 포함 (#3002)</td>
         </tr>
         <tr>
           <td>지금 할 일 — 작성 중 파티 카드</td>
           <td><a href="/specs/party_create_wizard_page/index.html"><code>PartyCreateWizardPage</code></a> (resume)</td>
           <td>✅</td>
           <td>저장 시점에서 이어서 작성</td>
+        </tr>
+        <tr>
+          <td>지금 할 일 — 작성 중 이벤트 카드</td>
+          <td><a href="/specs/event_create_page/index.html"><code>EventCreatePage</code></a> (resume)</td>
+          <td>✅</td>
+          <td>저장된 partyId/draft payload로 이어 작성. 게시 완료 시 첫 이벤트 todo 소멸 (#3002)</td>
         </tr>
         <tr>
           <td>하단 nav — 신청관리</td>
@@ -3563,7 +3577,7 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td><a href="/specs/event_create_page/index.html"><code>EventCreatePage</code></a></td>
-          <td>Onboarding 상태에서 "첫 이벤트 만들기" CTA의 도착지. 첫 이벤트 wizard 강화는 #3002에서 추적.</td>
+          <td>Onboarding 상태에서 "첫 이벤트 만들기" CTA의 canonical destination. Home은 party selection만 담당하고, 작성/검토/게시/resume 계약은 <code>EventCreatePage</code>가 담당.</td>
         </tr>
         <tr>
           <td><a href="/specs/bank_account_page/index.html"><code>BankAccountPage</code></a></td>

--- a/apps/mds/docs/src/lib/flow-data.ts
+++ b/apps/mds/docs/src/lib/flow-data.ts
@@ -121,6 +121,7 @@ const APP_PARTNER_MAIN_FLOW = `flowchart TB
   ApplicationListRoute -->|"tap approved/rejected/paid row"| EventApplicationDetailRoute
   HomeRoute -->|"bottom nav"| CheckinRoute
   HomeRoute -->|"todo 계좌 등록 / 계좌 확인 중"| BankAccountRoute
+  HomeRoute -->|"todo 첫 이벤트 만들기 / 작성 중 이벤트 resume"| EventCreateRoute
   HomeRoute -->|"bottom nav (SETTLEMENT_VIEW role required)"| SettlementRoute
   SettlementRoute -->|"tap settlement item"| SettlementDetailRoute
   SettlementRoute -->|"manage bank account"| BankAccountRoute


### PR DESCRIPTION
## Summary

- Defines `EventCreatePage` as the canonical PartnerHome onboarding destination for Todo `첫 이벤트 만들기`
- Documents Home entry behavior: one party auto-select, multiple parties via `MinglitBottomSheet` party selector, and draft/resume card behavior
- Clarifies EventCreate responsibility boundaries for date/time, capacity/contact/location, ticket templates, review/submit, and `TicketCreatePage` separation
- Updates PartnerHome subpages/todo spec and app_partner flow graph for Home → EventCreateRoute
- Creates Flutter follow-up #3053 for event draft/resume persistence and Minglit bottom sheet standardization

## Verification

- `git diff --check`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- `npm run lint --workspace=apps/mds/docs`
- `npm run build --workspace=apps/mds/docs` (passes; existing local symlinked node_modules warnings about Next/SWC version, workspace root inference, and NFT trace)

Closes #3002
Refs #2222
Refs #3053