### PR TITLE
feat(partner): add event create draft resume

### DIFF
--- a/apps/app_partner/BLUEDOC.md
+++ b/apps/app_partner/BLUEDOC.md
@@ -47,4 +47,4 @@ Minglit 의 **파트너 사장님 Flutter 앱**. 매장 관리·멤버 초대·�
 - [README.md](./README.md) — 빌드·실행 / [integration_test/cuj](./integration_test/cuj/BLUEDOC.md) — CUJ
 
 ---
-_Reviewed: 2026-06-03 19:28_
+_Reviewed: 2026-06-04 23:56_

--- a/apps/app_partner/lib/src/features/home/partner_dashboard_controller.dart
+++ b/apps/app_partner/lib/src/features/home/partner_dashboard_controller.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
 
-import 'package:app_partner/src/logic/event_operation_phase.dart';
 import 'package:app_partner/src/logic/current_partner_provider.dart';
 import 'package:app_partner/src/logic/dashboard_refresh_notifier.dart';
+import 'package:app_partner/src/logic/event_create_draft_repository.dart';
+import 'package:app_partner/src/logic/event_operation_phase.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -20,6 +21,7 @@ abstract class PartnerDashboardState with _$PartnerDashboardState {
     @Default([]) List<Event> preparingEvents,
     @Default([]) List<Party> activeParties,
     @Default([]) List<Party> draftParties,
+    @Default([]) List<EventCreateDraft> draftEvents,
     @Default(0) int totalPartyCount,
     @Default(0) int totalAttendees,
     // Fix #1215: tracks ALL events ever created, not just upcoming ones.
@@ -62,6 +64,7 @@ class PartnerDashboardController extends _$PartnerDashboardController {
           preparingEvents: [],
           activeParties: [],
           draftParties: [],
+          draftEvents: [],
           totalPartyCount: 0,
           totalAttendees: 0,
           hasAnyEvents: false,
@@ -70,14 +73,14 @@ class PartnerDashboardController extends _$PartnerDashboardController {
       }
       final eventRepo = ref.read(eventRepositoryProvider);
       final partyRepo = ref.read(partyRepositoryProvider);
+      final draftRepo = ref.read(eventCreateDraftRepositoryProvider);
       // 1. Pending Count
       final pendingCount = await eventRepo.getPendingApplicationCount(
         partner.id,
       );
 
-      // Fix #2219: use getEventsByPartnerId (gt end_time) so liveEvents is populated.
-      // getUpcomingEvents (gte start_time, 7-day window) excludes started events,
-      // making liveEvents always empty and overview counts too low.
+      // Fix #2219: getUpcomingEvents excludes started events, making
+      // liveEvents always empty and overview counts too low.
       final upcomingEvents = await eventRepo.getEventsByPartnerId(partner.id);
 
       // 3. Active Parties
@@ -102,9 +105,15 @@ class PartnerDashboardController extends _$PartnerDashboardController {
         final phase = getEventPhase(event);
         return phase == EventPhase.preStart || phase == EventPhase.checkinReady;
       }).toList();
+      final activePartyIds = activeParties.map((party) => party.id).toSet();
+      final draftEvents = (await draftRepo.getDrafts())
+          .where((draft) => activePartyIds.contains(draft.partyId))
+          .toList();
+      final draftEventPartyIds = draftEvents.map((draft) => draft.partyId);
       final draftParties = activeParties
           .where(
             (party) =>
+                !draftEventPartyIds.contains(party.id) &&
                 upcomingEvents.every((event) => event.partyId != party.id),
           )
           .toList();
@@ -124,6 +133,7 @@ class PartnerDashboardController extends _$PartnerDashboardController {
         preparingEvents: preparingEvents,
         activeParties: activeParties,
         draftParties: draftParties,
+        draftEvents: draftEvents,
         totalPartyCount: activeParties.length,
         totalAttendees: totalAttendees,
         hasAnyEvents: hasAnyEvents,

--- a/apps/app_partner/lib/src/features/home/partner_dashboard_controller.freezed.dart
+++ b/apps/app_partner/lib/src/features/home/partner_dashboard_controller.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PartnerDashboardState {
 
- int get pendingReviewCount; List<Event> get upcomingEvents; List<Event> get liveEvents; List<Event> get recruitingEvents; List<Event> get preparingEvents; List<Party> get activeParties; List<Party> get draftParties; int get totalPartyCount; int get totalAttendees;// Fix #1215: tracks ALL events ever created, not just upcoming ones.
+ int get pendingReviewCount; List<Event> get upcomingEvents; List<Event> get liveEvents; List<Event> get recruitingEvents; List<Event> get preparingEvents; List<Party> get activeParties; List<Party> get draftParties; List<EventCreateDraft> get draftEvents; int get totalPartyCount; int get totalAttendees;// Fix #1215: tracks ALL events ever created, not just upcoming ones.
 // Using upcomingEvents for onboarding check caused the guide to reappear
 // after all events ended or were more than 7 days away.
  bool get hasAnyEvents; AsyncValue<void> get status;
@@ -28,16 +28,16 @@ $PartnerDashboardStateCopyWith<PartnerDashboardState> get copyWith => _$PartnerD
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PartnerDashboardState&&(identical(other.pendingReviewCount, pendingReviewCount) || other.pendingReviewCount == pendingReviewCount)&&const DeepCollectionEquality().equals(other.upcomingEvents, upcomingEvents)&&const DeepCollectionEquality().equals(other.liveEvents, liveEvents)&&const DeepCollectionEquality().equals(other.recruitingEvents, recruitingEvents)&&const DeepCollectionEquality().equals(other.preparingEvents, preparingEvents)&&const DeepCollectionEquality().equals(other.activeParties, activeParties)&&const DeepCollectionEquality().equals(other.draftParties, draftParties)&&(identical(other.totalPartyCount, totalPartyCount) || other.totalPartyCount == totalPartyCount)&&(identical(other.totalAttendees, totalAttendees) || other.totalAttendees == totalAttendees)&&(identical(other.hasAnyEvents, hasAnyEvents) || other.hasAnyEvents == hasAnyEvents)&&(identical(other.status, status) || other.status == status));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PartnerDashboardState&&(identical(other.pendingReviewCount, pendingReviewCount) || other.pendingReviewCount == pendingReviewCount)&&const DeepCollectionEquality().equals(other.upcomingEvents, upcomingEvents)&&const DeepCollectionEquality().equals(other.liveEvents, liveEvents)&&const DeepCollectionEquality().equals(other.recruitingEvents, recruitingEvents)&&const DeepCollectionEquality().equals(other.preparingEvents, preparingEvents)&&const DeepCollectionEquality().equals(other.activeParties, activeParties)&&const DeepCollectionEquality().equals(other.draftParties, draftParties)&&const DeepCollectionEquality().equals(other.draftEvents, draftEvents)&&(identical(other.totalPartyCount, totalPartyCount) || other.totalPartyCount == totalPartyCount)&&(identical(other.totalAttendees, totalAttendees) || other.totalAttendees == totalAttendees)&&(identical(other.hasAnyEvents, hasAnyEvents) || other.hasAnyEvents == hasAnyEvents)&&(identical(other.status, status) || other.status == status));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,pendingReviewCount,const DeepCollectionEquality().hash(upcomingEvents),const DeepCollectionEquality().hash(liveEvents),const DeepCollectionEquality().hash(recruitingEvents),const DeepCollectionEquality().hash(preparingEvents),const DeepCollectionEquality().hash(activeParties),const DeepCollectionEquality().hash(draftParties),totalPartyCount,totalAttendees,hasAnyEvents,status);
+int get hashCode => Object.hash(runtimeType,pendingReviewCount,const DeepCollectionEquality().hash(upcomingEvents),const DeepCollectionEquality().hash(liveEvents),const DeepCollectionEquality().hash(recruitingEvents),const DeepCollectionEquality().hash(preparingEvents),const DeepCollectionEquality().hash(activeParties),const DeepCollectionEquality().hash(draftParties),const DeepCollectionEquality().hash(draftEvents),totalPartyCount,totalAttendees,hasAnyEvents,status);
 
 @override
 String toString() {
-  return 'PartnerDashboardState(pendingReviewCount: $pendingReviewCount, upcomingEvents: $upcomingEvents, liveEvents: $liveEvents, recruitingEvents: $recruitingEvents, preparingEvents: $preparingEvents, activeParties: $activeParties, draftParties: $draftParties, totalPartyCount: $totalPartyCount, totalAttendees: $totalAttendees, hasAnyEvents: $hasAnyEvents, status: $status)';
+  return 'PartnerDashboardState(pendingReviewCount: $pendingReviewCount, upcomingEvents: $upcomingEvents, liveEvents: $liveEvents, recruitingEvents: $recruitingEvents, preparingEvents: $preparingEvents, activeParties: $activeParties, draftParties: $draftParties, draftEvents: $draftEvents, totalPartyCount: $totalPartyCount, totalAttendees: $totalAttendees, hasAnyEvents: $hasAnyEvents, status: $status)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $PartnerDashboardStateCopyWith<$Res>  {
   factory $PartnerDashboardStateCopyWith(PartnerDashboardState value, $Res Function(PartnerDashboardState) _then) = _$PartnerDashboardStateCopyWithImpl;
 @useResult
 $Res call({
- int pendingReviewCount, List<Event> upcomingEvents, List<Event> liveEvents, List<Event> recruitingEvents, List<Event> preparingEvents, List<Party> activeParties, List<Party> draftParties, int totalPartyCount, int totalAttendees, bool hasAnyEvents, AsyncValue<void> status
+ int pendingReviewCount, List<Event> upcomingEvents, List<Event> liveEvents, List<Event> recruitingEvents, List<Event> preparingEvents, List<Party> activeParties, List<Party> draftParties, List<EventCreateDraft> draftEvents, int totalPartyCount, int totalAttendees, bool hasAnyEvents, AsyncValue<void> status
 });
 
 
@@ -65,7 +65,7 @@ class _$PartnerDashboardStateCopyWithImpl<$Res>
 
 /// Create a copy of PartnerDashboardState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? pendingReviewCount = null,Object? upcomingEvents = null,Object? liveEvents = null,Object? recruitingEvents = null,Object? preparingEvents = null,Object? activeParties = null,Object? draftParties = null,Object? totalPartyCount = null,Object? totalAttendees = null,Object? hasAnyEvents = null,Object? status = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? pendingReviewCount = null,Object? upcomingEvents = null,Object? liveEvents = null,Object? recruitingEvents = null,Object? preparingEvents = null,Object? activeParties = null,Object? draftParties = null,Object? draftEvents = null,Object? totalPartyCount = null,Object? totalAttendees = null,Object? hasAnyEvents = null,Object? status = null,}) {
   return _then(_self.copyWith(
 pendingReviewCount: null == pendingReviewCount ? _self.pendingReviewCount : pendingReviewCount // ignore: cast_nullable_to_non_nullable
 as int,upcomingEvents: null == upcomingEvents ? _self.upcomingEvents : upcomingEvents // ignore: cast_nullable_to_non_nullable
@@ -74,7 +74,8 @@ as List<Event>,recruitingEvents: null == recruitingEvents ? _self.recruitingEven
 as List<Event>,preparingEvents: null == preparingEvents ? _self.preparingEvents : preparingEvents // ignore: cast_nullable_to_non_nullable
 as List<Event>,activeParties: null == activeParties ? _self.activeParties : activeParties // ignore: cast_nullable_to_non_nullable
 as List<Party>,draftParties: null == draftParties ? _self.draftParties : draftParties // ignore: cast_nullable_to_non_nullable
-as List<Party>,totalPartyCount: null == totalPartyCount ? _self.totalPartyCount : totalPartyCount // ignore: cast_nullable_to_non_nullable
+as List<Party>,draftEvents: null == draftEvents ? _self.draftEvents : draftEvents // ignore: cast_nullable_to_non_nullable
+as List<EventCreateDraft>,totalPartyCount: null == totalPartyCount ? _self.totalPartyCount : totalPartyCount // ignore: cast_nullable_to_non_nullable
 as int,totalAttendees: null == totalAttendees ? _self.totalAttendees : totalAttendees // ignore: cast_nullable_to_non_nullable
 as int,hasAnyEvents: null == hasAnyEvents ? _self.hasAnyEvents : hasAnyEvents // ignore: cast_nullable_to_non_nullable
 as bool,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
@@ -163,10 +164,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int pendingReviewCount,  List<Event> upcomingEvents,  List<Event> liveEvents,  List<Event> recruitingEvents,  List<Event> preparingEvents,  List<Party> activeParties,  List<Party> draftParties,  int totalPartyCount,  int totalAttendees,  bool hasAnyEvents,  AsyncValue<void> status)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int pendingReviewCount,  List<Event> upcomingEvents,  List<Event> liveEvents,  List<Event> recruitingEvents,  List<Event> preparingEvents,  List<Party> activeParties,  List<Party> draftParties,  List<EventCreateDraft> draftEvents,  int totalPartyCount,  int totalAttendees,  bool hasAnyEvents,  AsyncValue<void> status)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _PartnerDashboardState() when $default != null:
-return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_that.recruitingEvents,_that.preparingEvents,_that.activeParties,_that.draftParties,_that.totalPartyCount,_that.totalAttendees,_that.hasAnyEvents,_that.status);case _:
+return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_that.recruitingEvents,_that.preparingEvents,_that.activeParties,_that.draftParties,_that.draftEvents,_that.totalPartyCount,_that.totalAttendees,_that.hasAnyEvents,_that.status);case _:
   return orElse();
 
 }
@@ -184,10 +185,10 @@ return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int pendingReviewCount,  List<Event> upcomingEvents,  List<Event> liveEvents,  List<Event> recruitingEvents,  List<Event> preparingEvents,  List<Party> activeParties,  List<Party> draftParties,  int totalPartyCount,  int totalAttendees,  bool hasAnyEvents,  AsyncValue<void> status)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int pendingReviewCount,  List<Event> upcomingEvents,  List<Event> liveEvents,  List<Event> recruitingEvents,  List<Event> preparingEvents,  List<Party> activeParties,  List<Party> draftParties,  List<EventCreateDraft> draftEvents,  int totalPartyCount,  int totalAttendees,  bool hasAnyEvents,  AsyncValue<void> status)  $default,) {final _that = this;
 switch (_that) {
 case _PartnerDashboardState():
-return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_that.recruitingEvents,_that.preparingEvents,_that.activeParties,_that.draftParties,_that.totalPartyCount,_that.totalAttendees,_that.hasAnyEvents,_that.status);case _:
+return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_that.recruitingEvents,_that.preparingEvents,_that.activeParties,_that.draftParties,_that.draftEvents,_that.totalPartyCount,_that.totalAttendees,_that.hasAnyEvents,_that.status);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -204,10 +205,10 @@ return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int pendingReviewCount,  List<Event> upcomingEvents,  List<Event> liveEvents,  List<Event> recruitingEvents,  List<Event> preparingEvents,  List<Party> activeParties,  List<Party> draftParties,  int totalPartyCount,  int totalAttendees,  bool hasAnyEvents,  AsyncValue<void> status)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int pendingReviewCount,  List<Event> upcomingEvents,  List<Event> liveEvents,  List<Event> recruitingEvents,  List<Event> preparingEvents,  List<Party> activeParties,  List<Party> draftParties,  List<EventCreateDraft> draftEvents,  int totalPartyCount,  int totalAttendees,  bool hasAnyEvents,  AsyncValue<void> status)?  $default,) {final _that = this;
 switch (_that) {
 case _PartnerDashboardState() when $default != null:
-return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_that.recruitingEvents,_that.preparingEvents,_that.activeParties,_that.draftParties,_that.totalPartyCount,_that.totalAttendees,_that.hasAnyEvents,_that.status);case _:
+return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_that.recruitingEvents,_that.preparingEvents,_that.activeParties,_that.draftParties,_that.draftEvents,_that.totalPartyCount,_that.totalAttendees,_that.hasAnyEvents,_that.status);case _:
   return null;
 
 }
