### PR TITLE
docs(mds): define partner notification center contract

### DIFF
--- a/apps/mds/docs/BLUEDOC.md
+++ b/apps/mds/docs/BLUEDOC.md
@@ -47,4 +47,4 @@ npm run tokens:sync && npm run icons:sync && npm run icons:sync-data
 - [`../../../shared/packages/mds/icons/README.md`](../../../shared/packages/mds/icons/README.md) — icon codegen
 - [`../../../scripts/mds_render_coverage.dart`](../../../scripts/mds_render_coverage.dart) — MDS spec ↔ emulator render coverage
 ---
-_Reviewed: 2026-06-04 23:25_
+_Reviewed: 2026-06-05 10:12_

--- a/apps/mds/docs/public/specs/BLUEDOC.md
+++ b/apps/mds/docs/public/specs/BLUEDOC.md
@@ -41,4 +41,4 @@ MDS 화면 spec 의 **source HTML + 자동 산출물 디렉터리**. Flutter 화
 - [`../../src/lib/flow-data.ts`](../../src/lib/flow-data.ts) — route/spec 매핑
 
 ---
-_Reviewed: 2026-06-04 23:25_
+_Reviewed: 2026-06-05 10:12_

--- a/apps/mds/docs/public/specs/notification_list_screen/index.html
+++ b/apps/mds/docs/public/specs/notification_list_screen/index.html
@@ -114,18 +114,38 @@ body.dark-mode .notif-appbar__action { color: var(--color-dark-text-primary); }
 }
 body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-background); }
 
-/* --- Empty state (Center + Text "알림이 없습니다.") --- */
+/* --- Empty / error state (MinglitEmptyState centered) --- */
 .notif-empty {
   position: absolute;
   inset: 56px 0 0 0;
   display: grid;
   place-items: center;
   text-align: center;
-  padding: 0 var(--spacing-large);
+  padding: var(--spacing-xlarge);
 }
-.notif-empty__text {
+.notif-empty__card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 260px;
+}
+.notif-empty__icon {
+  width: 64px;
+  height: 64px;
+  color: var(--color-text-secondary);
+  opacity: var(--opacity-strong);
+  margin-bottom: var(--spacing-medium);
+}
+.notif-empty__title {
   font-size: 16px;
+  font-weight: 700;
   line-height: 1.5;
+  color: var(--color-text-primary);
+}
+.notif-empty__sub {
+  margin-top: var(--spacing-small);
+  font-size: 13px;
+  line-height: 1.45;
   color: var(--color-text-secondary);
 }
 
@@ -145,21 +165,27 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
 }
 @keyframes notif-spin { to { transform: rotate(360deg); } }
 
-/* --- Error state (_DefaultErrorView · showErrorDetails: false 기준,
-       단 NotificationListScreen은 error: builder를 직접 override해서
-       Center + "에러: $err"로 표시한다 — 코드 137행 참고). --- */
+/* --- Error state (MinglitEmptyState with retry action) --- */
 .notif-error {
   position: absolute;
   inset: 56px 0 0 0;
   display: grid;
   place-items: center;
   text-align: center;
-  padding: 0 var(--spacing-large);
+  padding: var(--spacing-xlarge);
 }
-.notif-error__text {
-  font-size: 16px;
-  line-height: 1.5;
-  color: var(--color-text-secondary);
+.notif-empty__action {
+  margin-top: var(--spacing-large);
+  min-height: 40px;
+  padding: 0 var(--spacing-medium);
+  border-radius: var(--radius-button);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-primary);
+  color: var(--color-background);
+  font-size: 14px;
+  font-weight: 700;
 }
 </style>
 </head>
@@ -188,11 +214,11 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
     <tbody>
       <tr>
         <th style="width: 140px;">Status</th>
-        <td><strong>디자인완료</strong> <em style="color: var(--color-text-secondary);">— 5 state · kit-shared (user + partner)</em></td>
+        <td><strong>디자인완료</strong> <em style="color: var(--color-text-secondary);">— 5 state · kit-shared (user + partner) + partner category contract</em></td>
       </tr>
       <tr>
         <th>App</th>