@@ -219,7 +220,7 @@ return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_
 
 
 class _PartnerDashboardState implements PartnerDashboardState {
-  const _PartnerDashboardState({this.pendingReviewCount = 0, final  List<Event> upcomingEvents = const [], final  List<Event> liveEvents = const [], final  List<Event> recruitingEvents = const [], final  List<Event> preparingEvents = const [], final  List<Party> activeParties = const [], final  List<Party> draftParties = const [], this.totalPartyCount = 0, this.totalAttendees = 0, this.hasAnyEvents = false, this.status = const AsyncValue<void>.loading()}): _upcomingEvents = upcomingEvents,_liveEvents = liveEvents,_recruitingEvents = recruitingEvents,_preparingEvents = preparingEvents,_activeParties = activeParties,_draftParties = draftParties;
+  const _PartnerDashboardState({this.pendingReviewCount = 0, final  List<Event> upcomingEvents = const [], final  List<Event> liveEvents = const [], final  List<Event> recruitingEvents = const [], final  List<Event> preparingEvents = const [], final  List<Party> activeParties = const [], final  List<Party> draftParties = const [], final  List<EventCreateDraft> draftEvents = const [], this.totalPartyCount = 0, this.totalAttendees = 0, this.hasAnyEvents = false, this.status = const AsyncValue<void>.loading()}): _upcomingEvents = upcomingEvents,_liveEvents = liveEvents,_recruitingEvents = recruitingEvents,_preparingEvents = preparingEvents,_activeParties = activeParties,_draftParties = draftParties,_draftEvents = draftEvents;
   
 
 @override@JsonKey() final  int pendingReviewCount;
@@ -265,6 +266,13 @@ class _PartnerDashboardState implements PartnerDashboardState {
   return EqualUnmodifiableListView(_draftParties);
 }
 
+ final  List<EventCreateDraft> _draftEvents;
+@override@JsonKey() List<EventCreateDraft> get draftEvents {
+  if (_draftEvents is EqualUnmodifiableListView) return _draftEvents;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_draftEvents);
+}
+
 @override@JsonKey() final  int totalPartyCount;
 @override@JsonKey() final  int totalAttendees;
 // Fix #1215: tracks ALL events ever created, not just upcoming ones.
@@ -283,16 +291,16 @@ _$PartnerDashboardStateCopyWith<_PartnerDashboardState> get copyWith => __$Partn
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PartnerDashboardState&&(identical(other.pendingReviewCount, pendingReviewCount) || other.pendingReviewCount == pendingReviewCount)&&const DeepCollectionEquality().equals(other._upcomingEvents, _upcomingEvents)&&const DeepCollectionEquality().equals(other._liveEvents, _liveEvents)&&const DeepCollectionEquality().equals(other._recruitingEvents, _recruitingEvents)&&const DeepCollectionEquality().equals(other._preparingEvents, _preparingEvents)&&const DeepCollectionEquality().equals(other._activeParties, _activeParties)&&const DeepCollectionEquality().equals(other._draftParties, _draftParties)&&(identical(other.totalPartyCount, totalPartyCount) || other.totalPartyCount == totalPartyCount)&&(identical(other.totalAttendees, totalAttendees) || other.totalAttendees == totalAttendees)&&(identical(other.hasAnyEvents, hasAnyEvents) || other.hasAnyEvents == hasAnyEvents)&&(identical(other.status, status) || other.status == status));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PartnerDashboardState&&(identical(other.pendingReviewCount, pendingReviewCount) || other.pendingReviewCount == pendingReviewCount)&&const DeepCollectionEquality().equals(other._upcomingEvents, _upcomingEvents)&&const DeepCollectionEquality().equals(other._liveEvents, _liveEvents)&&const DeepCollectionEquality().equals(other._recruitingEvents, _recruitingEvents)&&const DeepCollectionEquality().equals(other._preparingEvents, _preparingEvents)&&const DeepCollectionEquality().equals(other._activeParties, _activeParties)&&const DeepCollectionEquality().equals(other._draftParties, _draftParties)&&const DeepCollectionEquality().equals(other._draftEvents, _draftEvents)&&(identical(other.totalPartyCount, totalPartyCount) || other.totalPartyCount == totalPartyCount)&&(identical(other.totalAttendees, totalAttendees) || other.totalAttendees == totalAttendees)&&(identical(other.hasAnyEvents, hasAnyEvents) || other.hasAnyEvents == hasAnyEvents)&&(identical(other.status, status) || other.status == status));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,pendingReviewCount,const DeepCollectionEquality().hash(_upcomingEvents),const DeepCollectionEquality().hash(_liveEvents),const DeepCollectionEquality().hash(_recruitingEvents),const DeepCollectionEquality().hash(_preparingEvents),const DeepCollectionEquality().hash(_activeParties),const DeepCollectionEquality().hash(_draftParties),totalPartyCount,totalAttendees,hasAnyEvents,status);
+int get hashCode => Object.hash(runtimeType,pendingReviewCount,const DeepCollectionEquality().hash(_upcomingEvents),const DeepCollectionEquality().hash(_liveEvents),const DeepCollectionEquality().hash(_recruitingEvents),const DeepCollectionEquality().hash(_preparingEvents),const DeepCollectionEquality().hash(_activeParties),const DeepCollectionEquality().hash(_draftParties),const DeepCollectionEquality().hash(_draftEvents),totalPartyCount,totalAttendees,hasAnyEvents,status);
 
 @override
 String toString() {
-  return 'PartnerDashboardState(pendingReviewCount: $pendingReviewCount, upcomingEvents: $upcomingEvents, liveEvents: $liveEvents, recruitingEvents: $recruitingEvents, preparingEvents: $preparingEvents, activeParties: $activeParties, draftParties: $draftParties, totalPartyCount: $totalPartyCount, totalAttendees: $totalAttendees, hasAnyEvents: $hasAnyEvents, status: $status)';
+  return 'PartnerDashboardState(pendingReviewCount: $pendingReviewCount, upcomingEvents: $upcomingEvents, liveEvents: $liveEvents, recruitingEvents: $recruitingEvents, preparingEvents: $preparingEvents, activeParties: $activeParties, draftParties: $draftParties, draftEvents: $draftEvents, totalPartyCount: $totalPartyCount, totalAttendees: $totalAttendees, hasAnyEvents: $hasAnyEvents, status: $status)';
 }
 
 
@@ -303,7 +311,7 @@ abstract mixin class _$PartnerDashboardStateCopyWith<$Res> implements $PartnerDa
   factory _$PartnerDashboardStateCopyWith(_PartnerDashboardState value, $Res Function(_PartnerDashboardState) _then) = __$PartnerDashboardStateCopyWithImpl;
 @override @useResult
 $Res call({
- int pendingReviewCount, List<Event> upcomingEvents, List<Event> liveEvents, List<Event> recruitingEvents, List<Event> preparingEvents, List<Party> activeParties, List<Party> draftParties, int totalPartyCount, int totalAttendees, bool hasAnyEvents, AsyncValue<void> status
+ int pendingReviewCount, List<Event> upcomingEvents, List<Event> liveEvents, List<Event> recruitingEvents, List<Event> preparingEvents, List<Party> activeParties, List<Party> draftParties, List<EventCreateDraft> draftEvents, int totalPartyCount, int totalAttendees, bool hasAnyEvents, AsyncValue<void> status
 });
 
 
@@ -320,7 +328,7 @@ class __$PartnerDashboardStateCopyWithImpl<$Res>
 
 /// Create a copy of PartnerDashboardState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? pendingReviewCount = null,Object? upcomingEvents = null,Object? liveEvents = null,Object? recruitingEvents = null,Object? preparingEvents = null,Object? activeParties = null,Object? draftParties = null,Object? totalPartyCount = null,Object? totalAttendees = null,Object? hasAnyEvents = null,Object? status = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? pendingReviewCount = null,Object? upcomingEvents = null,Object? liveEvents = null,Object? recruitingEvents = null,Object? preparingEvents = null,Object? activeParties = null,Object? draftParties = null,Object? draftEvents = null,Object? totalPartyCount = null,Object? totalAttendees = null,Object? hasAnyEvents = null,Object? status = null,}) {
   return _then(_PartnerDashboardState(
 pendingReviewCount: null == pendingReviewCount ? _self.pendingReviewCount : pendingReviewCount // ignore: cast_nullable_to_non_nullable
 as int,upcomingEvents: null == upcomingEvents ? _self._upcomingEvents : upcomingEvents // ignore: cast_nullable_to_non_nullable
@@ -329,7 +337,8 @@ as List<Event>,recruitingEvents: null == recruitingEvents ? _self._recruitingEve
 as List<Event>,preparingEvents: null == preparingEvents ? _self._preparingEvents : preparingEvents // ignore: cast_nullable_to_non_nullable
 as List<Event>,activeParties: null == activeParties ? _self._activeParties : activeParties // ignore: cast_nullable_to_non_nullable
 as List<Party>,draftParties: null == draftParties ? _self._draftParties : draftParties // ignore: cast_nullable_to_non_nullable
-as List<Party>,totalPartyCount: null == totalPartyCount ? _self.totalPartyCount : totalPartyCount // ignore: cast_nullable_to_non_nullable
+as List<Party>,draftEvents: null == draftEvents ? _self._draftEvents : draftEvents // ignore: cast_nullable_to_non_nullable
+as List<EventCreateDraft>,totalPartyCount: null == totalPartyCount ? _self.totalPartyCount : totalPartyCount // ignore: cast_nullable_to_non_nullable
 as int,totalAttendees: null == totalAttendees ? _self.totalAttendees : totalAttendees // ignore: cast_nullable_to_non_nullable
 as int,hasAnyEvents: null == hasAnyEvents ? _self.hasAnyEvents : hasAnyEvents // ignore: cast_nullable_to_non_nullable
 as bool,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable

--- a/apps/app_partner/lib/src/features/home/partner_dashboard_controller.g.dart
+++ b/apps/app_partner/lib/src/features/home/partner_dashboard_controller.g.dart
@@ -44,7 +44,7 @@ final class PartnerDashboardControllerProvider
 }
 
 String _$partnerDashboardControllerHash() =>
-    r'41a7469d75396ef734499342ce7f735ce58ba444';
+    r'899e6138643104840ee0bf6656d89ef7c19047af';
 
 abstract class _$PartnerDashboardController
     extends $Notifier<PartnerDashboardState> {

--- a/apps/app_partner/lib/src/features/home/partner_home_page.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_page.dart
@@ -3,6 +3,7 @@ import 'dart:async' show unawaited;
 import 'package:app_partner/src/features/home/partner_dashboard_controller.dart';
 import 'package:app_partner/src/features/home/partner_home_coordinator.dart';
 import 'package:app_partner/src/features/home/widgets/home_approval_pending_card.dart';
+import 'package:app_partner/src/features/home/widgets/home_draft_event_card.dart';
 import 'package:app_partner/src/features/home/widgets/home_draft_party_card.dart';
 import 'package:app_partner/src/features/home/widgets/home_live_event_card.dart';
 import 'package:app_partner/src/features/home/widgets/home_overview_block.dart';
@@ -41,6 +42,28 @@ class PartnerHomePage extends ConsumerWidget {
     final state = ref.watch(partnerDashboardControllerProvider);
     final partner = ref.watch(currentPartnerInfoProvider).asData?.value;
     final coordinator = ref.read(partnerHomeCoordinatorProvider);
+    String? partyNameFor(String partyId) {
+      for (final party in state.activeParties) {
+        if (party.id == partyId) return party.title;
+      }
+      return null;
+    }
+
+    Future<void> openFirstEventCreate() async {
+      if (state.activeParties.length == 1) {
+        coordinator.pushEventCreate(state.activeParties.first.id);
+        return;
+      }
+      final selected = await showMinglitBottomSheet<Party>(
+        context: context,
+        title: '이벤트를 만들 파티를 선택하세요',
+        child: _PartySelectionSheet(parties: state.activeParties),
+      );
+      if (selected != null) {
+        coordinator.pushEventCreate(selected.id);
+      }
+    }
+
     final unreadCount = ref
         .watch(notificationListProvider)
         .maybeWhen(
@@ -133,23 +156,18 @@ class PartnerHomePage extends ConsumerWidget {
                       hasParty: state.activeParties.isNotEmpty,
                       partyName: state.activeParties.firstOrNull?.title,
                       onCreateParty: coordinator.pushPartyCreate,
-                      onCreateEvent: () async {
-                        if (state.activeParties.length == 1) {
-                          coordinator.pushEventCreate(
-                            state.activeParties.first.id,
-                          );
-                          return;
-                        }
-                        final selected = await showModalBottomSheet<Party>(
-                          context: context,
-                          builder: (bottomSheetContext) => _PartySelectionSheet(
-                            parties: state.activeParties,
-                          ),
-                        );
-                        if (selected != null) {
-                          coordinator.pushEventCreate(selected.id);
-                        }
-                      },
+                      onCreateEvent: openFirstEventCreate,
+                      draftEventCard: state.draftEvents.isEmpty
+                          ? null
+                          : HomeDraftEventCard(
+                              draft: state.draftEvents.first,
+                              partyName: partyNameFor(
+                                state.draftEvents.first.partyId,
+                              ),
+                              onResume: () => coordinator.pushEventCreate(
+                                state.draftEvents.first.partyId,
+                              ),
+                            ),
                       onOpenGuide: coordinator.pushPartnerGuide,
                     ),
                   ] else ...[
@@ -262,6 +280,24 @@ class PartnerHomePage extends ConsumerWidget {
                         ),
                       ),
                     ],
+                    if (state.draftEvents.isNotEmpty) ...[
+                      const SizedBox(height: MinglitSpacing.large),
+                      const HomeSectionHeader(title: '작성 중'),
+                      const SizedBox(height: MinglitSpacing.small),
+                      ...state.draftEvents.map(
+                        (draft) => Padding(
+                          padding: const EdgeInsets.only(
+                            bottom: MinglitSpacing.small,
+                          ),
+                          child: HomeDraftEventCard(
+                            draft: draft,
+                            partyName: partyNameFor(draft.partyId),
+                            onResume: () =>
+                                coordinator.pushEventCreate(draft.partyId),
+                          ),
+                        ),
+                      ),
+                    ],
                   ],
                 ],
               ),
@@ -319,31 +355,18 @@ class _PartySelectionSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.only(bottom: MinglitSpacing.medium),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(MinglitSpacing.large),
-              child: Text(
-                '이벤트를 만들 파티를 선택하세요',
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-            ),
-            ...parties.map(
-              (party) => ListTile(
-                leading: const Icon(Icons.storefront_outlined),
-                title: Text(party.title),
-                onTap: () => Navigator.of(context).pop(party),
-              ),
-            ),
-          ],
-        ),
-      ),
+    return ListView.separated(
+      shrinkWrap: true,
+      itemCount: parties.length,
+      separatorBuilder: (_, _) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final party = parties[index];
+        return MinglitListTile(
+          leading: const Icon(Icons.storefront_outlined),
+          title: party.title,
+          onTap: () => Navigator.of(context).pop(party),
+        );
+      },
     );
   }
 }

--- a/apps/app_partner/lib/src/features/home/widgets/home_draft_event_card.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/home_draft_event_card.dart
@@ -1,0 +1,67 @@
+import 'package:app_partner/src/logic/event_create_draft_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+class HomeDraftEventCard extends StatelessWidget {
+  const HomeDraftEventCard({
+    required this.draft,
+    required this.partyName,
+    required this.onResume,
+    super.key,
+  });
+
+  final EventCreateDraft draft;
+  final String? partyName;
+  final VoidCallback onResume;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final updatedAt = DateFormat('yyyy-MM-dd HH:mm').format(draft.updatedAt);
+    final title = draft.title.trim().isEmpty ? '작성 중인 이벤트' : draft.title;
+
+    return Card(
+      elevation: 0,
+      margin: EdgeInsets.zero,
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: MinglitSpacing.medium,
+          vertical: MinglitSpacing.xsmall,
+        ),
+        leading: Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: theme.colorScheme.outlineVariant.withValues(
+              alpha: MinglitOpacity.muted,
+            ),
+            borderRadius: BorderRadius.circular(MinglitRadius.input),
+          ),
+          child: Icon(
+            Icons.edit_note_outlined,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        title: Text(
+          title,
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        subtitle: Text(
+          [
+            if (partyName != null) partyName,
+            '임시저장 · $updatedAt 마지막 수정',
+          ].join(' · '),
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        onTap: onResume,
+      ),
+    );
+  }
+}

--- a/apps/app_partner/lib/src/features/home/widgets/onboarding_step_guide.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/onboarding_step_guide.dart
@@ -9,6 +9,7 @@ class OnboardingStepGuide extends StatelessWidget {
     required this.partyName,
     required this.onCreateParty,
     required this.onCreateEvent,
+    this.draftEventCard,
     this.onOpenGuide,
     super.key,
   });
@@ -17,6 +18,7 @@ class OnboardingStepGuide extends StatelessWidget {
   final String? partyName;
   final VoidCallback onCreateParty;
   final VoidCallback onCreateEvent;
+  final Widget? draftEventCard;
   final VoidCallback? onOpenGuide;
 
   @override
@@ -194,26 +196,33 @@ class OnboardingStepGuide extends StatelessWidget {
           ),
         ],
 
-        const SizedBox(height: MinglitSpacing.medium),
+        if (hasParty && draftEventCard != null) ...[
+          const SizedBox(height: MinglitSpacing.medium),
+          draftEventCard!,
+        ] else ...[
+          const SizedBox(height: MinglitSpacing.medium),
 
-        // Main CTA
-        SizedBox(
-          width: double.infinity,
-          child: FilledButton.icon(
-            onPressed: hasParty ? onCreateEvent : onCreateParty,
-            icon: Icon(
-              hasParty ? Icons.event_outlined : Icons.celebration_outlined,
-              size: MinglitIconSize.small,
-            ),
-            label: Text(hasParty ? '첫 이벤트 만들기' : '첫 파티 만들기'),
-            style: FilledButton.styleFrom(
-              padding: const EdgeInsets.symmetric(vertical: MinglitSpacing.sm),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(MinglitRadius.input),
+          // Main CTA
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: hasParty ? onCreateEvent : onCreateParty,
+              icon: Icon(
+                hasParty ? Icons.event_outlined : Icons.celebration_outlined,
+                size: MinglitIconSize.small,
+              ),
+              label: Text(hasParty ? '첫 이벤트 만들기' : '첫 파티 만들기'),
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(
+                  vertical: MinglitSpacing.sm,
+                ),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(MinglitRadius.input),
+                ),
               ),
             ),
           ),