-        <td><code>app_user</code> + <code>app_partner</code> — <strong>shared between user / partner</strong>. 두 앱 모두 <code>NotificationCenterRoute</code>가 동일한 <code>NotificationListScreen</code>(kit-shared)을 그대로 push 한다. 분기 props 없음.</td>
+        <td><code>app_user</code> + <code>app_partner</code> — <strong>shared between user / partner</strong>. 두 앱 모두 <code>NotificationCenterRoute</code>가 동일한 <code>NotificationListScreen</code>(kit-shared)을 그대로 push 한다. 화면 props 분기는 없고, partner category는 알림 payload/title/body/deep_link taxonomy로 정의한다.</td>
       </tr>
       <tr>
         <th>Category</th>
@@ -219,7 +245,7 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
         <th>Purpose</th>
         <td>
           푸시 / 인앱 알림 히스토리를 한곳에서 보고, 읽음 처리·전체 읽음·개별 삭제·deep-link 이동을 수행하는 단일 list 화면. 데이터 소스는
-          <code>user_notifications</code> 테이블 (page size 20).
+          <code>user_notifications</code> 테이블 (page size 20). Partner 앱에서는 신청/체크인/정산/운영 공지 알림을 같은 chronological list 안에 노출한다.
         </td>
       </tr>
       <tr>
@@ -260,6 +286,12 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
     </thead>
     <tbody>
       <tr>
+        <td>2026-06-04</td>
+        <td>1.1</td>
+        <td>codex</td>
+        <td>#3003: partner notification center를 신규 화면이 아닌 shared <code>NotificationListScreen</code> partner variant로 확정. 신청/체크인/정산/시스템 category taxonomy, Home unread 99+ badge, empty/error <code>MinglitEmptyState</code> drift를 문서화.</td>
+      </tr>
+      <tr>
         <td>2026-05-01</td>
         <td>1.0</td>
         <td>mark-yun</td>
@@ -269,8 +301,63 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
   </table>
 </section>
 
+<section class="doc" id="partner-variant">
+  <h2>Partner variant contract</h2>
+  <p class="intro">
+    #3003 기준. Partner notification center는 신규 HTML/spec을 만들지 않고 이 shared spec을 canonical surface로 사용한다.
+    카테고리는 화면 섹션 header가 아니라 notification payload/title/body/deep_link의 의미 그룹이다. 목록은 계속 최신순 chronological list다.
+  </p>
+
+  <h3>Partner category taxonomy</h3>
+  <table class="ref">
+    <thead><tr><th style="width: 180px;">Group</th><th style="width: 220px;">Example copy</th><th>Deep-link target / note</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>신청 / 승인 대기</td>
+        <td>신규 신청 4건이 대기 중입니다 · 참가자 결제가 완료되었습니다</td>
+        <td><code>ApplicationListRoute</code>, <code>EventApplicationListRoute</code>, <code>EventApplicationReviewCarouselRoute</code>. 신청 검토가 필요한 알림은 운영 우선순위가 높다.</td>
+      </tr>
+      <tr>
+        <td>체크인 / LIVE</td>
+        <td>체크인이 곧 시작됩니다 · LIVE 이벤트 참가자 확인이 필요합니다</td>
+        <td><code>CheckinRoute</code>, <code>OngoingEventListPage</code>, partner <code>EventDetailRoute</code>. D-0/T-2 이후 운영 알림은 참가자 리스트 또는 체크인 hub로 연결.</td>
+      </tr>
+      <tr>
+        <td>정산</td>
+        <td>5월 정산이 완료되었습니다 · 계좌 확인이 필요합니다</td>
+        <td><code>SettlementRoute</code>, <code>SettlementDetailRoute</code>, <code>BankAccountRoute</code>. 정산 권한이 없으면 route guard가 기존 권한 정책을 따른다.</td>
+      </tr>
+      <tr>
+        <td>시스템 / 운영 공지</td>
+        <td>운영 정책이 업데이트되었습니다 · 서비스 점검 안내</td>
+        <td>deep_link가 있으면 해당 guide/notice target으로 push. 없거나 invalid면 기존 SnackBar fallback("이동할 링크가 없습니다." / "올바르지 않은 링크입니다.")을 사용.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Unread indicator contract</h3>
+  <table class="ref">
+    <thead><tr><th style="width: 220px;">Surface</th><th>Contract</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>PartnerHome AppBar</td>
+        <td><code>notificationListProvider</code>에서 <code>is_read == false</code>를 count. 0이면 숨김, 1-99는 숫자 badge, 100+는 <code>99+</code>. Badge color는 <code>MinglitColors.error</code>, text는 <code>MinglitColors.background</code>, radius는 <code>MinglitRadius.button</code>, border는 current surface color.</td>
+      </tr>
+      <tr>
+        <td>NotificationListScreen row</td>
+        <td>별도 unread dot/chevron은 쓰지 않는다. 미읽음 row는 <code>theme.colorScheme.primary.withValues(alpha: MinglitOpacity.tintFill)</code> bg + title bold로 구분한다. 읽음 처리 후 row는 all-read 시각으로 즉시 변환.</td>
+      </tr>
+      <tr>
+        <td>Loading / error fallback</td>
+        <td>Home unread count를 모를 때는 badge를 숨긴다. 알림 센터 안에서는 loading/error state가 list를 대체하고, Home badge는 다음 성공 fetch 때 다시 맞춰진다.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
 <!-- Anchor nav -->
 <nav class="perspective-nav">
+  <a href="#partner-variant"><span class="glyph">🏷️</span> Partner</a>
   <a href="#layout"><span class="glyph">🧱</span> Layout</a>
   <a href="#states"><span class="glyph">🎨</span> States</a>
   <a href="#behavior"><span class="glyph">🔄</span> Global Behavior</a>
@@ -325,7 +412,7 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
 └─ <b>AppBar</b>(<i>title: "알림 센터"</i>)                    ← ①
 │  └─ actions: [<b>IconButton</b>(Icons.done_all, tooltip "모두 읽음")]
 └─ <b>MinglitAsyncValueWidget&lt;List&lt;Map&gt;&gt;</b>
-   └─ data: <em>if notifications.isEmpty → Center("알림이 없습니다.")</em>
+   └─ data: <em>if notifications.isEmpty → MinglitEmptyState</em>
             <em>else →</em>
    └─ <b>RefreshIndicator</b>(onRefresh: <code>controller.refresh()</code>)
       └─ <b>ListView.separated</b>
@@ -586,7 +673,11 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
                 </button>
               </div>
               <div class="notif-empty">
-                <div class="notif-empty__text">알림이 없습니다.</div>
+                <div class="notif-empty__card">
+                  <svg class="notif-empty__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+                  <div class="notif-empty__title">알림이 없습니다</div>
+                  <div class="notif-empty__sub">새 알림이 오면 여기에 표시됩니다.</div>
+                </div>
               </div>
             </div>
           </td>
@@ -610,19 +701,20 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
         </tr>
         <tr>
           <td class="state-mini__aspect">컴포넌트</td>
-          <td>↔ ListView / RefreshIndicator → <code>Center(child: Text('알림이 없습니다.'))</code> 단일 — <strong>전용 EmptyState atom 미사용</strong> (plain Text)</td>
+          <td>↔ ListView / RefreshIndicator → <code>MinglitEmptyState</code>(Icons.notifications_none_outlined, title "알림이 없습니다", subtitle "새 알림이 오면 여기에 표시됩니다.")</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">토큰</td>
           <td>
             − list 토큰 모두 미사용<br>
-            + <code>color-text-secondary</code> (Text 색 — bodyMedium default)<br>
-            + <code>color-surface</code> (scaffold bg 유지)
+            + <code>colorScheme.onSurface</code> (title), <code>colorScheme.outline</code> (fullPage icon), <code>colorScheme.onSurfaceVariant</code> (subtitle), <code>color-surface</code> (scaffold bg 유지)<br>
+            + <code>MinglitIconSize.hero</code> (64 · fullPage icon)<br>
+            + <code>MinglitSpacing.xlarge</code> (32 · fullPage padding), <code>MinglitSpacing.medium</code> (icon→title), <code>MinglitSpacing.small</code> (title→subtitle)
           </td>
         </tr>
         <tr>
           <td class="state-mini__aspect">노트</td>
-          <td>📝 다른 화면들의 표준 Empty 비주얼(아이콘 + 안내 + CTA) 대비 매우 빈약한 안내. 후속 작업에서 보강 검토 가치.</td>
+          <td>📝 #2414 기준 plain Text empty에서 표준 <code>MinglitEmptyState</code>로 보강됨. CTA는 없다.</td>
         </tr>
       </tbody>
     </table>
@@ -692,7 +784,12 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
                 </button>
               </div>
               <div class="notif-error">