-        ),
+        ],
 
         // How it works (only before party creation)
         if (!hasParty) ...[

--- a/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
+++ b/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
@@ -279,7 +279,18 @@ class EventCreateController extends _$EventCreateController {
 
   Future<void> saveDraftNow() async {
     if (_isSubmitting) return;
-    final save = _saveDraftNow();
+    final previousSave = _draftSaveInFlight;
+    final save = () async {
+      if (previousSave != null) {
+        try {
+          await previousSave;
+        } on Object {
+          // A later explicit save should still try to persist the latest state.
+        }
+      }
+      if (_isSubmitting || !ref.mounted) return;
+      await _saveDraftNow();
+    }();
     _draftSaveInFlight = save;
     try {
       await save;

--- a/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
+++ b/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
 import 'package:app_partner/src/features/party/logic/recurrence_settings_controller.dart';
 import 'package:app_partner/src/logic/dashboard_refresh_notifier.dart';
+import 'package:app_partner/src/logic/event_create_draft_repository.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -14,6 +17,8 @@ abstract class EventCreateState with _$EventCreateState {
     required String partyId,
     required DateTime startTime,
     required DateTime endTime,
+    String? draftId,
+    @Default(0) int checkpointTabIndex,
     @Default(20) int maxParticipants,
     @Default('') String title,
     @Default({}) Map<String, dynamic> description,
@@ -26,14 +31,18 @@ abstract class EventCreateState with _$EventCreateState {
     @Default([]) List<EntryGroup> entryGroups,
     @Default([]) List<Ticket> tickets,
     String? visibility,
+    DateTime? draftUpdatedAt,
     @Default(AsyncValue.data(null)) AsyncValue<void> status,
   }) = _EventCreateState;
 }
 
 @riverpod
 class EventCreateController extends _$EventCreateController {
+  Timer? _draftSaveDebounce;
+
   @override
   EventCreateState build(String partyId) {
+    ref.onDispose(() => _draftSaveDebounce?.cancel());
     final now = DateTime.now();
     final nextWeek = DateTime(now.year, now.month, now.day + 7, 19);
 
@@ -44,11 +53,21 @@ class EventCreateController extends _$EventCreateController {
     );
   }
 
-  void initWithParty({
+  Future<void> initWithParty({
     required Party party,
     required List<TicketTemplate> templates,
     Location? location,
-  }) {
+  }) async {
+    final savedDraft = await ref
+        .read(eventCreateDraftRepositoryProvider)
+        .getDraft(party.id);
+    if (savedDraft != null) {
+      state = savedDraft.toState();
+      ref.read(recurrenceSettingsControllerProvider.notifier).snapshot =
+          savedDraft.recurrence;
+      return;
+    }
+
     // 1. Create a base event from party template using the standardized factory
     final baseEvent = Event.createFromParty(
       party,
@@ -84,61 +103,78 @@ class EventCreateController extends _$EventCreateController {
   }
 
   void updateStartTime(DateTime dateTime) {
-    state = state.copyWith(startTime: dateTime);
-    if (state.endTime.isBefore(dateTime)) {
-      state = state.copyWith(endTime: dateTime.add(const Duration(hours: 3)));
+    var nextState = state.copyWith(startTime: dateTime);
+    if (nextState.endTime.isBefore(dateTime)) {
+      nextState = nextState.copyWith(
+        endTime: dateTime.add(const Duration(hours: 3)),
+      );
     }
+    _setDraftableState(nextState);
   }
 
   void updateEndTime(DateTime dateTime) {
-    state = state.copyWith(endTime: dateTime);
+    _setDraftableState(state.copyWith(endTime: dateTime));
   }
 
   void updateMaxParticipants(int count) {
-    state = state.copyWith(maxParticipants: count);
+    _setDraftableState(state.copyWith(maxParticipants: count));
   }
 
   void updateTitle(String? value) {
-    state = state.copyWith(title: value ?? '');
+    _setDraftableState(state.copyWith(title: value ?? ''));
   }
 
   void updateDescription(Map<String, dynamic> value) {
-    state = state.copyWith(description: value);
+    _setDraftableState(state.copyWith(description: value));
   }
 
   void updateImageUrl(String? value) {
-    state = state.copyWith(imageUrl: value);
+    _setDraftableState(state.copyWith(imageUrl: value));
   }
 
   void updateContactOptions(Map<String, dynamic> options) {
-    state = state.copyWith(contactOptions: options);
+    _setDraftableState(state.copyWith(contactOptions: options));
   }
 
   void updateLocation(Location? location) {
-    state = state.copyWith(
-      selectedLocation: location,
-      locationId: location?.id,
+    _setDraftableState(
+      state.copyWith(
+        selectedLocation: location,
+        locationId: location?.id,
+      ),
     );
   }
 
   void updateAddressDetail(String? value) {
-    state = state.copyWith(addressDetail: value);
+    _setDraftableState(state.copyWith(addressDetail: value));
   }
 
   void updateDirections(String? value) {
-    state = state.copyWith(directionsGuide: value);
+    _setDraftableState(state.copyWith(directionsGuide: value));
   }
 
   void setVisibility(String? value) {
-    state = state.copyWith(visibility: value);
+    _setDraftableState(state.copyWith(visibility: value));
+  }
+
+  void updateCheckpointTab(int index) {
+    if (state.checkpointTabIndex == index) return;
+    _setDraftableState(state.copyWith(checkpointTabIndex: index));
+  }
+
+  void saveDraftSoon() {
+    _scheduleDraftSave();
   }
 
   Future<void> submit() async {
+    _draftSaveDebounce?.cancel();
     state = state.copyWith(status: const AsyncValue<void>.loading());
 
     // Fix #1037: snapshot recurrence state before any await to avoid race
     // conditions.
     final recurrenceSnapshot = ref.read(recurrenceSettingsControllerProvider);
+    final draftRepo = ref.read(eventCreateDraftRepositoryProvider);
+    final draftPartyId = state.partyId;
 
     final result = await AsyncValue.guard(() async {
       final repo = ref.read(partyRepositoryProvider);
@@ -204,6 +240,39 @@ class EventCreateController extends _$EventCreateController {
       ref.read(dashboardRefreshProvider.notifier).bump();
     });
 
-    state = state.copyWith(status: result);
+    if (result.hasValue) {
+      await draftRepo.deleteDraft(draftPartyId);
+    }
+    if (!ref.mounted) return;
+    state = state.copyWith(
+      draftId: result.hasValue ? null : state.draftId,
+      draftUpdatedAt: result.hasValue ? null : state.draftUpdatedAt,
+      status: result,
+    );
+  }
+
+  void _setDraftableState(EventCreateState nextState) {
+    state = nextState;
+    _scheduleDraftSave();
+  }
+
+  void _scheduleDraftSave() {
+    _draftSaveDebounce?.cancel();
+    _draftSaveDebounce = Timer(const Duration(milliseconds: 500), () {
+      unawaited(saveDraftNow());
+    });
+  }
+
+  Future<void> saveDraftNow() async {
+    _draftSaveDebounce?.cancel();
+    final updatedAt = DateTime.now();
+    final recurrence = ref.read(recurrenceSettingsControllerProvider);
+    final draft = EventCreateDraft.fromState(
+      state: state,
+      recurrence: recurrence,
+      updatedAt: updatedAt,
+    );
+    await ref.read(eventCreateDraftRepositoryProvider).saveDraft(draft);
+    state = state.copyWith(draftId: draft.id, draftUpdatedAt: updatedAt);
   }
 }

--- a/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
+++ b/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
@@ -39,6 +39,8 @@ abstract class EventCreateState with _$EventCreateState {
 @riverpod
 class EventCreateController extends _$EventCreateController {
   Timer? _draftSaveDebounce;
+  Future<void>? _draftSaveInFlight;
+  bool _isSubmitting = false;
 
   @override
   EventCreateState build(String partyId) {
@@ -168,90 +170,99 @@ class EventCreateController extends _$EventCreateController {
   }
 
   Future<void> submit() async {
-    _draftSaveDebounce?.cancel();
-    state = state.copyWith(status: const AsyncValue<void>.loading());
+    _isSubmitting = true;
+    try {
+      _draftSaveDebounce?.cancel();
+      state = state.copyWith(status: const AsyncValue<void>.loading());
+      await _draftSaveInFlight;
+      if (!ref.mounted) return;
 
-    // Fix #1037: snapshot recurrence state before any await to avoid race
-    // conditions.
-    final recurrenceSnapshot = ref.read(recurrenceSettingsControllerProvider);
-    final draftRepo = ref.read(eventCreateDraftRepositoryProvider);
-    final dashboardRefresh = ref.read(dashboardRefreshProvider.notifier);
-    final draftPartyId = state.partyId;
+      // Fix #1037: snapshot recurrence state before any await to avoid race
+      // conditions.
+      final recurrenceSnapshot = ref.read(recurrenceSettingsControllerProvider);
+      final draftRepo = ref.read(eventCreateDraftRepositoryProvider);
+      final dashboardRefresh = ref.read(dashboardRefreshProvider.notifier);
+      final draftPartyId = state.partyId;
 
-    final result = await AsyncValue.guard(() async {
-      final repo = ref.read(partyRepositoryProvider);
-      final locationRepo = ref.read(locationRepositoryProvider);
+      final result = await AsyncValue.guard(() async {
+        final repo = ref.read(partyRepositoryProvider);
+        final locationRepo = ref.read(locationRepositoryProvider);
 
-      var finalLocationId = state.locationId;
+        var finalLocationId = state.locationId;
 
-      if (state.selectedLocation != null &&
-          (state.locationId == null || state.locationId!.isEmpty)) {
-        // Fetch current party to get partnerId
-        final party = await ref.read(partyDetailProvider(state.partyId).future);
-        final newLoc = await locationRepo.createLocation(
-          state.selectedLocation!.copyWith(
-            partnerId: party.partnerId,
-            addressDetail: state.addressDetail,
-            directionsGuide: state.directionsGuide,
-          ),
-        );
-        finalLocationId = newLoc.id;
-      }
+        if (state.selectedLocation != null &&
+            (state.locationId == null || state.locationId!.isEmpty)) {
+          // Fetch current party to get partnerId
+          final party = await ref.read(
+            partyDetailProvider(state.partyId).future,
+          );
+          final newLoc = await locationRepo.createLocation(
+            state.selectedLocation!.copyWith(
+              partnerId: party.partnerId,
+              addressDetail: state.addressDetail,
+              directionsGuide: state.directionsGuide,
+            ),
+          );
+          finalLocationId = newLoc.id;
+        }
 
-      final event = Event(
-        id: '',
-        partyId: state.partyId,
-        startTime: state.startTime,
-        endTime: state.endTime,
-        createdAt: DateTime.now(),
-        updatedAt: DateTime.now(),
-        maxParticipants: state.maxParticipants,
-        locationId: finalLocationId,
-        title: state.title,
-        description: state.description.isEmpty ? null : state.description,
-        contactOptions: state.contactOptions,
-        entryGroups: state.entryGroups,
-        tickets: state.tickets, // Pass the tickets to repository
-        visibility: state.visibility,
-      );
-
-      await repo.createEvent(event);
-
-      // Fix #1037: 반복 설정이 활성화된 경우 recurrence rule 생성 (invalidate는 이후)
-      if (recurrenceSnapshot.isEnabled) {
-        final recurrenceRepo = ref.read(recurrenceRuleRepositoryProvider);
-        String pad2(int n) => n.toString().padLeft(2, '0');
-        final startTimeStr =
-            '${pad2(state.startTime.hour)}:${pad2(state.startTime.minute)}';
-        final endTimeStr =
-            '${pad2(state.endTime.hour)}:${pad2(state.endTime.minute)}';
-        await recurrenceRepo.create(
+        final event = Event(
+          id: '',
           partyId: state.partyId,
-          pattern: recurrenceSnapshot.pattern,
-          daysOfWeek: recurrenceSnapshot.daysOfWeek,
-          monthDay: recurrenceSnapshot.monthDay,
-          startTime: startTimeStr,
-          endTime: endTimeStr,
-          endDate: recurrenceSnapshot.endDate,
+          startTime: state.startTime,
+          endTime: state.endTime,
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+          maxParticipants: state.maxParticipants,
+          locationId: finalLocationId,
+          title: state.title,
+          description: state.description.isEmpty ? null : state.description,
+          contactOptions: state.contactOptions,
+          entryGroups: state.entryGroups,
+          tickets: state.tickets, // Pass the tickets to repository
+          visibility: state.visibility,
         );
+
+        await repo.createEvent(event);
+
+        // Fix #1037: 반복 설정이 활성화된 경우 recurrence rule 생성 (invalidate는 이후)
+        if (recurrenceSnapshot.isEnabled) {
+          final recurrenceRepo = ref.read(recurrenceRuleRepositoryProvider);
+          String pad2(int n) => n.toString().padLeft(2, '0');
+          final startTimeStr =
+              '${pad2(state.startTime.hour)}:${pad2(state.startTime.minute)}';
+          final endTimeStr =
+              '${pad2(state.endTime.hour)}:${pad2(state.endTime.minute)}';
+          await recurrenceRepo.create(
+            partyId: state.partyId,
+            pattern: recurrenceSnapshot.pattern,
+            daysOfWeek: recurrenceSnapshot.daysOfWeek,
+            monthDay: recurrenceSnapshot.monthDay,
+            startTime: startTimeStr,
+            endTime: endTimeStr,
+            endDate: recurrenceSnapshot.endDate,
+          );
+        }
+
+        ref.invalidate(partyEventsProvider(state.partyId));
+        // Fix #1943: bump shared signal so dashboard refreshes without
+        // cross-feature import.
+        dashboardRefresh.bump();
+      });
+
+      if (result.hasValue) {
+        await draftRepo.deleteDraft(draftPartyId);
+        dashboardRefresh.bump();
       }
-
-      ref.invalidate(partyEventsProvider(state.partyId));
-      // Fix #1943: bump shared signal so dashboard refreshes without
-      // cross-feature import.
-      dashboardRefresh.bump();
-    });
-
-    if (result.hasValue) {
-      await draftRepo.deleteDraft(draftPartyId);
-      dashboardRefresh.bump();
+      if (!ref.mounted) return;
+      state = state.copyWith(
+        draftId: result.hasValue ? null : state.draftId,
+        draftUpdatedAt: result.hasValue ? null : state.draftUpdatedAt,
+        status: result,
+      );
+    } finally {
+      _isSubmitting = false;
     }
-    if (!ref.mounted) return;
-    state = state.copyWith(
-      draftId: result.hasValue ? null : state.draftId,
-      draftUpdatedAt: result.hasValue ? null : state.draftUpdatedAt,
-      status: result,
-    );
   }
 
   void _setDraftableState(EventCreateState nextState) {
@@ -267,6 +278,19 @@ class EventCreateController extends _$EventCreateController {
   }
 
   Future<void> saveDraftNow() async {
+    if (_isSubmitting) return;
+    final save = _saveDraftNow();
+    _draftSaveInFlight = save;
+    try {
+      await save;
+    } finally {
+      if (identical(_draftSaveInFlight, save)) {
+        _draftSaveInFlight = null;
+      }
+    }
+  }
+
+  Future<void> _saveDraftNow() async {
     _draftSaveDebounce?.cancel();
     final updatedAt = DateTime.now();
     final recurrence = ref.read(recurrenceSettingsControllerProvider);

--- a/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
+++ b/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
@@ -61,6 +61,7 @@ class EventCreateController extends _$EventCreateController {
     final savedDraft = await ref
         .read(eventCreateDraftRepositoryProvider)
         .getDraft(party.id);
+    if (!ref.mounted) return;
     if (savedDraft != null) {
       state = savedDraft.toState();
       ref.read(recurrenceSettingsControllerProvider.notifier).snapshot =
@@ -174,6 +175,7 @@ class EventCreateController extends _$EventCreateController {
     // conditions.
     final recurrenceSnapshot = ref.read(recurrenceSettingsControllerProvider);
     final draftRepo = ref.read(eventCreateDraftRepositoryProvider);
+    final dashboardRefresh = ref.read(dashboardRefreshProvider.notifier);
     final draftPartyId = state.partyId;
 
     final result = await AsyncValue.guard(() async {
@@ -237,11 +239,12 @@ class EventCreateController extends _$EventCreateController {
       ref.invalidate(partyEventsProvider(state.partyId));
       // Fix #1943: bump shared signal so dashboard refreshes without
       // cross-feature import.
-      ref.read(dashboardRefreshProvider.notifier).bump();
+      dashboardRefresh.bump();
     });
 
     if (result.hasValue) {
       await draftRepo.deleteDraft(draftPartyId);
+      dashboardRefresh.bump();
     }
     if (!ref.mounted) return;
     state = state.copyWith(
@@ -267,12 +270,16 @@ class EventCreateController extends _$EventCreateController {
     _draftSaveDebounce?.cancel();
     final updatedAt = DateTime.now();
     final recurrence = ref.read(recurrenceSettingsControllerProvider);
+    final draftRepo = ref.read(eventCreateDraftRepositoryProvider);
+    final dashboardRefresh = ref.read(dashboardRefreshProvider.notifier);
     final draft = EventCreateDraft.fromState(
       state: state,
       recurrence: recurrence,
       updatedAt: updatedAt,
     );
-    await ref.read(eventCreateDraftRepositoryProvider).saveDraft(draft);
+    await draftRepo.saveDraft(draft);
+    dashboardRefresh.bump();
+    if (!ref.mounted) return;
     state = state.copyWith(draftId: draft.id, draftUpdatedAt: updatedAt);
   }
 }

--- a/apps/app_partner/lib/src/features/party/event/create/event_create_controller.freezed.dart
+++ b/apps/app_partner/lib/src/features/party/event/create/event_create_controller.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EventCreateState {
 
- String get partyId; DateTime get startTime; DateTime get endTime; int get maxParticipants; String get title; Map<String, dynamic> get description; String? get imageUrl; String? get locationId; Location? get selectedLocation; String? get addressDetail; String? get directionsGuide; Map<String, dynamic> get contactOptions; List<EntryGroup> get entryGroups; List<Ticket> get tickets; String? get visibility; AsyncValue<void> get status;
+ String get partyId; DateTime get startTime; DateTime get endTime; String? get draftId; int get checkpointTabIndex; int get maxParticipants; String get title; Map<String, dynamic> get description; String? get imageUrl; String? get locationId; Location? get selectedLocation; String? get addressDetail; String? get directionsGuide; Map<String, dynamic> get contactOptions; List<EntryGroup> get entryGroups; List<Ticket> get tickets; String? get visibility; DateTime? get draftUpdatedAt; AsyncValue<void> get status;
 /// Create a copy of EventCreateState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $EventCreateStateCopyWith<EventCreateState> get copyWith => _$EventCreateStateCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EventCreateState&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.maxParticipants, maxParticipants) || other.maxParticipants == maxParticipants)&&(identical(other.title, title) || other.title == title)&&const DeepCollectionEquality().equals(other.description, description)&&(identical(other.imageUrl, imageUrl) || other.imageUrl == imageUrl)&&(identical(other.locationId, locationId) || other.locationId == locationId)&&(identical(other.selectedLocation, selectedLocation) || other.selectedLocation == selectedLocation)&&(identical(other.addressDetail, addressDetail) || other.addressDetail == addressDetail)&&(identical(other.directionsGuide, directionsGuide) || other.directionsGuide == directionsGuide)&&const DeepCollectionEquality().equals(other.contactOptions, contactOptions)&&const DeepCollectionEquality().equals(other.entryGroups, entryGroups)&&const DeepCollectionEquality().equals(other.tickets, tickets)&&(identical(other.visibility, visibility) || other.visibility == visibility)&&(identical(other.status, status) || other.status == status));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EventCreateState&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.draftId, draftId) || other.draftId == draftId)&&(identical(other.checkpointTabIndex, checkpointTabIndex) || other.checkpointTabIndex == checkpointTabIndex)&&(identical(other.maxParticipants, maxParticipants) || other.maxParticipants == maxParticipants)&&(identical(other.title, title) || other.title == title)&&const DeepCollectionEquality().equals(other.description, description)&&(identical(other.imageUrl, imageUrl) || other.imageUrl == imageUrl)&&(identical(other.locationId, locationId) || other.locationId == locationId)&&(identical(other.selectedLocation, selectedLocation) || other.selectedLocation == selectedLocation)&&(identical(other.addressDetail, addressDetail) || other.addressDetail == addressDetail)&&(identical(other.directionsGuide, directionsGuide) || other.directionsGuide == directionsGuide)&&const DeepCollectionEquality().equals(other.contactOptions, contactOptions)&&const DeepCollectionEquality().equals(other.entryGroups, entryGroups)&&const DeepCollectionEquality().equals(other.tickets, tickets)&&(identical(other.visibility, visibility) || other.visibility == visibility)&&(identical(other.draftUpdatedAt, draftUpdatedAt) || other.draftUpdatedAt == draftUpdatedAt)&&(identical(other.status, status) || other.status == status));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,partyId,startTime,endTime,maxParticipants,title,const DeepCollectionEquality().hash(description),imageUrl,locationId,selectedLocation,addressDetail,directionsGuide,const DeepCollectionEquality().hash(contactOptions),const DeepCollectionEquality().hash(entryGroups),const DeepCollectionEquality().hash(tickets),visibility,status);
+int get hashCode => Object.hashAll([runtimeType,partyId,startTime,endTime,draftId,checkpointTabIndex,maxParticipants,title,const DeepCollectionEquality().hash(description),imageUrl,locationId,selectedLocation,addressDetail,directionsGuide,const DeepCollectionEquality().hash(contactOptions),const DeepCollectionEquality().hash(entryGroups),const DeepCollectionEquality().hash(tickets),visibility,draftUpdatedAt,status]);
 
 @override
 String toString() {
-  return 'EventCreateState(partyId: $partyId, startTime: $startTime, endTime: $endTime, maxParticipants: $maxParticipants, title: $title, description: $description, imageUrl: $imageUrl, locationId: $locationId, selectedLocation: $selectedLocation, addressDetail: $addressDetail, directionsGuide: $directionsGuide, contactOptions: $contactOptions, entryGroups: $entryGroups, tickets: $tickets, visibility: $visibility, status: $status)';
+  return 'EventCreateState(partyId: $partyId, startTime: $startTime, endTime: $endTime, draftId: $draftId, checkpointTabIndex: $checkpointTabIndex, maxParticipants: $maxParticipants, title: $title, description: $description, imageUrl: $imageUrl, locationId: $locationId, selectedLocation: $selectedLocation, addressDetail: $addressDetail, directionsGuide: $directionsGuide, contactOptions: $contactOptions, entryGroups: $entryGroups, tickets: $tickets, visibility: $visibility, draftUpdatedAt: $draftUpdatedAt, status: $status)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $EventCreateStateCopyWith<$Res>  {
   factory $EventCreateStateCopyWith(EventCreateState value, $Res Function(EventCreateState) _then) = _$EventCreateStateCopyWithImpl;
 @useResult
 $Res call({
- String partyId, DateTime startTime, DateTime endTime, int maxParticipants, String title, Map<String, dynamic> description, String? imageUrl, String? locationId, Location? selectedLocation, String? addressDetail, String? directionsGuide, Map<String, dynamic> contactOptions, List<EntryGroup> entryGroups, List<Ticket> tickets, String? visibility, AsyncValue<void> status
+ String partyId, DateTime startTime, DateTime endTime, String? draftId, int checkpointTabIndex, int maxParticipants, String title, Map<String, dynamic> description, String? imageUrl, String? locationId, Location? selectedLocation, String? addressDetail, String? directionsGuide, Map<String, dynamic> contactOptions, List<EntryGroup> entryGroups, List<Ticket> tickets, String? visibility, DateTime? draftUpdatedAt, AsyncValue<void> status
 });
 
 
@@ -62,12 +62,14 @@ class _$EventCreateStateCopyWithImpl<$Res>
 
 /// Create a copy of EventCreateState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? partyId = null,Object? startTime = null,Object? endTime = null,Object? maxParticipants = null,Object? title = null,Object? description = null,Object? imageUrl = freezed,Object? locationId = freezed,Object? selectedLocation = freezed,Object? addressDetail = freezed,Object? directionsGuide = freezed,Object? contactOptions = null,Object? entryGroups = null,Object? tickets = null,Object? visibility = freezed,Object? status = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? partyId = null,Object? startTime = null,Object? endTime = null,Object? draftId = freezed,Object? checkpointTabIndex = null,Object? maxParticipants = null,Object? title = null,Object? description = null,Object? imageUrl = freezed,Object? locationId = freezed,Object? selectedLocation = freezed,Object? addressDetail = freezed,Object? directionsGuide = freezed,Object? contactOptions = null,Object? entryGroups = null,Object? tickets = null,Object? visibility = freezed,Object? draftUpdatedAt = freezed,Object? status = null,}) {
   return _then(_self.copyWith(
 partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
 as String,startTime: null == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
 as DateTime,endTime: null == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
-as DateTime,maxParticipants: null == maxParticipants ? _self.maxParticipants : maxParticipants // ignore: cast_nullable_to_non_nullable
+as DateTime,draftId: freezed == draftId ? _self.draftId : draftId // ignore: cast_nullable_to_non_nullable
+as String?,checkpointTabIndex: null == checkpointTabIndex ? _self.checkpointTabIndex : checkpointTabIndex // ignore: cast_nullable_to_non_nullable
+as int,maxParticipants: null == maxParticipants ? _self.maxParticipants : maxParticipants // ignore: cast_nullable_to_non_nullable
 as int,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as Map<String, dynamic>,imageUrl: freezed == imageUrl ? _self.imageUrl : imageUrl // ignore: cast_nullable_to_non_nullable
@@ -79,7 +81,8 @@ as String?,contactOptions: null == contactOptions ? _self.contactOptions : conta
 as Map<String, dynamic>,entryGroups: null == entryGroups ? _self.entryGroups : entryGroups // ignore: cast_nullable_to_non_nullable
 as List<EntryGroup>,tickets: null == tickets ? _self.tickets : tickets // ignore: cast_nullable_to_non_nullable
 as List<Ticket>,visibility: freezed == visibility ? _self.visibility : visibility // ignore: cast_nullable_to_non_nullable
-as String?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String?,draftUpdatedAt: freezed == draftUpdatedAt ? _self.draftUpdatedAt : draftUpdatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as AsyncValue<void>,
   ));
 }
@@ -177,10 +180,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String partyId,  DateTime startTime,  DateTime endTime,  int maxParticipants,  String title,  Map<String, dynamic> description,  String? imageUrl,  String? locationId,  Location? selectedLocation,  String? addressDetail,  String? directionsGuide,  Map<String, dynamic> contactOptions,  List<EntryGroup> entryGroups,  List<Ticket> tickets,  String? visibility,  AsyncValue<void> status)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String partyId,  DateTime startTime,  DateTime endTime,  String? draftId,  int checkpointTabIndex,  int maxParticipants,  String title,  Map<String, dynamic> description,  String? imageUrl,  String? locationId,  Location? selectedLocation,  String? addressDetail,  String? directionsGuide,  Map<String, dynamic> contactOptions,  List<EntryGroup> entryGroups,  List<Ticket> tickets,  String? visibility,  DateTime? draftUpdatedAt,  AsyncValue<void> status)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EventCreateState() when $default != null:
-return $default(_that.partyId,_that.startTime,_that.endTime,_that.maxParticipants,_that.title,_that.description,_that.imageUrl,_that.locationId,_that.selectedLocation,_that.addressDetail,_that.directionsGuide,_that.contactOptions,_that.entryGroups,_that.tickets,_that.visibility,_that.status);case _:
+return $default(_that.partyId,_that.startTime,_that.endTime,_that.draftId,_that.checkpointTabIndex,_that.maxParticipants,_that.title,_that.description,_that.imageUrl,_that.locationId,_that.selectedLocation,_that.addressDetail,_that.directionsGuide,_that.contactOptions,_that.entryGroups,_that.tickets,_that.visibility,_that.draftUpdatedAt,_that.status);case _:
   return orElse();
 
 }
@@ -198,10 +201,10 @@ return $default(_that.partyId,_that.startTime,_that.endTime,_that.maxParticipant
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String partyId,  DateTime startTime,  DateTime endTime,  int maxParticipants,  String title,  Map<String, dynamic> description,  String? imageUrl,  String? locationId,  Location? selectedLocation,  String? addressDetail,  String? directionsGuide,  Map<String, dynamic> contactOptions,  List<EntryGroup> entryGroups,  List<Ticket> tickets,  String? visibility,  AsyncValue<void> status)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String partyId,  DateTime startTime,  DateTime endTime,  String? draftId,  int checkpointTabIndex,  int maxParticipants,  String title,  Map<String, dynamic> description,  String? imageUrl,  String? locationId,  Location? selectedLocation,  String? addressDetail,  String? directionsGuide,  Map<String, dynamic> contactOptions,  List<EntryGroup> entryGroups,  List<Ticket> tickets,  String? visibility,  DateTime? draftUpdatedAt,  AsyncValue<void> status)  $default,) {final _that = this;
 switch (_that) {
 case _EventCreateState():
-return $default(_that.partyId,_that.startTime,_that.endTime,_that.maxParticipants,_that.title,_that.description,_that.imageUrl,_that.locationId,_that.selectedLocation,_that.addressDetail,_that.directionsGuide,_that.contactOptions,_that.entryGroups,_that.tickets,_that.visibility,_that.status);case _:
+return $default(_that.partyId,_that.startTime,_that.endTime,_that.draftId,_that.checkpointTabIndex,_that.maxParticipants,_that.title,_that.description,_that.imageUrl,_that.locationId,_that.selectedLocation,_that.addressDetail,_that.directionsGuide,_that.contactOptions,_that.entryGroups,_that.tickets,_that.visibility,_that.draftUpdatedAt,_that.status);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -218,10 +221,10 @@ return $default(_that.partyId,_that.startTime,_that.endTime,_that.maxParticipant
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String partyId,  DateTime startTime,  DateTime endTime,  int maxParticipants,  String title,  Map<String, dynamic> description,  String? imageUrl,  String? locationId,  Location? selectedLocation,  String? addressDetail,  String? directionsGuide,  Map<String, dynamic> contactOptions,  List<EntryGroup> entryGroups,  List<Ticket> tickets,  String? visibility,  AsyncValue<void> status)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String partyId,  DateTime startTime,  DateTime endTime,  String? draftId,  int checkpointTabIndex,  int maxParticipants,  String title,  Map<String, dynamic> description,  String? imageUrl,  String? locationId,  Location? selectedLocation,  String? addressDetail,  String? directionsGuide,  Map<String, dynamic> contactOptions,  List<EntryGroup> entryGroups,  List<Ticket> tickets,  String? visibility,  DateTime? draftUpdatedAt,  AsyncValue<void> status)?  $default,) {final _that = this;
 switch (_that) {
 case _EventCreateState() when $default != null:
-return $default(_that.partyId,_that.startTime,_that.endTime,_that.maxParticipants,_that.title,_that.description,_that.imageUrl,_that.locationId,_that.selectedLocation,_that.addressDetail,_that.directionsGuide,_that.contactOptions,_that.entryGroups,_that.tickets,_that.visibility,_that.status);case _:
+return $default(_that.partyId,_that.startTime,_that.endTime,_that.draftId,_that.checkpointTabIndex,_that.maxParticipants,_that.title,_that.description,_that.imageUrl,_that.locationId,_that.selectedLocation,_that.addressDetail,_that.directionsGuide,_that.contactOptions,_that.entryGroups,_that.tickets,_that.visibility,_that.draftUpdatedAt,_that.status);case _:
   return null;
 
 }
@@ -233,12 +236,14 @@ return $default(_that.partyId,_that.startTime,_that.endTime,_that.maxParticipant
 
 
 class _EventCreateState implements EventCreateState {
-  const _EventCreateState({required this.partyId, required this.startTime, required this.endTime, this.maxParticipants = 20, this.title = '', final  Map<String, dynamic> description = const {}, this.imageUrl, this.locationId, this.selectedLocation, this.addressDetail, this.directionsGuide, final  Map<String, dynamic> contactOptions = const {}, final  List<EntryGroup> entryGroups = const [], final  List<Ticket> tickets = const [], this.visibility, this.status = const AsyncValue.data(null)}): _description = description,_contactOptions = contactOptions,_entryGroups = entryGroups,_tickets = tickets;
+  const _EventCreateState({required this.partyId, required this.startTime, required this.endTime, this.draftId, this.checkpointTabIndex = 0, this.maxParticipants = 20, this.title = '', final  Map<String, dynamic> description = const {}, this.imageUrl, this.locationId, this.selectedLocation, this.addressDetail, this.directionsGuide, final  Map<String, dynamic> contactOptions = const {}, final  List<EntryGroup> entryGroups = const [], final  List<Ticket> tickets = const [], this.visibility, this.draftUpdatedAt, this.status = const AsyncValue.data(null)}): _description = description,_contactOptions = contactOptions,_entryGroups = entryGroups,_tickets = tickets;
   
 
 @override final  String partyId;
 @override final  DateTime startTime;
 @override final  DateTime endTime;
+@override final  String? draftId;
+@override@JsonKey() final  int checkpointTabIndex;
 @override@JsonKey() final  int maxParticipants;
 @override@JsonKey() final  String title;
  final  Map<String, dynamic> _description;
@@ -275,6 +280,7 @@ class _EventCreateState implements EventCreateState {
 }
 
 @override final  String? visibility;
+@override final  DateTime? draftUpdatedAt;
 @override@JsonKey() final  AsyncValue<void> status;
 
 /// Create a copy of EventCreateState
@@ -287,16 +293,16 @@ _$EventCreateStateCopyWith<_EventCreateState> get copyWith => __$EventCreateStat
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EventCreateState&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.maxParticipants, maxParticipants) || other.maxParticipants == maxParticipants)&&(identical(other.title, title) || other.title == title)&&const DeepCollectionEquality().equals(other._description, _description)&&(identical(other.imageUrl, imageUrl) || other.imageUrl == imageUrl)&&(identical(other.locationId, locationId) || other.locationId == locationId)&&(identical(other.selectedLocation, selectedLocation) || other.selectedLocation == selectedLocation)&&(identical(other.addressDetail, addressDetail) || other.addressDetail == addressDetail)&&(identical(other.directionsGuide, directionsGuide) || other.directionsGuide == directionsGuide)&&const DeepCollectionEquality().equals(other._contactOptions, _contactOptions)&&const DeepCollectionEquality().equals(other._entryGroups, _entryGroups)&&const DeepCollectionEquality().equals(other._tickets, _tickets)&&(identical(other.visibility, visibility) || other.visibility == visibility)&&(identical(other.status, status) || other.status == status));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EventCreateState&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.draftId, draftId) || other.draftId == draftId)&&(identical(other.checkpointTabIndex, checkpointTabIndex) || other.checkpointTabIndex == checkpointTabIndex)&&(identical(other.maxParticipants, maxParticipants) || other.maxParticipants == maxParticipants)&&(identical(other.title, title) || other.title == title)&&const DeepCollectionEquality().equals(other._description, _description)&&(identical(other.imageUrl, imageUrl) || other.imageUrl == imageUrl)&&(identical(other.locationId, locationId) || other.locationId == locationId)&&(identical(other.selectedLocation, selectedLocation) || other.selectedLocation == selectedLocation)&&(identical(other.addressDetail, addressDetail) || other.addressDetail == addressDetail)&&(identical(other.directionsGuide, directionsGuide) || other.directionsGuide == directionsGuide)&&const DeepCollectionEquality().equals(other._contactOptions, _contactOptions)&&const DeepCollectionEquality().equals(other._entryGroups, _entryGroups)&&const DeepCollectionEquality().equals(other._tickets, _tickets)&&(identical(other.visibility, visibility) || other.visibility == visibility)&&(identical(other.draftUpdatedAt, draftUpdatedAt) || other.draftUpdatedAt == draftUpdatedAt)&&(identical(other.status, status) || other.status == status));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,partyId,startTime,endTime,maxParticipants,title,const DeepCollectionEquality().hash(_description),imageUrl,locationId,selectedLocation,addressDetail,directionsGuide,const DeepCollectionEquality().hash(_contactOptions),const DeepCollectionEquality().hash(_entryGroups),const DeepCollectionEquality().hash(_tickets),visibility,status);
+int get hashCode => Object.hashAll([runtimeType,partyId,startTime,endTime,draftId,checkpointTabIndex,maxParticipants,title,const DeepCollectionEquality().hash(_description),imageUrl,locationId,selectedLocation,addressDetail,directionsGuide,const DeepCollectionEquality().hash(_contactOptions),const DeepCollectionEquality().hash(_entryGroups),const DeepCollectionEquality().hash(_tickets),visibility,draftUpdatedAt,status]);
 
 @override
 String toString() {
-  return 'EventCreateState(partyId: $partyId, startTime: $startTime, endTime: $endTime, maxParticipants: $maxParticipants, title: $title, description: $description, imageUrl: $imageUrl, locationId: $locationId, selectedLocation: $selectedLocation, addressDetail: $addressDetail, directionsGuide: $directionsGuide, contactOptions: $contactOptions, entryGroups: $entryGroups, tickets: $tickets, visibility: $visibility, status: $status)';
+  return 'EventCreateState(partyId: $partyId, startTime: $startTime, endTime: $endTime, draftId: $draftId, checkpointTabIndex: $checkpointTabIndex, maxParticipants: $maxParticipants, title: $title, description: $description, imageUrl: $imageUrl, locationId: $locationId, selectedLocation: $selectedLocation, addressDetail: $addressDetail, directionsGuide: $directionsGuide, contactOptions: $contactOptions, entryGroups: $entryGroups, tickets: $tickets, visibility: $visibility, draftUpdatedAt: $draftUpdatedAt, status: $status)';
 }
 
 
@@ -307,7 +313,7 @@ abstract mixin class _$EventCreateStateCopyWith<$Res> implements $EventCreateSta
   factory _$EventCreateStateCopyWith(_EventCreateState value, $Res Function(_EventCreateState) _then) = __$EventCreateStateCopyWithImpl;
 @override @useResult
 $Res call({
- String partyId, DateTime startTime, DateTime endTime, int maxParticipants, String title, Map<String, dynamic> description, String? imageUrl, String? locationId, Location? selectedLocation, String? addressDetail, String? directionsGuide, Map<String, dynamic> contactOptions, List<EntryGroup> entryGroups, List<Ticket> tickets, String? visibility, AsyncValue<void> status
+ String partyId, DateTime startTime, DateTime endTime, String? draftId, int checkpointTabIndex, int maxParticipants, String title, Map<String, dynamic> description, String? imageUrl, String? locationId, Location? selectedLocation, String? addressDetail, String? directionsGuide, Map<String, dynamic> contactOptions, List<EntryGroup> entryGroups, List<Ticket> tickets, String? visibility, DateTime? draftUpdatedAt, AsyncValue<void> status
 });
 
 
@@ -324,12 +330,14 @@ class __$EventCreateStateCopyWithImpl<$Res>
 
 /// Create a copy of EventCreateState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? partyId = null,Object? startTime = null,Object? endTime = null,Object? maxParticipants = null,Object? title = null,Object? description = null,Object? imageUrl = freezed,Object? locationId = freezed,Object? selectedLocation = freezed,Object? addressDetail = freezed,Object? directionsGuide = freezed,Object? contactOptions = null,Object? entryGroups = null,Object? tickets = null,Object? visibility = freezed,Object? status = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? partyId = null,Object? startTime = null,Object? endTime = null,Object? draftId = freezed,Object? checkpointTabIndex = null,Object? maxParticipants = null,Object? title = null,Object? description = null,Object? imageUrl = freezed,Object? locationId = freezed,Object? selectedLocation = freezed,Object? addressDetail = freezed,Object? directionsGuide = freezed,Object? contactOptions = null,Object? entryGroups = null,Object? tickets = null,Object? visibility = freezed,Object? draftUpdatedAt = freezed,Object? status = null,}) {
   return _then(_EventCreateState(
 partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
 as String,startTime: null == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
 as DateTime,endTime: null == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
-as DateTime,maxParticipants: null == maxParticipants ? _self.maxParticipants : maxParticipants // ignore: cast_nullable_to_non_nullable
+as DateTime,draftId: freezed == draftId ? _self.draftId : draftId // ignore: cast_nullable_to_non_nullable
+as String?,checkpointTabIndex: null == checkpointTabIndex ? _self.checkpointTabIndex : checkpointTabIndex // ignore: cast_nullable_to_non_nullable
+as int,maxParticipants: null == maxParticipants ? _self.maxParticipants : maxParticipants // ignore: cast_nullable_to_non_nullable
 as int,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,description: null == description ? _self._description : description // ignore: cast_nullable_to_non_nullable
 as Map<String, dynamic>,imageUrl: freezed == imageUrl ? _self.imageUrl : imageUrl // ignore: cast_nullable_to_non_nullable
@@ -341,7 +349,8 @@ as String?,contactOptions: null == contactOptions ? _self._contactOptions : cont
 as Map<String, dynamic>,entryGroups: null == entryGroups ? _self._entryGroups : entryGroups // ignore: cast_nullable_to_non_nullable
 as List<EntryGroup>,tickets: null == tickets ? _self._tickets : tickets // ignore: cast_nullable_to_non_nullable
 as List<Ticket>,visibility: freezed == visibility ? _self.visibility : visibility // ignore: cast_nullable_to_non_nullable
-as String?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String?,draftUpdatedAt: freezed == draftUpdatedAt ? _self.draftUpdatedAt : draftUpdatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as AsyncValue<void>,
   ));
 }

--- a/apps/app_partner/lib/src/features/party/event/create/event_create_controller.g.dart
+++ b/apps/app_partner/lib/src/features/party/event/create/event_create_controller.g.dart
@@ -59,7 +59,7 @@ final class EventCreateControllerProvider
 }
 
 String _$eventCreateControllerHash() =>
-    r'6935d7ae54d06004a563ed91668e214d4e30096c';
+    r'c629725be1fbb6e60a9a6203f0b2b515ec05778b';
 
 final class EventCreateControllerFamily extends $Family
     with

--- a/apps/app_partner/lib/src/features/party/event/create/event_create_page.dart
+++ b/apps/app_partner/lib/src/features/party/event/create/event_create_page.dart
@@ -4,6 +4,7 @@ import 'package:app_partner/src/features/party/detail/party_detail_controller.da
 import 'package:app_partner/src/features/party/event/create/event_create_controller.dart';
 import 'package:app_partner/src/features/party/event/create/tabs/event_create_info_tab.dart';
 import 'package:app_partner/src/features/party/event/create/tabs/event_create_operation_tab.dart';
+import 'package:app_partner/src/features/party/logic/recurrence_settings_controller.dart';
 import 'package:app_partner/src/utils/l10n_ext.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -18,10 +19,16 @@ class EventCreatePage extends ConsumerStatefulWidget {
   ConsumerState<EventCreatePage> createState() => _EventCreatePageState();
 }
 
-class _EventCreatePageState extends ConsumerState<EventCreatePage> {
+class _EventCreatePageState extends ConsumerState<EventCreatePage>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+  bool _appliedDraftCheckpoint = false;
+
   @override
   void initState() {
     super.initState();
+    _tabController = TabController(length: 2, vsync: this)
+      ..addListener(_handleTabChanged);
 
     // Initialize controller state from Party data
     WidgetsBinding.instance.addPostFrameCallback((_) async {
@@ -37,7 +44,7 @@ class _EventCreatePageState extends ConsumerState<EventCreatePage> {
       }
 
       if (mounted) {
-        ref
+        await ref
             .read(eventCreateControllerProvider(widget.partyId).notifier)
             .initWithParty(
               party: party,
@@ -46,6 +53,21 @@ class _EventCreatePageState extends ConsumerState<EventCreatePage> {
             );
       }
     });
+  }
+
+  @override
+  void dispose() {
+    _tabController
+      ..removeListener(_handleTabChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _handleTabChanged() {
+    if (_tabController.indexIsChanging) return;
+    ref
+        .read(eventCreateControllerProvider(widget.partyId).notifier)
+        .updateCheckpointTab(_tabController.index);
   }
 
   Future<void> _submit() async {
@@ -72,63 +94,75 @@ class _EventCreatePageState extends ConsumerState<EventCreatePage> {
       eventCreateControllerProvider(widget.partyId).notifier,
     );
     final theme = Theme.of(context);
+    ref.listen(recurrenceSettingsControllerProvider, (_, _) {
+      notifier.saveDraftSoon();
+    });
 
-    return DefaultTabController(
-      length: 2,
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text(context.l10n.eventCreate_title),
-          bottom: TabBar(
-            tabs: [
-              const Tab(text: '운영 및 티켓'),
-              Tab(text: context.l10n.partyDetail_tab_info),
-            ],
-          ),
-        ),
-        body: Column(
-          children: [
-            Expanded(
-              child: TabBarView(
-                children: [
-                  // Tab 1: Schedule & Tickets
-                  EventCreateOperationTab(state: state, notifier: notifier),
+    if (!_appliedDraftCheckpoint && state.draftId != null) {
+      _appliedDraftCheckpoint = true;
+      final index = state.checkpointTabIndex.clamp(0, 1);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _tabController.index != index) {
+          _tabController.index = index;
+        }
+      });
+    }
 
-                  // Tab 2: Event Details (Summary Based)
-                  EventCreateInfoTab(
-                    state: state,
-                    notifier: notifier,
-                    partyId: widget.partyId,
-                  ),
-                ],
-              ),
-            ),
-
-            // Submit Button
-            Container(
-              padding: const EdgeInsets.all(MinglitSpacing.medium),
-              decoration: BoxDecoration(
-                color: theme.scaffoldBackgroundColor,
-                boxShadow: [
-                  BoxShadow(
-                    color: theme.shadowColor.withValues(
-                      alpha: MinglitOpacity.tintFill,
-                    ),
-                    blurRadius: 10,
-                    offset: const Offset(0, -4),
-                  ),
-                ],
-              ),
-              child: SafeArea(
-                child: ElevatedButton(
-                  onPressed: state.status.isLoading ? null : _submit,
-                  child: state.status.isLoading
-                      ? const Text('회차 생성 중...')
-                      : const Text('회차 생성 완료'),
-                ),
-              ),
-            ),
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(context.l10n.eventCreate_title),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: [
+            const Tab(text: '운영 및 티켓'),
+            Tab(text: context.l10n.partyDetail_tab_info),
           ],
         ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: TabBarView(
+              controller: _tabController,
+              children: [
+                // Tab 1: Schedule & Tickets
+                EventCreateOperationTab(state: state, notifier: notifier),
+
+                // Tab 2: Event Details (Summary Based)
+                EventCreateInfoTab(
+                  state: state,
+                  notifier: notifier,
+                  partyId: widget.partyId,
+                ),
+              ],
+            ),
+          ),
+
+          // Submit Button
+          Container(
+            padding: const EdgeInsets.all(MinglitSpacing.medium),
+            decoration: BoxDecoration(
+              color: theme.scaffoldBackgroundColor,
+              boxShadow: [
+                BoxShadow(
+                  color: theme.shadowColor.withValues(
+                    alpha: MinglitOpacity.tintFill,
+                  ),
+                  blurRadius: 10,
+                  offset: const Offset(0, -4),
+                ),
+              ],
+            ),
+            child: SafeArea(
+              child: ElevatedButton(
+                onPressed: state.status.isLoading ? null : _submit,
+                child: state.status.isLoading
+                    ? const Text('회차 생성 중...')
+                    : const Text('회차 생성 완료'),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/app_partner/lib/src/features/party/logic/recurrence_settings_controller.dart
+++ b/apps/app_partner/lib/src/features/party/logic/recurrence_settings_controller.dart
@@ -14,7 +14,9 @@ abstract class RecurrenceSettingsState with _$RecurrenceSettingsState {
     /// Repeat pattern (weekly / biweekly / monthly).
     @Default(RecurrencePattern.weekly) RecurrencePattern pattern,
 
-    /// Days of week to generate events on (0=Sun … 6=Sat, JavaScript convention).
+    /// Days of week to generate events on.
+    ///
+    /// Uses JavaScript convention: 0=Sun … 6=Sat.
     /// Used for weekly and biweekly patterns.
     @Default([1]) List<int> daysOfWeek,
 
@@ -28,9 +30,9 @@ abstract class RecurrenceSettingsState with _$RecurrenceSettingsState {
 
 /// Manages the recurrence settings UI state for the event creation flow.
 ///
-/// The controller is scoped to the event-create screen via [ProviderScope.overrides]
-/// or via its auto-dispose lifetime. It computes preview dates without any
-/// repository calls — submission is handled by EventCreateController.submit.
+/// The controller is scoped to the event-create screen via
+/// [ProviderScope.overrides] or via its auto-dispose lifetime.
+/// It computes preview dates without repository calls.
 @riverpod
 class RecurrenceSettingsController extends _$RecurrenceSettingsController {
   @override
@@ -38,6 +40,12 @@ class RecurrenceSettingsController extends _$RecurrenceSettingsController {
 
   /// Toggles recurrence on or off.
   void toggle() => state = state.copyWith(isEnabled: !state.isEnabled);
+
+  /// Restores a saved draft recurrence snapshot.
+  RecurrenceSettingsState get snapshot => state;
+
+  /// Restores a saved draft recurrence snapshot.
+  set snapshot(RecurrenceSettingsState snapshot) => state = snapshot;
 
   /// Changes the repeat pattern. Resets conflicting fields.
   void setPattern(RecurrencePattern pattern) {
@@ -67,12 +75,14 @@ class RecurrenceSettingsController extends _$RecurrenceSettingsController {
   /// Sets the day-of-month for monthly pattern (1–31).
   void setMonthDay(int day) => state = state.copyWith(monthDay: day);
 
-  /// Sets the optional rule end date in YYYY-MM-DD format. Pass `null` to clear.
+  /// Sets the optional rule end date in YYYY-MM-DD format.
+  ///
+  /// Pass `null` to clear.
   void setEndDate(String? date) => state = state.copyWith(endDate: date);
 
-  /// Returns the next [count] dates (from today) that match the current settings.
+  /// Returns next [count] dates that match the current settings.
   ///
-  /// Respects [RecurrenceSettingsState.endDate] — no dates after it are returned.
+  /// Respects [RecurrenceSettingsState.endDate].
   /// Returns an empty list when recurrence is disabled or settings are invalid.
   List<DateTime> previewDates({int count = 5}) {
     if (!state.isEnabled) return [];
@@ -87,7 +97,7 @@ class RecurrenceSettingsController extends _$RecurrenceSettingsController {
     final today = DateTime.now();
     final refDay = DateTime(today.year, today.month, today.day);
 
-    // Parse optional end date so the preview matches what will actually be saved.
+    // Parse optional end date so preview matches the saved rule.
     final endDateDay = state.endDate != null
         ? DateTime.tryParse(state.endDate!)
         : null;

--- a/apps/app_partner/lib/src/features/party/logic/recurrence_settings_controller.freezed.dart
+++ b/apps/app_partner/lib/src/features/party/logic/recurrence_settings_controller.freezed.dart
@@ -16,7 +16,9 @@ mixin _$RecurrenceSettingsState {
 
 /// Whether recurrence is enabled for the event being created.
  bool get isEnabled;/// Repeat pattern (weekly / biweekly / monthly).
- RecurrencePattern get pattern;/// Days of week to generate events on (0=Sun … 6=Sat, JavaScript convention).
+ RecurrencePattern get pattern;/// Days of week to generate events on.
+///
+/// Uses JavaScript convention: 0=Sun … 6=Sat.
 /// Used for weekly and biweekly patterns.
  List<int> get daysOfWeek;/// Day of month (1–31) for monthly pattern.
  int? get monthDay;/// Optional rule end date in YYYY-MM-DD format.
@@ -223,10 +225,14 @@ class _RecurrenceSettingsState implements RecurrenceSettingsState {
 @override@JsonKey() final  bool isEnabled;
 /// Repeat pattern (weekly / biweekly / monthly).
 @override@JsonKey() final  RecurrencePattern pattern;
-/// Days of week to generate events on (0=Sun … 6=Sat, JavaScript convention).
+/// Days of week to generate events on.
+///
+/// Uses JavaScript convention: 0=Sun … 6=Sat.
 /// Used for weekly and biweekly patterns.
  final  List<int> _daysOfWeek;
-/// Days of week to generate events on (0=Sun … 6=Sat, JavaScript convention).
+/// Days of week to generate events on.
+///
+/// Uses JavaScript convention: 0=Sun … 6=Sat.
 /// Used for weekly and biweekly patterns.
 @override@JsonKey() List<int> get daysOfWeek {
   if (_daysOfWeek is EqualUnmodifiableListView) return _daysOfWeek;

--- a/apps/app_partner/lib/src/features/party/logic/recurrence_settings_controller.g.dart
+++ b/apps/app_partner/lib/src/features/party/logic/recurrence_settings_controller.g.dart
@@ -10,9 +10,9 @@ part of 'recurrence_settings_controller.dart';
 // ignore_for_file: type=lint, type=warning
 /// Manages the recurrence settings UI state for the event creation flow.
 ///
-/// The controller is scoped to the event-create screen via [ProviderScope.overrides]
-/// or via its auto-dispose lifetime. It computes preview dates without any
-/// repository calls — submission is handled by EventCreateController.submit.
+/// The controller is scoped to the event-create screen via
+/// [ProviderScope.overrides] or via its auto-dispose lifetime.
+/// It computes preview dates without repository calls.
 
 @ProviderFor(RecurrenceSettingsController)
 const recurrenceSettingsControllerProvider =
@@ -20,9 +20,9 @@ const recurrenceSettingsControllerProvider =
 
 /// Manages the recurrence settings UI state for the event creation flow.
 ///
-/// The controller is scoped to the event-create screen via [ProviderScope.overrides]
-/// or via its auto-dispose lifetime. It computes preview dates without any
-/// repository calls — submission is handled by EventCreateController.submit.
+/// The controller is scoped to the event-create screen via
+/// [ProviderScope.overrides] or via its auto-dispose lifetime.
+/// It computes preview dates without repository calls.
 final class RecurrenceSettingsControllerProvider
     extends
         $NotifierProvider<
@@ -31,9 +31,9 @@ final class RecurrenceSettingsControllerProvider
         > {
   /// Manages the recurrence settings UI state for the event creation flow.
   ///
-  /// The controller is scoped to the event-create screen via [ProviderScope.overrides]
-  /// or via its auto-dispose lifetime. It computes preview dates without any
-  /// repository calls — submission is handled by EventCreateController.submit.
+  /// The controller is scoped to the event-create screen via
+  /// [ProviderScope.overrides] or via its auto-dispose lifetime.
+  /// It computes preview dates without repository calls.
   const RecurrenceSettingsControllerProvider._()
     : super(
         from: null,
@@ -62,13 +62,13 @@ final class RecurrenceSettingsControllerProvider
 }
 
 String _$recurrenceSettingsControllerHash() =>
-    r'a5eebab1bdcdbdc9b821114f1677237e89c71239';
+    r'a6662b339468cfb12b5327f6d10898a9935a8edc';
 
 /// Manages the recurrence settings UI state for the event creation flow.
 ///
-/// The controller is scoped to the event-create screen via [ProviderScope.overrides]
-/// or via its auto-dispose lifetime. It computes preview dates without any
-/// repository calls — submission is handled by EventCreateController.submit.
+/// The controller is scoped to the event-create screen via
+/// [ProviderScope.overrides] or via its auto-dispose lifetime.
+/// It computes preview dates without repository calls.
 
 abstract class _$RecurrenceSettingsController
     extends $Notifier<RecurrenceSettingsState> {

--- a/apps/app_partner/lib/src/logic/event_create_draft_repository.dart
+++ b/apps/app_partner/lib/src/logic/event_create_draft_repository.dart
@@ -1,0 +1,275 @@
+import 'dart:convert';
+
+import 'package:app_partner/src/features/party/event/create/event_create_controller.dart';
+import 'package:app_partner/src/features/party/logic/recurrence_settings_controller.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+final eventCreateDraftRepositoryProvider = Provider<EventCreateDraftRepository>(
+  (ref) => SharedPreferencesEventCreateDraftRepository(),
+);
+
+abstract class EventCreateDraftRepository {
+  Future<EventCreateDraft?> getDraft(String partyId);
+
+  Future<List<EventCreateDraft>> getDrafts();
+
+  Future<void> saveDraft(EventCreateDraft draft);
+
+  Future<void> deleteDraft(String partyId);
+}
+
+class SharedPreferencesEventCreateDraftRepository
+    implements EventCreateDraftRepository {
+  static const _indexKey = 'event_create_draft_party_ids';
+  static const _keyPrefix = 'event_create_draft_v1_';
+
+  @override
+  Future<EventCreateDraft?> getDraft(String partyId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('$_keyPrefix$partyId');
+    if (raw == null) return null;
+    return EventCreateDraft.fromJson(
+      jsonDecode(raw) as Map<String, dynamic>,
+    );
+  }
+
+  @override
+  Future<List<EventCreateDraft>> getDrafts() async {
+    final prefs = await SharedPreferences.getInstance();
+    final partyIds = prefs.getStringList(_indexKey) ?? const <String>[];
+    final drafts = <EventCreateDraft>[];
+    for (final partyId in partyIds) {
+      final raw = prefs.getString('$_keyPrefix$partyId');
+      if (raw == null) continue;
+      drafts.add(
+        EventCreateDraft.fromJson(
+          jsonDecode(raw) as Map<String, dynamic>,
+        ),
+      );
+    }
+    drafts.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+    return drafts;
+  }
+
+  @override
+  Future<void> saveDraft(EventCreateDraft draft) async {
+    final prefs = await SharedPreferences.getInstance();
+    final partyIds = prefs.getStringList(_indexKey) ?? <String>[];
+    if (!partyIds.contains(draft.partyId)) {
+      partyIds.add(draft.partyId);
+      await prefs.setStringList(_indexKey, partyIds);
+    }
+    await prefs.setString(
+      '$_keyPrefix${draft.partyId}',
+      jsonEncode(draft.toJson()),
+    );
+  }
+
+  @override
+  Future<void> deleteDraft(String partyId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final partyIds = (prefs.getStringList(_indexKey) ?? <String>[])
+      ..remove(partyId);
+    await prefs.setStringList(_indexKey, partyIds);
+    await _removeDraftPayload(prefs, partyId);
+  }
+
+  Future<void> _removeDraftPayload(
+    SharedPreferences prefs,
+    String partyId,
+  ) async {
+    await prefs.remove('$_keyPrefix$partyId');
+  }
+}
+
+class EventCreateDraft {
+  EventCreateDraft({
+    required this.id,
+    required this.partyId,
+    required this.checkpointTabIndex,
+    required this.startTime,
+    required this.endTime,
+    required this.maxParticipants,
+    required this.title,
+    required this.description,
+    required this.contactOptions,
+    required this.entryGroups,
+    required this.tickets,
+    required this.recurrence,
+    required this.updatedAt,
+    this.imageUrl,
+    this.locationId,
+    this.selectedLocation,
+    this.addressDetail,
+    this.directionsGuide,
+    this.visibility,
+  });
+
+  factory EventCreateDraft.fromState({
+    required EventCreateState state,
+    required RecurrenceSettingsState recurrence,
+    required DateTime updatedAt,
+  }) {
+    return EventCreateDraft(
+      id: state.draftId ?? const Uuid().v4(),
+      partyId: state.partyId,
+      checkpointTabIndex: state.checkpointTabIndex,
+      startTime: state.startTime,
+      endTime: state.endTime,
+      maxParticipants: state.maxParticipants,
+      title: state.title,
+      description: state.description,
+      imageUrl: state.imageUrl,
+      locationId: state.locationId,
+      selectedLocation: state.selectedLocation,
+      addressDetail: state.addressDetail,
+      directionsGuide: state.directionsGuide,
+      contactOptions: state.contactOptions,
+      entryGroups: state.entryGroups,
+      tickets: state.tickets,
+      visibility: state.visibility,
+      recurrence: recurrence,
+      updatedAt: updatedAt,
+    );
+  }
+
+  factory EventCreateDraft.fromJson(Map<String, dynamic> json) {
+    return EventCreateDraft(
+      id: json['id'] as String,
+      partyId: json['partyId'] as String,
+      checkpointTabIndex: json['checkpointTabIndex'] as int? ?? 0,
+      startTime: DateTime.parse(json['startTime'] as String),
+      endTime: DateTime.parse(json['endTime'] as String),
+      maxParticipants: json['maxParticipants'] as int? ?? 20,
+      title: json['title'] as String? ?? '',
+      description:
+          (json['description'] as Map?)?.cast<String, dynamic>() ??
+          const <String, dynamic>{},
+      imageUrl: json['imageUrl'] as String?,
+      locationId: json['locationId'] as String?,
+      selectedLocation: json['selectedLocation'] == null
+          ? null
+          : Location.fromJson(
+              (json['selectedLocation'] as Map).cast<String, dynamic>(),
+            ),
+      addressDetail: json['addressDetail'] as String?,
+      directionsGuide: json['directionsGuide'] as String?,
+      contactOptions:
+          (json['contactOptions'] as Map?)?.cast<String, dynamic>() ??
+          const <String, dynamic>{},
+      entryGroups: (json['entryGroups'] as List<dynamic>? ?? const <dynamic>[])
+          .map(
+            (entry) => EntryGroup.fromJson(
+              (entry as Map).cast<String, dynamic>(),
+            ),
+          )
+          .toList(),
+      tickets: (json['tickets'] as List<dynamic>? ?? const <dynamic>[])
+          .map(
+            (ticket) => Ticket.fromJson(
+              (ticket as Map).cast<String, dynamic>(),
+            ),
+          )
+          .toList(),
+      visibility: json['visibility'] as String?,
+      recurrence: _recurrenceFromJson(
+        (json['recurrence'] as Map?)?.cast<String, dynamic>(),
+      ),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+    );
+  }
+
+  final String id;
+  final String partyId;
+  final int checkpointTabIndex;
+  final DateTime startTime;
+  final DateTime endTime;
+  final int maxParticipants;
+  final String title;
+  final Map<String, dynamic> description;
+  final String? imageUrl;
+  final String? locationId;
+  final Location? selectedLocation;
+  final String? addressDetail;
+  final String? directionsGuide;
+  final Map<String, dynamic> contactOptions;
+  final List<EntryGroup> entryGroups;
+  final List<Ticket> tickets;
+  final String? visibility;
+  final RecurrenceSettingsState recurrence;
+  final DateTime updatedAt;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'partyId': partyId,
+      'checkpointTabIndex': checkpointTabIndex,
+      'startTime': startTime.toIso8601String(),
+      'endTime': endTime.toIso8601String(),
+      'maxParticipants': maxParticipants,
+      'title': title,
+      'description': description,
+      'imageUrl': imageUrl,
+      'locationId': locationId,
+      'selectedLocation': selectedLocation?.toJson(),
+      'addressDetail': addressDetail,
+      'directionsGuide': directionsGuide,
+      'contactOptions': contactOptions,
+      'entryGroups': entryGroups.map((entry) => entry.toJson()).toList(),
+      'tickets': tickets.map((ticket) => ticket.toJson()).toList(),
+      'visibility': visibility,
+      'recurrence': _recurrenceToJson(recurrence),
+      'updatedAt': updatedAt.toIso8601String(),
+    };
+  }
+
+  EventCreateState toState() {
+    return EventCreateState(
+      partyId: partyId,
+      draftId: id,
+      checkpointTabIndex: checkpointTabIndex,
+      startTime: startTime,
+      endTime: endTime,
+      maxParticipants: maxParticipants,
+      title: title,
+      description: description,
+      imageUrl: imageUrl,
+      locationId: locationId,
+      selectedLocation: selectedLocation,
+      addressDetail: addressDetail,
+      directionsGuide: directionsGuide,
+      contactOptions: contactOptions,
+      entryGroups: entryGroups,
+      tickets: tickets,
+      visibility: visibility,
+      draftUpdatedAt: updatedAt,
+    );
+  }
+}
+
+Map<String, dynamic> _recurrenceToJson(RecurrenceSettingsState recurrence) {
+  return {
+    'isEnabled': recurrence.isEnabled,
+    'pattern': recurrence.pattern.name,
+    'daysOfWeek': recurrence.daysOfWeek,
+    'monthDay': recurrence.monthDay,
+    'endDate': recurrence.endDate,
+  };
+}
+
+RecurrenceSettingsState _recurrenceFromJson(Map<String, dynamic>? json) {
+  if (json == null) return const RecurrenceSettingsState();
+  return RecurrenceSettingsState(
+    isEnabled: json['isEnabled'] as bool? ?? false,
+    pattern: RecurrencePattern.values.firstWhere(
+      (pattern) => pattern.name == json['pattern'],
+      orElse: () => RecurrencePattern.weekly,
+    ),
+    daysOfWeek: (json['daysOfWeek'] as List<dynamic>? ?? const <dynamic>[1])
+        .cast<int>(),
+    monthDay: json['monthDay'] as int?,
+    endDate: json['endDate'] as String?,
+  );
+}

--- a/apps/app_partner/test/src/features/home/partner_dashboard_controller_test.dart
+++ b/apps/app_partner/test/src/features/home/partner_dashboard_controller_test.dart
@@ -1,5 +1,6 @@
 import 'package:app_partner/src/features/home/partner_dashboard_controller.dart';
 import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:app_partner/src/logic/event_create_draft_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -44,6 +45,22 @@ const _testPartner = Partner(
   contactEmail: 'test@partner.com',
 );
 
+class _FakeEventCreateDraftRepository implements EventCreateDraftRepository {
+  const _FakeEventCreateDraftRepository();
+
+  @override
+  Future<void> deleteDraft(String partyId) async {}
+
+  @override
+  Future<EventCreateDraft?> getDraft(String partyId) async => null;
+
+  @override
+  Future<List<EventCreateDraft>> getDrafts() async => const [];
+
+  @override
+  Future<void> saveDraft(EventCreateDraft draft) async {}
+}
+
 void main() {
   late MockEventRepository mockEventRepo;
   late MockPartyRepository mockPartyRepo;
@@ -55,8 +72,9 @@ void main() {
     when(
       () => mockEventRepo.getPendingApplicationCount(any()),
     ).thenAnswer((_) async => 3);
-    // Fix #2219: controller now uses getEventsByPartnerId (gt end_time) to include
-    // live events. getUpcomingEvents (gte start_time) excluded started events.
+    // Fix #2219: controller now uses getEventsByPartnerId (gt end_time)
+    // to include live events. getUpcomingEvents (gte start_time) excluded
+    // started events.
     when(
       () => mockEventRepo.getEventsByPartnerId(any()),
     ).thenAnswer((_) async => [_testEvent]);
@@ -81,6 +99,9 @@ void main() {
         currentPartnerInfoProvider.overrideWith((_) async => partner),
         eventRepositoryProvider.overrideWithValue(mockEventRepo),
         partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+        eventCreateDraftRepositoryProvider.overrideWithValue(
+          const _FakeEventCreateDraftRepository(),
+        ),
       ],
     );
 
@@ -107,6 +128,9 @@ void main() {
           currentPartnerInfoProvider.overrideWith((_) async => _testPartner),
           eventRepositoryProvider.overrideWithValue(mockEventRepo),
           partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          eventCreateDraftRepositoryProvider.overrideWithValue(
+            const _FakeEventCreateDraftRepository(),
+          ),
         ],
       );
 
@@ -179,9 +203,9 @@ void main() {
       },
     );
 
-    // Fix #2219: regression guard — liveEvents must be populated when an active
-    // event has started. This was broken when getUpcomingEvents (gte start_time)
-    // was used; getEventsByPartnerId (gt end_time) fixes it.
+    // Fix #2219: regression guard. liveEvents must be populated when an
+    // active event has started. This was broken when getUpcomingEvents
+    // (gte start_time) was used; getEventsByPartnerId (gt end_time) fixes it.
     test(
       'liveEvents is populated from active events that have started',
       () async {
@@ -217,7 +241,8 @@ void main() {
           state.totalAttendees,
           5,
           reason:
-              'Live event participants must count toward overview total (#2219)',
+              'Live event participants must count toward overview total '
+              '(#2219)',
         );
       },
     );
@@ -228,6 +253,9 @@ void main() {
           currentPartnerInfoProvider.overrideWith((_) async => null),
           eventRepositoryProvider.overrideWithValue(mockEventRepo),
           partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          eventCreateDraftRepositoryProvider.overrideWithValue(
+            const _FakeEventCreateDraftRepository(),
+          ),
         ],
       );
       final sub = container.listen(

--- a/apps/app_partner/test/src/features/home/partner_home_page_test.dart
+++ b/apps/app_partner/test/src/features/home/partner_home_page_test.dart
@@ -6,6 +6,8 @@ import 'package:app_partner/src/features/home/partner_dashboard_controller.dart'
 import 'package:app_partner/src/features/home/partner_home_coordinator.dart';
 import 'package:app_partner/src/features/home/partner_home_page.dart';
 import 'package:app_partner/src/features/home/widgets/weekly_stats_row.dart';
+import 'package:app_partner/src/logic/event_create_draft_repository.dart';
+import 'package:app_partner/src/features/party/logic/recurrence_settings_controller.dart';
 import 'package:app_partner/src/logic/current_partner_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -22,15 +24,38 @@ class _EmptyNotificationList extends NotificationList {
 
 class _LoadedDashboardController extends PartnerDashboardController {
   @override
-  PartnerDashboardState build() => const PartnerDashboardState(
-    status: AsyncValue.data(null),
-    hasAnyEvents: true,
+  PartnerDashboardState build() => _dashboardState;
+}
+
+PartnerDashboardState _dashboardState = const PartnerDashboardState(
+  status: AsyncValue.data(null),
+  hasAnyEvents: true,
+);
+
+Party _makeParty() {
+  final now = DateTime(2030);
+  return Party(
+    id: 'party-1',
+    partnerId: 'partner_1',
+    title: '테스트 파티',
+    createdAt: now,
+    updatedAt: now,
   );
 }
 
-Widget _buildPage({PartnerHomeCoordinator? coordinator}) {
+Widget _buildPage({
+  PartnerHomeCoordinator? coordinator,
+  PartnerDashboardState? dashboardState,
+}) {
+  _dashboardState =
+      dashboardState ??
+      const PartnerDashboardState(
+        status: AsyncValue.data(null),
+        hasAnyEvents: true,
+      );
   final coord = coordinator ?? _MockPartnerHomeCoordinator();
   when(coord.pushNotificationCenter).thenReturn(null);
+  when(() => coord.pushEventCreate(any())).thenReturn(null);
   return ProviderScope(
     overrides: [
       currentPartnerInfoProvider.overrideWith(
@@ -64,8 +89,7 @@ void main() {
         expect(
           find.text('PARTNER'),
           findsOneWidget,
-          reason:
-              'AppBar must show minglit · PARTNER wordmark (partner_home_page.html#① AppBar)',
+          reason: 'AppBar must show minglit · PARTNER wordmark',
         );
       },
     );
@@ -90,6 +114,55 @@ void main() {
           reason:
               'Weekly stats header must not appear until backend API is wired',
         );
+      },
+    );
+
+    testWidgets(
+      'shows draft event resume card instead of first event CTA',
+      (tester) async {
+        final party = _makeParty();
+        final draft = EventCreateDraft(
+          id: 'draft-1',
+          partyId: party.id,
+          checkpointTabIndex: 1,
+          startTime: DateTime(2030, 1, 1, 19),
+          endTime: DateTime(2030, 1, 1, 22),
+          maxParticipants: 20,
+          title: '작성 중인 이벤트',
+          description: const {},
+          contactOptions: const {},
+          entryGroups: const [],
+          tickets: const [],
+          recurrence: const RecurrenceSettingsState(),
+          updatedAt: DateTime(2030, 1, 1, 18),
+        );
+        final coord = _MockPartnerHomeCoordinator();
+        when(coord.pushNotificationCenter).thenReturn(null);
+        when(() => coord.pushEventCreate(any())).thenReturn(null);
+
+        await tester.pumpWidget(
+          _buildPage(
+            coordinator: coord,
+            dashboardState: PartnerDashboardState(
+              status: const AsyncValue.data(null),
+              activeParties: [party],
+              draftEvents: [draft],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('작성 중인 이벤트'), findsOneWidget);
+        expect(
+          find.widgetWithText(FilledButton, '첫 이벤트 만들기'),
+          findsNothing,
+        );
+
+        await tester.ensureVisible(find.text('작성 중인 이벤트'));
+        await tester.tap(find.text('작성 중인 이벤트'));
+        await tester.pump();
+
+        verify(() => coord.pushEventCreate('party-1')).called(1);
       },
     );
   });

--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_recurrence_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_recurrence_test.dart
@@ -1,7 +1,8 @@
 // Critical-path tests for EventCreateController.submit with recurrence enabled.
 //
 // When recurrenceSettingsControllerProvider.isEnabled is true, submit must call
-// recurrenceRuleRepository.create() in addition to partyRepository.createEvent().
+// recurrenceRuleRepository.create() in addition to
+// partyRepository.createEvent().
 // A regression here would create an event without its recurrence rule — partner
 // thinks recurrence is set up, but it silently never generates future events.
 //
@@ -11,6 +12,7 @@
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
 import 'package:app_partner/src/features/party/event/create/event_create_controller.dart';
 import 'package:app_partner/src/features/party/logic/recurrence_settings_controller.dart';
+import 'package:app_partner/src/logic/event_create_draft_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -24,6 +26,22 @@ import '../../../../../utils/test_utils.dart';
 
 class _MockRecurrenceRuleRepository extends Mock
     implements RecurrenceRuleRepository {}
+
+class _FakeEventCreateDraftRepository implements EventCreateDraftRepository {
+  const _FakeEventCreateDraftRepository();
+
+  @override
+  Future<void> deleteDraft(String partyId) async {}
+
+  @override
+  Future<EventCreateDraft?> getDraft(String partyId) async => null;
+
+  @override
+  Future<List<EventCreateDraft>> getDrafts() async => const [];
+
+  @override
+  Future<void> saveDraft(EventCreateDraft draft) async {}
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -124,6 +142,9 @@ void main() {
             recurrenceRuleRepositoryProvider.overrideWithValue(
               mockRecurrenceRepo,
             ),
+            eventCreateDraftRepositoryProvider.overrideWithValue(
+              const _FakeEventCreateDraftRepository(),
+            ),
             partyDetailProvider('party-rec-1').overrideWith(
               (ref) async => party,
             ),
@@ -149,18 +170,17 @@ void main() {
         final notifier = container.read(
           eventCreateControllerProvider('party-rec-1').notifier,
         );
-        notifier.updateLocation(
-          Location(
-            id: 'loc-1',
-            partnerId: 'partner-1',
-            name: 'Venue',
-            address: '서울시',
-            createdAt: DateTime.now(),
-            updatedAt: DateTime.now(),
-          ),
-        );
-
-        await notifier.submit();
+        await (notifier..updateLocation(
+              Location(
+                id: 'loc-1',
+                partnerId: 'partner-1',
+                name: 'Venue',
+                address: '서울시',
+                createdAt: DateTime.now(),
+                updatedAt: DateTime.now(),
+              ),
+            ))
+            .submit();
 
         final state = container.read(
           eventCreateControllerProvider('party-rec-1'),
@@ -213,6 +233,9 @@ void main() {
             recurrenceRuleRepositoryProvider.overrideWithValue(
               mockRecurrenceRepo,
             ),
+            eventCreateDraftRepositoryProvider.overrideWithValue(
+              const _FakeEventCreateDraftRepository(),
+            ),
             partyDetailProvider('party-rec-1').overrideWith(
               (ref) async => party,
             ),
@@ -226,20 +249,20 @@ void main() {
         final notifier = container.read(
           eventCreateControllerProvider('party-rec-1').notifier,
         );
-        notifier.updateStartTime(startTime);
-        notifier.updateEndTime(endTime);
-        notifier.updateLocation(
-          Location(
-            id: 'loc-1',
-            partnerId: 'partner-1',
-            name: 'Venue',
-            address: '서울시',
-            createdAt: DateTime.now(),
-            updatedAt: DateTime.now(),
-          ),
-        );
-
-        await notifier.submit();
+        await (notifier
+              ..updateStartTime(startTime)
+              ..updateEndTime(endTime)
+              ..updateLocation(
+                Location(
+                  id: 'loc-1',
+                  partnerId: 'partner-1',
+                  name: 'Venue',
+                  address: '서울시',
+                  createdAt: DateTime.now(),
+                  updatedAt: DateTime.now(),
+                ),
+              ))
+            .submit();
 
         // Capture the create() call arguments
         final createCall = verify(
@@ -254,9 +277,10 @@ void main() {
           ),
         )..called(1);
 
-        // captureAny with named returns a list of [partyId, pattern, daysOfWeek, startTime, endTime, ...]
+        // captureAny with named returns:
+        // [partyId, pattern, daysOfWeek, startTime, endTime, ...]
         final captured = createCall.captured;
-        // The captured values for named params come in the order they appear in verify()
+        // Captured named params follow the order they appear in verify().
         final capturedStartTime = captured[3] as String; // 'startTime' index
         final capturedEndTime = captured[4] as String; // 'endTime' index
 
@@ -284,6 +308,9 @@ void main() {
             recurrenceRuleRepositoryProvider.overrideWithValue(
               mockRecurrenceRepo,
             ),
+            eventCreateDraftRepositoryProvider.overrideWithValue(
+              const _FakeEventCreateDraftRepository(),
+            ),
             partyDetailProvider('party-rec-1').overrideWith(
               (ref) async => party,
             ),
@@ -294,18 +321,17 @@ void main() {
         final notifier = container.read(
           eventCreateControllerProvider('party-rec-1').notifier,
         );
-        notifier.updateLocation(
-          Location(
-            id: 'loc-1',
-            partnerId: 'partner-1',
-            name: 'Venue',
-            address: '서울시',
-            createdAt: DateTime.now(),
-            updatedAt: DateTime.now(),
-          ),
-        );
-
-        await notifier.submit();
+        await (notifier..updateLocation(
+              Location(
+                id: 'loc-1',
+                partnerId: 'partner-1',
+                name: 'Venue',
+                address: '서울시',
+                createdAt: DateTime.now(),
+                updatedAt: DateTime.now(),
+              ),
+            ))
+            .submit();
 
         final state = container.read(
           eventCreateControllerProvider('party-rec-1'),
@@ -354,6 +380,9 @@ void main() {
             recurrenceRuleRepositoryProvider.overrideWithValue(
               mockRecurrenceRepo,
             ),
+            eventCreateDraftRepositoryProvider.overrideWithValue(
+              const _FakeEventCreateDraftRepository(),
+            ),
             partyDetailProvider('party-rec-1').overrideWith(
               (ref) async => party,
             ),
@@ -365,18 +394,17 @@ void main() {
         final notifier = container.read(
           eventCreateControllerProvider('party-rec-1').notifier,
         );
-        notifier.updateLocation(
-          Location(
-            id: 'loc-1',
-            partnerId: 'partner-1',
-            name: 'Venue',
-            address: '서울시',
-            createdAt: DateTime.now(),
-            updatedAt: DateTime.now(),
-          ),
-        );
-
-        await notifier.submit();
+        await (notifier..updateLocation(
+              Location(
+                id: 'loc-1',
+                partnerId: 'partner-1',
+                name: 'Venue',
+                address: '서울시',
+                createdAt: DateTime.now(),
+                updatedAt: DateTime.now(),
+              ),
+            ))
+            .submit();
 
         final state = container.read(
           eventCreateControllerProvider('party-rec-1'),

--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:app_partner/src/features/home/partner_dashboard_controller.dart';
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
 import 'package:app_partner/src/features/party/event/create/event_create_controller.dart';
-import 'package:app_partner/src/logic/event_create_draft_repository.dart';
 import 'package:app_partner/src/features/party/logic/recurrence_settings_controller.dart';
 import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:app_partner/src/logic/dashboard_refresh_notifier.dart';
+import 'package:app_partner/src/logic/event_create_draft_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -75,6 +78,35 @@ class _FakeEventCreateDraftRepository implements EventCreateDraftRepository {
   @override
   Future<void> saveDraft(EventCreateDraft draft) async {
     _drafts[draft.partyId] = draft;
+  }
+}
+
+class _DelayedEventCreateDraftRepository
+    extends _FakeEventCreateDraftRepository {
+  final saveStarted = Completer<void>();
+  final allowSave = Completer<void>();
+  final getStarted = Completer<void>();
+  final allowGet = Completer<void>();
+  EventCreateDraft? draftToReturn;
+
+  bool hasSavedDraft(String partyId) => _drafts.containsKey(partyId);
+
+  @override
+  Future<EventCreateDraft?> getDraft(String partyId) async {
+    if (!getStarted.isCompleted) {
+      getStarted.complete();
+    }
+    await allowGet.future;
+    return draftToReturn;
+  }
+
+  @override
+  Future<void> saveDraft(EventCreateDraft draft) async {
+    if (!saveStarted.isCompleted) {
+      saveStarted.complete();
+    }
+    await allowSave.future;
+    await super.saveDraft(draft);
   }
 }
 
@@ -284,6 +316,48 @@ void main() {
           expect(recurrence.isEnabled, isTrue);
           expect(recurrence.pattern, RecurrencePattern.biweekly);
           expect(recurrence.daysOfWeek, [2, 4]);
+        },
+      );
+
+      test(
+        'does not write restored draft state after provider disposal',
+        () async {
+          final draftRepo = _DelayedEventCreateDraftRepository()
+            ..draftToReturn = EventCreateDraft(
+              id: 'draft-1',
+              partyId: 'party-1',
+              checkpointTabIndex: 0,
+              startTime: DateTime(2030, 1, 1, 19),
+              endTime: DateTime(2030, 1, 1, 22),
+              maxParticipants: 20,
+              title: 'Saved Draft Event',
+              description: const {},
+              contactOptions: const {},
+              entryGroups: const [],
+              tickets: const [],
+              recurrence: const RecurrenceSettingsState(),
+              updatedAt: DateTime(2030, 1, 1, 18),
+            );
+          final container = createContainer(
+            overrides: [
+              partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+              eventCreateDraftRepositoryProvider.overrideWithValue(draftRepo),
+            ],
+          );
+          final provider = eventCreateControllerProvider('party-1');
+          final sub = container.listen(provider, (_, _) {});
+          final notifier = container.read(provider.notifier);
+
+          final init = notifier.initWithParty(
+            party: _makeParty(),
+            templates: [_makeTemplate()],
+          );
+          await draftRepo.getStarted.future;
+          sub.close();
+          await Future<void>.delayed(Duration.zero);
+          draftRepo.allowGet.complete();
+
+          await expectLater(init, completes);
         },
       );
     });
@@ -584,6 +658,52 @@ void main() {
         expect(draft!.title, 'Auto Saved Event');
         expect(draft.checkpointTabIndex, 1);
       });
+
+      test('bumps dashboard refresh after saving a draft', () async {
+        final draftRepo = _FakeEventCreateDraftRepository();
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+            eventCreateDraftRepositoryProvider.overrideWithValue(draftRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        notifier.updateTitle('Auto Saved Event');
+        final refreshBefore = container.read(dashboardRefreshProvider);
+
+        await notifier.saveDraftNow();
+
+        expect(container.read(dashboardRefreshProvider), refreshBefore + 1);
+      });
+
+      test(
+        'does not write auto-save state after provider disposal',
+        () async {
+          final draftRepo = _DelayedEventCreateDraftRepository();
+          final container = createContainer(
+            overrides: [
+              partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+              eventCreateDraftRepositoryProvider.overrideWithValue(draftRepo),
+            ],
+          );
+          final provider = eventCreateControllerProvider('party-1');
+          final sub = container.listen(provider, (_, _) {});
+          final notifier = container.read(provider.notifier);
+          notifier.updateTitle('Auto Saved Event');
+
+          final save = notifier.saveDraftNow();
+          await draftRepo.saveStarted.future;
+          sub.close();
+          await Future<void>.delayed(Duration.zero);
+          draftRepo.allowSave.complete();
+
+          await expectLater(save, completes);
+          expect(draftRepo.hasSavedDraft('party-1'), isTrue);
+        },
+      );
     });
 
     group('submit', () {
@@ -678,6 +798,58 @@ void main() {
         await notifier.submit();
 
         expect(await draftRepo.getDraft('party-1'), isNull);
+      });
+
+      test('bumps dashboard refresh after deleting published draft', () async {
+        final draftRepo = _FakeEventCreateDraftRepository();
+        await draftRepo.saveDraft(
+          EventCreateDraft.fromState(
+            state: EventCreateState(
+              partyId: 'party-1',
+              startTime: DateTime(2030, 1, 1, 19),
+              endTime: DateTime(2030, 1, 1, 22),
+              title: 'Saved Draft Event',
+            ),
+            recurrence: const RecurrenceSettingsState(),
+            updatedAt: DateTime(2030, 1, 1, 18),
+          ),
+        );
+        when(() => mockPartyRepo.createEvent(any())).thenAnswer(
+          (_) async => Event(
+            id: 'new-event',
+            partyId: 'party-1',
+            startTime: DateTime.now(),
+            endTime: DateTime.now(),
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+            locationRepositoryProvider.overrideWithValue(mockLocationRepo),
+            eventCreateDraftRepositoryProvider.overrideWithValue(draftRepo),
+            partyDetailProvider('party-1').overrideWith(
+              (ref) async => _makeParty(locationId: 'loc-1'),
+            ),
+          ],
+        );
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        notifier.updateLocation(_makeLocation());
+        final refreshBefore = container.read(dashboardRefreshProvider);
+
+        await notifier.submit();
+
+        expect(await draftRepo.getDraft('party-1'), isNull);
+        expect(
+          container.read(dashboardRefreshProvider),
+          refreshBefore + 2,
+          reason:
+              'Submit bumps once for event creation and again after draft cleanup',
+        );
       });
 
       test('creates location first when selectedLocation has no id', () async {

--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
@@ -852,6 +852,59 @@ void main() {
         );
       });
 
+      test('waits for in-flight draft save before publish cleanup', () async {
+        final draftRepo = _DelayedEventCreateDraftRepository();
+        when(() => mockPartyRepo.createEvent(any())).thenAnswer(
+          (_) async => Event(
+            id: 'new-event',
+            partyId: 'party-1',
+            startTime: DateTime.now(),
+            endTime: DateTime.now(),
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+            locationRepositoryProvider.overrideWithValue(mockLocationRepo),
+            eventCreateDraftRepositoryProvider.overrideWithValue(draftRepo),
+          ],
+        );
+        final provider = eventCreateControllerProvider('party-1');
+        final sub = container.listen(provider, (_, _) {});
+        addTearDown(sub.close);
+        final notifier = container.read(provider.notifier);
+        notifier
+          ..updateTitle('Saved Draft Event')
+          ..updateLocation(_makeLocation());
+
+        final save = notifier.saveDraftNow();
+        await draftRepo.saveStarted.future;
+        final submit = notifier.submit();
+
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          draftRepo.hasSavedDraft('party-1'),
+          isFalse,
+          reason: 'Submit must wait for in-flight draft save before deleting',
+        );
+
+        draftRepo.allowSave.complete();
+        await save;
+        await submit;
+
+        expect(
+          container.read(provider).status,
+          isA<AsyncData<void>>(),
+        );
+        expect(
+          draftRepo.hasSavedDraft('party-1'),
+          isFalse,
+          reason: 'Publish cleanup must be the final draft write',
+        );
+      });
+
       test('creates location first when selectedLocation has no id', () async {
         final party = _makeParty();
         final newLocation = _makeLocation(id: 'new-loc');

--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
@@ -110,6 +110,37 @@ class _DelayedEventCreateDraftRepository
   }
 }
 
+class _DraftSaveCall {
+  _DraftSaveCall(this.draft);
+
+  final EventCreateDraft draft;
+  final allow = Completer<void>();
+}
+
+class _SequencedEventCreateDraftRepository
+    extends _FakeEventCreateDraftRepository {
+  final calls = <_DraftSaveCall>[];
+  final _callAdded = StreamController<void>.broadcast();
+
+  bool hasSavedDraft(String partyId) => _drafts.containsKey(partyId);
+
+  Future<_DraftSaveCall> waitForCall(int count) async {
+    while (calls.length < count) {
+      await _callAdded.stream.first;
+    }
+    return calls[count - 1];
+  }
+
+  @override
+  Future<void> saveDraft(EventCreateDraft draft) async {
+    final call = _DraftSaveCall(draft);
+    calls.add(call);
+    _callAdded.add(null);
+    await call.allow.future;
+    await super.saveDraft(draft);
+  }
+}
+
 void main() {
   late MockPartyRepository mockPartyRepo;
   late MockLocationRepository mockLocationRepo;
@@ -704,6 +735,44 @@ void main() {
           expect(draftRepo.hasSavedDraft('party-1'), isTrue);
         },
       );
+
+      test('serializes overlapping explicit draft saves', () async {
+        final draftRepo = _SequencedEventCreateDraftRepository();
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+            eventCreateDraftRepositoryProvider.overrideWithValue(draftRepo),
+          ],
+        );
+        final provider = eventCreateControllerProvider('party-1');
+        final sub = container.listen(provider, (_, _) {});
+        addTearDown(sub.close);
+        final notifier = container.read(provider.notifier);
+
+        notifier.updateTitle('Older Draft');
+        final firstSave = notifier.saveDraftNow();
+        final firstCall = await draftRepo.waitForCall(1);
+
+        notifier.updateTitle('Latest Draft');
+        final secondSave = notifier.saveDraftNow();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          draftRepo.calls,
+          hasLength(1),
+          reason: 'The second save must wait for the first repository write',
+        );
+
+        firstCall.allow.complete();
+        final secondCall = await draftRepo.waitForCall(2);
+        expect(secondCall.draft.title, 'Latest Draft');
+        secondCall.allow.complete();
+
+        await Future.wait([firstSave, secondSave]);
+
+        final savedDraft = await draftRepo.getDraft('party-1');
+        expect(savedDraft?.title, 'Latest Draft');
+      });
     });
 
     group('submit', () {

--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
@@ -1,10 +1,13 @@
 import 'package:app_partner/src/features/home/partner_dashboard_controller.dart';
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
 import 'package:app_partner/src/features/party/event/create/event_create_controller.dart';
+import 'package:app_partner/src/logic/event_create_draft_repository.dart';
+import 'package:app_partner/src/features/party/logic/recurrence_settings_controller.dart';
 import 'package:app_partner/src/logic/current_partner_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../../../utils/mocks.dart';
 import '../../../../../utils/test_utils.dart';
@@ -55,12 +58,33 @@ TicketTemplate _makeTemplate({String id = 'tmpl-1'}) {
   );
 }
 
+class _FakeEventCreateDraftRepository implements EventCreateDraftRepository {
+  final _drafts = <String, EventCreateDraft>{};
+
+  @override
+  Future<void> deleteDraft(String partyId) async {
+    _drafts.remove(partyId);
+  }
+
+  @override
+  Future<EventCreateDraft?> getDraft(String partyId) async => _drafts[partyId];
+
+  @override
+  Future<List<EventCreateDraft>> getDrafts() async => _drafts.values.toList();
+
+  @override
+  Future<void> saveDraft(EventCreateDraft draft) async {
+    _drafts[draft.partyId] = draft;
+  }
+}
+
 void main() {
   late MockPartyRepository mockPartyRepo;
   late MockLocationRepository mockLocationRepo;
   late MockEventRepository mockEventRepo;
 
   setUp(() {
+    SharedPreferences.setMockInitialValues({});
     mockPartyRepo = MockPartyRepository();
     mockLocationRepo = MockLocationRepository();
     mockEventRepo = MockEventRepository();
@@ -110,7 +134,7 @@ void main() {
     });
 
     group('initWithParty', () {
-      test('populates state from party template', () {
+      test('populates state from party template', () async {
         final container = createContainer(
           overrides: [
             partyRepositoryProvider.overrideWithValue(mockPartyRepo),
@@ -125,7 +149,7 @@ void main() {
         final templates = [_makeTemplate()];
         final location = _makeLocation();
 
-        notifier.initWithParty(
+        await notifier.initWithParty(
           party: party,
           templates: templates,
           location: location,
@@ -146,7 +170,7 @@ void main() {
         expect(state.directionsGuide, '엘리베이터 이용');
       });
 
-      test('handles party without location', () {
+      test('handles party without location', () async {
         final container = createContainer(
           overrides: [
             partyRepositoryProvider.overrideWithValue(mockPartyRepo),
@@ -157,7 +181,7 @@ void main() {
           eventCreateControllerProvider('party-1').notifier,
         );
 
-        notifier.initWithParty(
+        await notifier.initWithParty(
           party: _makeParty(),
           templates: <TicketTemplate>[],
         );
@@ -171,7 +195,7 @@ void main() {
         expect(state.tickets, isEmpty);
       });
 
-      test('maps entry group templates to instances', () {
+      test('maps entry group templates to instances', () async {
         final container = createContainer(
           overrides: [
             partyRepositoryProvider.overrideWithValue(mockPartyRepo),
@@ -191,7 +215,7 @@ void main() {
           ),
         ];
 
-        notifier.initWithParty(
+        await notifier.initWithParty(
           party: _makeParty(entryGroups: entryGroupTemplates),
           templates: <TicketTemplate>[],
         );
@@ -204,6 +228,64 @@ void main() {
         expect(state.entryGroups.first.label, 'Male');
         expect(state.entryGroups.first.gender, 'male');
       });
+
+      test(
+        'restores saved draft instead of overwriting from party template',
+        () async {
+          final draftRepo = _FakeEventCreateDraftRepository();
+          final draft = EventCreateDraft(
+            id: 'draft-1',
+            partyId: 'party-1',
+            checkpointTabIndex: 1,
+            startTime: DateTime(2030, 1, 1, 19),
+            endTime: DateTime(2030, 1, 1, 22),
+            maxParticipants: 42,
+            title: 'Saved Draft Event',
+            description: const {'ops': <dynamic>[]},
+            contactOptions: const {'kakao': 'draft-chat'},
+            entryGroups: const [],
+            tickets: const [],
+            recurrence: const RecurrenceSettingsState(
+              isEnabled: true,
+              pattern: RecurrencePattern.biweekly,
+              daysOfWeek: [2, 4],
+            ),
+            updatedAt: DateTime(2030, 1, 1, 18),
+          );
+          await draftRepo.saveDraft(draft);
+
+          final container = createContainer(
+            overrides: [
+              partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+              eventCreateDraftRepositoryProvider.overrideWithValue(draftRepo),
+            ],
+          );
+
+          final notifier = container.read(
+            eventCreateControllerProvider('party-1').notifier,
+          );
+
+          await notifier.initWithParty(
+            party: _makeParty(),
+            templates: [_makeTemplate()],
+          );
+
+          final state = container.read(
+            eventCreateControllerProvider('party-1'),
+          );
+          final recurrence = container.read(
+            recurrenceSettingsControllerProvider,
+          );
+
+          expect(state.draftId, 'draft-1');
+          expect(state.title, 'Saved Draft Event');
+          expect(state.checkpointTabIndex, 1);
+          expect(state.maxParticipants, 42);
+          expect(recurrence.isEnabled, isTrue);
+          expect(recurrence.pattern, RecurrencePattern.biweekly);
+          expect(recurrence.daysOfWeek, [2, 4]);
+        },
+      );
     });
 
     group('update methods', () {
@@ -473,6 +555,35 @@ void main() {
           'private',
         );
       });
+
+      test('auto-saves dirty form state after debounce', () async {
+        final draftRepo = _FakeEventCreateDraftRepository();
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+            eventCreateDraftRepositoryProvider.overrideWithValue(draftRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        final sub = container.listen(
+          eventCreateControllerProvider('party-1'),
+          (_, _) {},
+        );
+        addTearDown(sub.close);
+        notifier
+          ..updateTitle('Auto Saved Event')
+          ..updateCheckpointTab(1);
+
+        await Future<void>.delayed(const Duration(milliseconds: 650));
+
+        final draft = await draftRepo.getDraft('party-1');
+        expect(draft, isNotNull);
+        expect(draft!.title, 'Auto Saved Event');
+        expect(draft.checkpointTabIndex, 1);
+      });
     });
 
     group('submit', () {
@@ -521,6 +632,53 @@ void main() {
           verifyNever(() => mockLocationRepo.createLocation(any()));
         },
       );
+
+      test('deletes saved draft after successful publish', () async {
+        final draftRepo = _FakeEventCreateDraftRepository();
+        await draftRepo.saveDraft(
+          EventCreateDraft.fromState(
+            state: EventCreateState(
+              partyId: 'party-1',
+              startTime: DateTime(2030, 1, 1, 19),
+              endTime: DateTime(2030, 1, 1, 22),
+              title: 'Saved Draft Event',
+            ),
+            recurrence: const RecurrenceSettingsState(),
+            updatedAt: DateTime(2030, 1, 1, 18),
+          ),
+        );
+
+        when(() => mockPartyRepo.createEvent(any())).thenAnswer(
+          (_) async => Event(
+            id: 'new-event',
+            partyId: 'party-1',
+            startTime: DateTime.now(),
+            endTime: DateTime.now(),
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+            locationRepositoryProvider.overrideWithValue(mockLocationRepo),
+            eventCreateDraftRepositoryProvider.overrideWithValue(draftRepo),
+            partyDetailProvider('party-1').overrideWith(
+              (ref) async => _makeParty(locationId: 'loc-1'),
+            ),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        notifier.updateLocation(_makeLocation());
+
+        await notifier.submit();
+
+        expect(await draftRepo.getDraft('party-1'), isNull);
+      });
 
       test('creates location first when selectedLocation has no id', () async {
         final party = _makeParty();


### PR DESCRIPTION
Scheduler: swe-codex-gpt55-medium-1

## What
- Add local EventCreate draft persistence with debounce auto-save, restore, checkpoint tab, recurrence snapshot, ticket/entry/location/info payload, and publish cleanup.
- Show PartnerHome `작성 중인 이벤트` compact resume card when event drafts exist, replacing the first-event CTA during onboarding.
- Switch the multi-party first-event selector from raw Material `showModalBottomSheet` to `showMinglitBottomSheet` + `MinglitListTile`.

## Why
Closes #3053

## MDS References
- `apps/mds/docs/public/specs/partner_home_page/index.html` — “Onboarding · 첫 이벤트 만들기 필요”: first event CTA auto-selects one party, uses party selection sheet for 2+ parties, and draft save replaces todo with `작성 중인 이벤트` card.
- `apps/mds/docs/public/specs/partner_home_page/index.html` — “Default · 운영 중”: feed includes `작성 중` compact cards for saved drafts.
- `apps/mds/docs/public/specs/event_create_page/index.html` — `EventCreatePage` route and controller contract for the 2-tab event creation surface.
- `apps/mds/docs/src/lib/components.ts` — `MinglitBottomSheet` component contract: `showMinglitBottomSheet`, handle/title, `radius-card`, `color-scrim`, and `spacing-screen-edge` padding.

## Verification
- `flutter analyze lib/src/features/party/event/create lib/src/features/party/logic/recurrence_settings_controller.dart lib/src/features/home/partner_dashboard_controller.dart lib/src/features/home/partner_home_page.dart lib/src/features/home/widgets/home_draft_event_card.dart lib/src/features/home/widgets/onboarding_step_guide.dart`
- `flutter test test/src/features/party/event/create/event_create_controller_test.dart test/src/features/home/partner_home_page_test.dart`

## Residual Risk
- Draft persistence is app-local via `SharedPreferences`; it does not sync drafts across devices or users. A server-backed draft model would need a separate backend/design decision.