-                <div class="notif-error__text">에러: SocketException: Failed host lookup …</div>
+                <div class="notif-empty__card">
+                  <svg class="notif-empty__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+                  <div class="notif-empty__title">알림을 불러오지 못했습니다</div>
+                  <div class="notif-empty__sub">잠시 후 다시 시도해 주세요.</div>
+                  <div class="notif-empty__action">다시 시도</div>
+                </div>
               </div>
             </div>
           </td>
@@ -701,26 +798,26 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>
-          <td>− 목록·스와이프·당겨서 새로고침 모두 사용 불가.<br>− 별도의 다시 시도 버튼은 없음.<br>↔ "모두 읽음" 버튼은 노출되지만 화면에 변화는 없음.<br>동일: 뒤로 가기 → 홈으로 복귀.</td>
+          <td>− 목록·스와이프·당겨서 새로고침 모두 사용 불가.<br>① <strong>"다시 시도" 탭</strong> → <code>ref.invalidate(notificationListProvider)</code>로 재요청.<br>↔ "모두 읽음" 버튼은 노출되지만 화면에 변화는 없음.<br>동일: 뒤로 가기 → 홈으로 복귀.</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">에지케이스</td>
           <td>
-            · 현재는 표준 오류 화면 대신 원본 오류 메시지가 그대로 노출됨 — 디버깅에 유리하지만 사용자 경험 측면에서는 보강 필요.<br>
-            · 후속 작업에서 표준 오류 화면("오류가 발생했습니다." + 다시 시도)으로 통일 권장.
+            · 원본 오류 메시지는 노출하지 않음 — 운영 환경에서 민감 정보가 UI에 보이지 않도록 정제.<br>
+            · 다시 시도도 실패하면 같은 error state 유지.
           </td>
         </tr>
         <tr>
           <td class="state-mini__aspect">컴포넌트</td>
-          <td>↔ list 전체 → <code>Center</code> + <code>Text('에러: $err')</code> (inline override). <em>Default error UI 미적용</em>.</td>
+          <td>↔ list 전체 → <code>MinglitEmptyState</code>(Icons.error_outline, title "알림을 불러오지 못했습니다", subtitle "잠시 후 다시 시도해 주세요.", actionLabel "다시 시도")</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">토큰</td>
-          <td>− list 토큰 모두 미사용<br>+ <code>color-text-secondary</code> (Text default)<br>+ <code>color-surface</code> (scaffold)<br>− <code>color-error</code> 미사용 (icon / 경고 색 없음)</td>
+          <td>− list 토큰 모두 미사용<br>+ <code>colorScheme.onSurface</code> (title), <code>colorScheme.outline</code> (fullPage icon), <code>colorScheme.onSurfaceVariant</code> (subtitle), <code>color-primary</code> (action), <code>color-background</code> (action text), <code>radius-button</code><br>+ <code>MinglitIconSize.hero</code> (64 · fullPage icon), <code>MinglitSpacing.xlarge</code> (32 · fullPage padding), <code>MinglitSpacing.medium</code> (icon→title), <code>MinglitSpacing.small</code> (title→subtitle), <code>MinglitSpacing.large</code> (subtitle→action)</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">노트</td>
-          <td>📝 원본 오류 메시지가 그대로 노출되므로 민감 정보가 보일 위험이 있음. 운영 환경에서는 사용자 친화적인 안내 문구로 정제 권장.</td>
+          <td>📝 #2413 기준 원본 오류 문자열 노출을 제거하고 표준 empty/error UI로 통일했다.</td>
         </tr>
       </tbody>
     </table>
@@ -831,7 +928,7 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
       <li><strong>읽음 / 삭제 처리는 화면에서 즉시 반영</strong> — 사용자에게는 항상 성공한 것처럼 보이지만, 서버 처리에 실패한 경우 다음 새로고침 시 서버 상태로 되돌아갈 수 있음.</li>
       <li><strong>홈의 미읽음 배지와 동기화</strong> — 이 화면에서 읽음 처리하면 홈의 미읽음 배지도 즉시 갱신됨.</li>
       <li><strong>페이지네이션 없음</strong> — 한 번에 최대 20건까지만 노출되며, 더 오래된 알림은 보이지 않음. 향후 무한 스크롤 보강 후보.</li>
-      <li><strong>당겨서 새로고침 영역 한정</strong> — 알림 목록이 보이는 변형에서만 동작. 알림이 없거나 로딩 / 오류 변형에서는 다시 시도하려면 화면을 떠났다 다시 들어와야 함.</li>
+      <li><strong>당겨서 새로고침 영역 한정</strong> — 알림 목록이 보이는 변형에서만 동작. Empty/loading에서는 다시 들어와야 재요청되고, error는 <code>MinglitEmptyState</code>의 "다시 시도" CTA로 재요청한다.</li>
       <li><strong>사용자 / 파트너 공용 화면</strong> — 동일한 화면이 양쪽 앱에서 노출됨. 미읽음 강조 톤과 로딩 인디케이터 색만 앱별 강조 색에 따라 살짝 다름. 동작·문구·구조는 100% 동일.</li>
       <li><strong>실시간 갱신 없음</strong> — 이 화면이 떠 있는 동안 새 알림이 도착해도 자동으로 추가되지 않음. 사용자가 직접 새로고침하거나 다시 들어와야 반영됨.</li>
     </ul>
@@ -859,7 +956,7 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
         <tr><th>Route (partner)</th><td><code>NotificationCenterRoute</code> · <code>/notifications</code> · <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/routing/app_routes.dart"><code>apps/app_partner/.../app_routes.dart</code></a> (line 92)</td></tr>
         <tr><th>Navigation (user)</th><td><code>homeCoordinator</code> — <code>_router.push(const NotificationCenterRoute().location)</code> (<code>apps/app_user/.../home_coordinator.dart:34</code>)</td></tr>
         <tr><th>Navigation (partner)</th><td><code>partnerHomeCoordinator</code> — <code>_router.push(const NotificationCenterRoute().location)</code> (<code>apps/app_partner/.../partner_home_coordinator.dart:18</code>)</td></tr>
-        <tr><th>Async wrapper</th><td><a href="/components#MinglitAsyncValueWidget"><code>MinglitAsyncValueWidget</code></a> — loading은 default(<code>MinglitCircularProgressIndicator</code>) · <strong>error는 inline override</strong>(plain <code>Center(Text('에러: $err'))</code>) → <em>_DefaultErrorView 미적용</em></td></tr>
+        <tr><th>Async wrapper</th><td><a href="/components#MinglitAsyncValueWidget"><code>MinglitAsyncValueWidget</code></a> — loading은 default(<code>MinglitCircularProgressIndicator</code>) · empty/error는 <code>MinglitEmptyState</code>로 직접 분기 (#2413, #2414)</td></tr>
         <tr><th>Icons (Material)</th><td><code>done_all</code> (AppBar action — 모두 읽음) · <code>delete</code> (Dismissible swipe BG)</td></tr>
         <tr><th>Date format</th><td><code>DateFormat('MM/dd HH:mm')</code> (intl) · <code>DateTime.parse(created_at).toLocal()</code></td></tr>
         <tr><th>Unread tint</th><td><code>theme.colorScheme.primary.withValues(alpha: MinglitOpacity.tintFill)</code> · tintFill = 0.05</td></tr>
@@ -882,7 +979,7 @@ body.dark-mode .notif-tile__swipe-front { background: var(--color-dark-backgroun
           <td>partner 진입점 — 동일 패턴, 동일 위젯.</td>
         </tr>
         <tr>
-          <td><a href="/specs/notification_settings_page.html"><code>NotificationSettingsScreen</code></a></td>
+          <td><a href="/specs/notification_settings_screen/index.html"><code>NotificationSettingsScreen</code></a></td>
           <td>알림 카테고리별 on/off 설정 — 본 화면과 데이터 모델은 분리(<code>user_settings</code>) 되었지만 동일 repository(<code>NotificationRepository</code>)에서 다룸.</td>
         </tr>
         <tr>

--- a/apps/mds/docs/public/specs/partner_home_page/index.html
+++ b/apps/mds/docs/public/specs/partner_home_page/index.html
@@ -969,6 +969,12 @@ body.dark-mode .viewport {
     <tbody>
       <tr>
         <td>2026-06-04</td>
+        <td>2.7</td>
+        <td>codex</td>
+        <td>#3003: AppBar 알림 아이콘 destination을 shared <code>NotificationListScreen</code> partner variant로 확정. 미읽음 99+ badge와 partner 신청/체크인/정산/시스템 category taxonomy는 notification spec에서 관리.</td>
+      </tr>
+      <tr>
+        <td>2026-06-04</td>
         <td>2.6</td>
         <td>codex</td>
         <td>#3002: Todo "첫 이벤트 만들기" destination을 <code>EventCreatePage</code>로 확정. 파티 1개 auto-select, 2개 이상 <code>MinglitBottomSheet</code> party selector, 작성 중 이벤트 resume card, 게시 완료 후 Home todo 소멸 조건을 명시.</td>
@@ -1157,7 +1163,7 @@ body.dark-mode .viewport {
         <tr><td>① Brand (leading)</td><td>좌측 정렬</td><td>minglit 로고 + "PARTNER" suffix · 탭 동작 없음 · 홈 식별자 역할.</td></tr>
         <tr><td>② Info action (1st trailing)</td><td>우측 · 40×40 hit-region</td><td>info_outline 22×22 · 탭 시 <strong>도움말 bottom sheet</strong> 진입 (State 8). 현재 적용 화면은 홈·파티 관리·신청관리·정산이며, 신규·리뉴얼 파트너 화면은 같은 패턴을 채택한다.</td></tr>
         <tr><td>③ Bug report (2nd trailing · dev only)</td><td>우측 · 40×40 hit-region</td><td>개발 빌드 한정 — BugReportAction 컴포넌트.</td></tr>
-        <tr><td>④ Notification (3rd trailing)</td><td>우측 · 40×40 hit-region</td><td>notifications_outlined 22×22 · 미읽음 배지(뱃지) 오버레이 가능.</td></tr>
+        <tr><td>④ Notification (3rd trailing)</td><td>우측 · 40×40 hit-region</td><td>notifications_outlined 22×22 · <code>notificationListProvider</code> 미읽음 count badge. 0이면 숨김, 1-99 숫자, 100+는 <code>99+</code>. Badge bg <code>MinglitColors.error</code>, radius <code>MinglitRadius.button</code>, surface border.</td></tr>
         <tr><td>—</td><td>AppBar bg</td><td><code>--color-surface</code> · surfaceTint transparent · border-bottom 없음.</td></tr>
       </tbody>
     </table>
@@ -3419,8 +3425,8 @@ body.dark-mode .viewport {
         <tr>
           <td>AppBar 알림 아이콘</td>
           <td><a href="/specs/notification_list_screen/index.html"><code>NotificationListScreen</code></a> (partner variant)</td>
-          <td>📝 #3003</td>
-          <td>shared notification center spec은 있음 · partner 신청/체크인/정산 grouping과 미읽음 99+ cap은 #3003에서 확정</td>
+          <td>✅</td>
+          <td>shared kit 화면 재사용. partner 신청/체크인/정산/시스템 taxonomy와 미읽음 99+ badge contract는 notification spec owner (#3003)</td>
         </tr>
         <tr>
           <td>AppBar 버그 리포트 (dev)</td>
@@ -3601,7 +3607,7 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td><a href="/specs/notification_list_screen/index.html"><code>NotificationListScreen</code></a></td>
-          <td>AppBar 알림 아이콘의 shared 도착지. partner notification center 강화는 #3003에서 추적.</td>
+          <td>AppBar 알림 아이콘의 shared 도착지. Partner variant는 같은 화면을 사용하되 신청/체크인/정산/시스템 category taxonomy를 payload/deep-link contract로 가진다.</td>
         </tr>
         <tr>
           <td>Partner active event list surface</td>


### PR DESCRIPTION
## Summary

- Defines the partner notification center as the shared `NotificationListScreen` partner variant, not a new standalone screen
- Adds partner notification taxonomy for 신청/승인 대기, 체크인/LIVE, 정산, 시스템/운영 공지
- Documents PartnerHome unread badge behavior: hidden at 0, numeric 1-99, `99+` cap, Minglit error badge tokens
- Updates stale NotificationList empty/error states to the current `MinglitEmptyState` implementation
- Marks PartnerHome AppBar notification destination as the shared notification spec owner

## Verification

- `git diff --check`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- `npm run lint --workspace=apps/mds/docs`
- `npm run build --workspace=apps/mds/docs` (passes; existing local symlinked node_modules warnings about Next/SWC version, workspace root inference, and NFT trace)

Closes #3003
Refs #2222