### PR TITLE
feat(partner): add bank account verification onboarding status

### DIFF
--- a/apps/app_partner/BLUEDOC.md
+++ b/apps/app_partner/BLUEDOC.md
@@ -47,4 +47,4 @@ Minglit 의 **파트너 사장님 Flutter 앱**. 매장 관리·멤버 초대·�
 - [README.md](./README.md) — 빌드·실행 / [integration_test/cuj](./integration_test/cuj/BLUEDOC.md) — CUJ
 
 ---
-_Reviewed: 2026-06-04 23:56_
+_Reviewed: 2026-06-05 01:53_

--- a/apps/app_partner/integration_test/cuj/settlement/partner_settlement_test.dart
+++ b/apps/app_partner/integration_test/cuj/settlement/partner_settlement_test.dart
@@ -178,6 +178,7 @@ void main() {
     when(
       () => repo.upsertBankAccount(
         partnerId: any(named: 'partnerId'),
+        bankCode: any(named: 'bankCode'),
         bankName: any(named: 'bankName'),
         accountHolder: any(named: 'accountHolder'),
         accountNumber: any(named: 'accountNumber'),
@@ -424,19 +425,23 @@ void main() {
         coordinator: coordinator,
       ),
       body: (t) async {
-        await t.enterText(find.widgetWithText(TextFormField, '은행명'), '국민은행');
+        await t.tap(find.widgetWithText(TextFormField, '은행 선택'));
+        await t.pumpAndSettle();
+        await t.tap(find.text('KB국민은행').last);
+        await t.pumpAndSettle();
         await t.enterText(find.widgetWithText(TextFormField, '예금주'), '홍길동');
         await t.enterText(
           find.widgetWithText(TextFormField, '계좌번호'),
           '1234567890',
         );
-        await t.tap(find.text('저장'));
+        await t.tap(find.text('저장하고 확인 요청'));
         await t.pumpAndSettle();
 
         verify(
           () => repo.upsertBankAccount(
             partnerId: 'partner-1',
-            bankName: '국민은행',
+            bankCode: 'kb',
+            bankName: 'KB국민은행',
             accountHolder: '홍길동',
             accountNumber: '1234567890',
           ),
@@ -452,26 +457,37 @@ void main() {
       overrides: () {
         when(() => repo.getBankAccount(any())).thenAnswer(
           (_) async => {
+            'bank_code': 'shinhan',
             'bank_name': '신한은행',
             'account_holder': '기존예금주',
             'account_number': '111122223333',
+            'bank_verification_status': 'manual_review_approved',
           },
         );
         return _baseOverrides(repo: repo, coordinator: coordinator);
       },
       body: (t) async {
-        await t.enterText(find.widgetWithText(TextFormField, '은행명'), '카카오뱅크');
+        await t.tap(find.widgetWithText(TextFormField, '은행 선택'));
+        await t.pumpAndSettle();
+        await t.drag(
+          find.byType(SingleChildScrollView).last,
+          const Offset(0, -240),
+        );
+        await t.pumpAndSettle();
+        await t.tap(find.text('카카오뱅크').last);
+        await t.pumpAndSettle();
         await t.enterText(find.widgetWithText(TextFormField, '예금주'), '변경예금주');
         await t.enterText(
           find.widgetWithText(TextFormField, '계좌번호'),
           '444455556666',
         );
-        await t.tap(find.text('저장'));
+        await t.tap(find.text('저장하고 확인 요청'));
         await t.pumpAndSettle();
 
         verify(
           () => repo.upsertBankAccount(
             partnerId: 'partner-1',
+            bankCode: 'kakao',
             bankName: '카카오뱅크',
             accountHolder: '변경예금주',
             accountNumber: '444455556666',

--- a/apps/app_partner/integration_test/mds-emulator-render/bank_account_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/bank_account_page/builder.dart
@@ -27,9 +27,15 @@ class _FakeSettlementRepository implements SettlementRepository {
   @override
   Future<void> upsertBankAccount({
     required String partnerId,
+    required String bankCode,
     required String bankName,
     required String accountHolder,
     required String accountNumber,
+  }) async {}
+
+  @override
+  Future<void> requestManualBankAccountReview({
+    required String partnerId,
   }) async {}
 
   @override

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_home_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_home_page/builder.dart
@@ -41,6 +41,8 @@ class _LoadedDashboardController extends PartnerDashboardController {
       totalPartyCount: 1,
       totalAttendees: 16,
       hasAnyEvents: true,
+      bankAccountReady: true,
+      bankVerificationStatus: bankVerificationStatusManualApproved,
     );
   }
 }
@@ -62,6 +64,9 @@ class _NoOpPartnerHomeCoordinator implements PartnerHomeCoordinator {
 
   @override
   void pushApplicationList() {}
+
+  @override
+  void pushBankAccount() {}
 
   @override
   void pushEventCreate(String partyId) {}

--- a/apps/app_partner/integration_test/mds-emulator-render/settlement_detail_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/settlement_detail_page/builder.dart
@@ -128,9 +128,15 @@ class _FakeSettlementRepository implements SettlementRepository {
   @override
   Future<void> upsertBankAccount({
     required String partnerId,
+    required String bankCode,
     required String bankName,
     required String accountHolder,
     required String accountNumber,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<void> requestManualBankAccountReview({
+    required String partnerId,
   }) => throw UnimplementedError();
 
   @override

--- a/apps/app_partner/integration_test/mds-emulator-render/settlement_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/settlement_page/builder.dart
@@ -58,9 +58,15 @@ class _FakeSettlementRepository implements SettlementRepository {
   @override
   Future<void> upsertBankAccount({
     required String partnerId,
+    required String bankCode,
     required String bankName,
     required String accountHolder,
     required String accountNumber,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<void> requestManualBankAccountReview({
+    required String partnerId,
   }) => throw UnimplementedError();
 
   @override

--- a/apps/app_partner/lib/src/features/home/partner_dashboard_controller.dart
+++ b/apps/app_partner/lib/src/features/home/partner_dashboard_controller.dart
@@ -11,6 +11,22 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'partner_dashboard_controller.freezed.dart';
 part 'partner_dashboard_controller.g.dart';
 
+const bankVerificationStatusNotStarted = 'not_started';
+const bankVerificationStatusFailed = 'verification_failed';
+const bankVerificationStatusPending = 'manual_review_pending';
+const bankVerificationStatusManualApproved = 'manual_review_approved';
+const bankVerificationStatusVerified = 'verified';
+
+bool isBankVerificationReady(String status) {
+  return status == bankVerificationStatusVerified ||
+      status == bankVerificationStatusManualApproved;
+}
+
+String bankVerificationStatusFromAccount(Map<String, dynamic>? accountData) {
+  return accountData?['bank_verification_status'] as String? ??
+      bankVerificationStatusNotStarted;
+}
+
 @freezed
 abstract class PartnerDashboardState with _$PartnerDashboardState {
   const factory PartnerDashboardState({
@@ -28,6 +44,8 @@ abstract class PartnerDashboardState with _$PartnerDashboardState {
     // Using upcomingEvents for onboarding check caused the guide to reappear
     // after all events ended or were more than 7 days away.
     @Default(false) bool hasAnyEvents,
+    @Default(false) bool bankAccountReady,
+    @Default(bankVerificationStatusNotStarted) String bankVerificationStatus,
     @Default(AsyncValue<void>.loading()) AsyncValue<void> status,
   }) = _PartnerDashboardState;
 }
@@ -68,12 +86,15 @@ class PartnerDashboardController extends _$PartnerDashboardController {
           totalPartyCount: 0,
           totalAttendees: 0,
           hasAnyEvents: false,
+          bankAccountReady: false,
+          bankVerificationStatus: bankVerificationStatusNotStarted,
         );
         return;
       }
       final eventRepo = ref.read(eventRepositoryProvider);
       final partyRepo = ref.read(partyRepositoryProvider);
       final draftRepo = ref.read(eventCreateDraftRepositoryProvider);
+      final settlementRepo = ref.read(settlementRepositoryProvider);
       // 1. Pending Count
       final pendingCount = await eventRepo.getPendingApplicationCount(
         partner.id,
@@ -92,6 +113,10 @@ class PartnerDashboardController extends _$PartnerDashboardController {
       // Fix #1215: onboarding must not reappear once partner has ever created
       // an event — getUpcomingEvents only covers next 7 days.
       final hasAnyEvents = await eventRepo.getHasAnyEvents(partner.id);
+      final bankAccount = await settlementRepo.getBankAccount(partner.id);
+      final bankVerificationStatus = bankVerificationStatusFromAccount(
+        bankAccount,
+      );
 
       final liveEvents = upcomingEvents
           .where((event) => getEventPhase(event) == EventPhase.live)
@@ -137,6 +162,8 @@ class PartnerDashboardController extends _$PartnerDashboardController {
         totalPartyCount: activeParties.length,
         totalAttendees: totalAttendees,
         hasAnyEvents: hasAnyEvents,
+        bankAccountReady: isBankVerificationReady(bankVerificationStatus),
+        bankVerificationStatus: bankVerificationStatus,
       );
     } on Exception catch (e, st) {
       if (!ref.mounted) return;

--- a/apps/app_partner/lib/src/features/home/partner_dashboard_controller.freezed.dart
+++ b/apps/app_partner/lib/src/features/home/partner_dashboard_controller.freezed.dart
@@ -17,7 +17,7 @@ mixin _$PartnerDashboardState {
  int get pendingReviewCount; List<Event> get upcomingEvents; List<Event> get liveEvents; List<Event> get recruitingEvents; List<Event> get preparingEvents; List<Party> get activeParties; List<Party> get draftParties; List<EventCreateDraft> get draftEvents; int get totalPartyCount; int get totalAttendees;// Fix #1215: tracks ALL events ever created, not just upcoming ones.
 // Using upcomingEvents for onboarding check caused the guide to reappear
 // after all events ended or were more than 7 days away.
- bool get hasAnyEvents; AsyncValue<void> get status;
+ bool get hasAnyEvents; bool get bankAccountReady; String get bankVerificationStatus; AsyncValue<void> get status;
 /// Create a copy of PartnerDashboardState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $PartnerDashboardStateCopyWith<PartnerDashboardState> get copyWith => _$PartnerD
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PartnerDashboardState&&(identical(other.pendingReviewCount, pendingReviewCount) || other.pendingReviewCount == pendingReviewCount)&&const DeepCollectionEquality().equals(other.upcomingEvents, upcomingEvents)&&const DeepCollectionEquality().equals(other.liveEvents, liveEvents)&&const DeepCollectionEquality().equals(other.recruitingEvents, recruitingEvents)&&const DeepCollectionEquality().equals(other.preparingEvents, preparingEvents)&&const DeepCollectionEquality().equals(other.activeParties, activeParties)&&const DeepCollectionEquality().equals(other.draftParties, draftParties)&&const DeepCollectionEquality().equals(other.draftEvents, draftEvents)&&(identical(other.totalPartyCount, totalPartyCount) || other.totalPartyCount == totalPartyCount)&&(identical(other.totalAttendees, totalAttendees) || other.totalAttendees == totalAttendees)&&(identical(other.hasAnyEvents, hasAnyEvents) || other.hasAnyEvents == hasAnyEvents)&&(identical(other.status, status) || other.status == status));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PartnerDashboardState&&(identical(other.pendingReviewCount, pendingReviewCount) || other.pendingReviewCount == pendingReviewCount)&&const DeepCollectionEquality().equals(other.upcomingEvents, upcomingEvents)&&const DeepCollectionEquality().equals(other.liveEvents, liveEvents)&&const DeepCollectionEquality().equals(other.recruitingEvents, recruitingEvents)&&const DeepCollectionEquality().equals(other.preparingEvents, preparingEvents)&&const DeepCollectionEquality().equals(other.activeParties, activeParties)&&const DeepCollectionEquality().equals(other.draftParties, draftParties)&&const DeepCollectionEquality().equals(other.draftEvents, draftEvents)&&(identical(other.totalPartyCount, totalPartyCount) || other.totalPartyCount == totalPartyCount)&&(identical(other.totalAttendees, totalAttendees) || other.totalAttendees == totalAttendees)&&(identical(other.hasAnyEvents, hasAnyEvents) || other.hasAnyEvents == hasAnyEvents)&&(identical(other.bankAccountReady, bankAccountReady) || other.bankAccountReady == bankAccountReady)&&(identical(other.bankVerificationStatus, bankVerificationStatus) || other.bankVerificationStatus == bankVerificationStatus)&&(identical(other.status, status) || other.status == status));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,pendingReviewCount,const DeepCollectionEquality().hash(upcomingEvents),const DeepCollectionEquality().hash(liveEvents),const DeepCollectionEquality().hash(recruitingEvents),const DeepCollectionEquality().hash(preparingEvents),const DeepCollectionEquality().hash(activeParties),const DeepCollectionEquality().hash(draftParties),const DeepCollectionEquality().hash(draftEvents),totalPartyCount,totalAttendees,hasAnyEvents,status);
+int get hashCode => Object.hash(runtimeType,pendingReviewCount,const DeepCollectionEquality().hash(upcomingEvents),const DeepCollectionEquality().hash(liveEvents),const DeepCollectionEquality().hash(recruitingEvents),const DeepCollectionEquality().hash(preparingEvents),const DeepCollectionEquality().hash(activeParties),const DeepCollectionEquality().hash(draftParties),const DeepCollectionEquality().hash(draftEvents),totalPartyCount,totalAttendees,hasAnyEvents,bankAccountReady,bankVerificationStatus,status);
 
 @override
 String toString() {
-  return 'PartnerDashboardState(pendingReviewCount: $pendingReviewCount, upcomingEvents: $upcomingEvents, liveEvents: $liveEvents, recruitingEvents: $recruitingEvents, preparingEvents: $preparingEvents, activeParties: $activeParties, draftParties: $draftParties, draftEvents: $draftEvents, totalPartyCount: $totalPartyCount, totalAttendees: $totalAttendees, hasAnyEvents: $hasAnyEvents, status: $status)';
+  return 'PartnerDashboardState(pendingReviewCount: $pendingReviewCount, upcomingEvents: $upcomingEvents, liveEvents: $liveEvents, recruitingEvents: $recruitingEvents, preparingEvents: $preparingEvents, activeParties: $activeParties, draftParties: $draftParties, draftEvents: $draftEvents, totalPartyCount: $totalPartyCount, totalAttendees: $totalAttendees, hasAnyEvents: $hasAnyEvents, bankAccountReady: $bankAccountReady, bankVerificationStatus: $bankVerificationStatus, status: $status)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $PartnerDashboardStateCopyWith<$Res>  {
   factory $PartnerDashboardStateCopyWith(PartnerDashboardState value, $Res Function(PartnerDashboardState) _then) = _$PartnerDashboardStateCopyWithImpl;
 @useResult
 $Res call({
- int pendingReviewCount, List<Event> upcomingEvents, List<Event> liveEvents, List<Event> recruitingEvents, List<Event> preparingEvents, List<Party> activeParties, List<Party> draftParties, List<EventCreateDraft> draftEvents, int totalPartyCount, int totalAttendees, bool hasAnyEvents, AsyncValue<void> status
+ int pendingReviewCount, List<Event> upcomingEvents, List<Event> liveEvents, List<Event> recruitingEvents, List<Event> preparingEvents, List<Party> activeParties, List<Party> draftParties, List<EventCreateDraft> draftEvents, int totalPartyCount, int totalAttendees, bool hasAnyEvents, bool bankAccountReady, String bankVerificationStatus, AsyncValue<void> status
 });
 
 
@@ -65,7 +65,7 @@ class _$PartnerDashboardStateCopyWithImpl<$Res>
 
 /// Create a copy of PartnerDashboardState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? pendingReviewCount = null,Object? upcomingEvents = null,Object? liveEvents = null,Object? recruitingEvents = null,Object? preparingEvents = null,Object? activeParties = null,Object? draftParties = null,Object? draftEvents = null,Object? totalPartyCount = null,Object? totalAttendees = null,Object? hasAnyEvents = null,Object? status = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? pendingReviewCount = null,Object? upcomingEvents = null,Object? liveEvents = null,Object? recruitingEvents = null,Object? preparingEvents = null,Object? activeParties = null,Object? draftParties = null,Object? draftEvents = null,Object? totalPartyCount = null,Object? totalAttendees = null,Object? hasAnyEvents = null,Object? bankAccountReady = null,Object? bankVerificationStatus = null,Object? status = null,}) {
   return _then(_self.copyWith(
 pendingReviewCount: null == pendingReviewCount ? _self.pendingReviewCount : pendingReviewCount // ignore: cast_nullable_to_non_nullable
 as int,upcomingEvents: null == upcomingEvents ? _self.upcomingEvents : upcomingEvents // ignore: cast_nullable_to_non_nullable
@@ -78,7 +78,9 @@ as List<Party>,draftEvents: null == draftEvents ? _self.draftEvents : draftEvent
 as List<EventCreateDraft>,totalPartyCount: null == totalPartyCount ? _self.totalPartyCount : totalPartyCount // ignore: cast_nullable_to_non_nullable
 as int,totalAttendees: null == totalAttendees ? _self.totalAttendees : totalAttendees // ignore: cast_nullable_to_non_nullable
 as int,hasAnyEvents: null == hasAnyEvents ? _self.hasAnyEvents : hasAnyEvents // ignore: cast_nullable_to_non_nullable
-as bool,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,bankAccountReady: null == bankAccountReady ? _self.bankAccountReady : bankAccountReady // ignore: cast_nullable_to_non_nullable
+as bool,bankVerificationStatus: null == bankVerificationStatus ? _self.bankVerificationStatus : bankVerificationStatus // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as AsyncValue<void>,
   ));
 }
@@ -164,10 +166,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int pendingReviewCount,  List<Event> upcomingEvents,  List<Event> liveEvents,  List<Event> recruitingEvents,  List<Event> preparingEvents,  List<Party> activeParties,  List<Party> draftParties,  List<EventCreateDraft> draftEvents,  int totalPartyCount,  int totalAttendees,  bool hasAnyEvents,  AsyncValue<void> status)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int pendingReviewCount,  List<Event> upcomingEvents,  List<Event> liveEvents,  List<Event> recruitingEvents,  List<Event> preparingEvents,  List<Party> activeParties,  List<Party> draftParties,  List<EventCreateDraft> draftEvents,  int totalPartyCount,  int totalAttendees,  bool hasAnyEvents,  bool bankAccountReady,  String bankVerificationStatus,  AsyncValue<void> status)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _PartnerDashboardState() when $default != null:
-return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_that.recruitingEvents,_that.preparingEvents,_that.activeParties,_that.draftParties,_that.draftEvents,_that.totalPartyCount,_that.totalAttendees,_that.hasAnyEvents,_that.status);case _:
+return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_that.recruitingEvents,_that.preparingEvents,_that.activeParties,_that.draftParties,_that.draftEvents,_that.totalPartyCount,_that.totalAttendees,_that.hasAnyEvents,_that.bankAccountReady,_that.bankVerificationStatus,_that.status);case _:
   return orElse();
 
 }
@@ -185,10 +187,10 @@ return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int pendingReviewCount,  List<Event> upcomingEvents,  List<Event> liveEvents,  List<Event> recruitingEvents,  List<Event> preparingEvents,  List<Party> activeParties,  List<Party> draftParties,  List<EventCreateDraft> draftEvents,  int totalPartyCount,  int totalAttendees,  bool hasAnyEvents,  AsyncValue<void> status)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int pendingReviewCount,  List<Event> upcomingEvents,  List<Event> liveEvents,  List<Event> recruitingEvents,  List<Event> preparingEvents,  List<Party> activeParties,  List<Party> draftParties,  List<EventCreateDraft> draftEvents,  int totalPartyCount,  int totalAttendees,  bool hasAnyEvents,  bool bankAccountReady,  String bankVerificationStatus,  AsyncValue<void> status)  $default,) {final _that = this;
 switch (_that) {
 case _PartnerDashboardState():
-return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_that.recruitingEvents,_that.preparingEvents,_that.activeParties,_that.draftParties,_that.draftEvents,_that.totalPartyCount,_that.totalAttendees,_that.hasAnyEvents,_that.status);case _:
+return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_that.recruitingEvents,_that.preparingEvents,_that.activeParties,_that.draftParties,_that.draftEvents,_that.totalPartyCount,_that.totalAttendees,_that.hasAnyEvents,_that.bankAccountReady,_that.bankVerificationStatus,_that.status);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -205,10 +207,10 @@ return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int pendingReviewCount,  List<Event> upcomingEvents,  List<Event> liveEvents,  List<Event> recruitingEvents,  List<Event> preparingEvents,  List<Party> activeParties,  List<Party> draftParties,  List<EventCreateDraft> draftEvents,  int totalPartyCount,  int totalAttendees,  bool hasAnyEvents,  AsyncValue<void> status)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int pendingReviewCount,  List<Event> upcomingEvents,  List<Event> liveEvents,  List<Event> recruitingEvents,  List<Event> preparingEvents,  List<Party> activeParties,  List<Party> draftParties,  List<EventCreateDraft> draftEvents,  int totalPartyCount,  int totalAttendees,  bool hasAnyEvents,  bool bankAccountReady,  String bankVerificationStatus,  AsyncValue<void> status)?  $default,) {final _that = this;
 switch (_that) {
 case _PartnerDashboardState() when $default != null:
-return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_that.recruitingEvents,_that.preparingEvents,_that.activeParties,_that.draftParties,_that.draftEvents,_that.totalPartyCount,_that.totalAttendees,_that.hasAnyEvents,_that.status);case _:
+return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_that.recruitingEvents,_that.preparingEvents,_that.activeParties,_that.draftParties,_that.draftEvents,_that.totalPartyCount,_that.totalAttendees,_that.hasAnyEvents,_that.bankAccountReady,_that.bankVerificationStatus,_that.status);case _:
   return null;
 
 }
@@ -220,7 +222,7 @@ return $default(_that.pendingReviewCount,_that.upcomingEvents,_that.liveEvents,_
 
 
 class _PartnerDashboardState implements PartnerDashboardState {
-  const _PartnerDashboardState({this.pendingReviewCount = 0, final  List<Event> upcomingEvents = const [], final  List<Event> liveEvents = const [], final  List<Event> recruitingEvents = const [], final  List<Event> preparingEvents = const [], final  List<Party> activeParties = const [], final  List<Party> draftParties = const [], final  List<EventCreateDraft> draftEvents = const [], this.totalPartyCount = 0, this.totalAttendees = 0, this.hasAnyEvents = false, this.status = const AsyncValue<void>.loading()}): _upcomingEvents = upcomingEvents,_liveEvents = liveEvents,_recruitingEvents = recruitingEvents,_preparingEvents = preparingEvents,_activeParties = activeParties,_draftParties = draftParties,_draftEvents = draftEvents;
+  const _PartnerDashboardState({this.pendingReviewCount = 0, final  List<Event> upcomingEvents = const [], final  List<Event> liveEvents = const [], final  List<Event> recruitingEvents = const [], final  List<Event> preparingEvents = const [], final  List<Party> activeParties = const [], final  List<Party> draftParties = const [], final  List<EventCreateDraft> draftEvents = const [], this.totalPartyCount = 0, this.totalAttendees = 0, this.hasAnyEvents = false, this.bankAccountReady = false, this.bankVerificationStatus = bankVerificationStatusNotStarted, this.status = const AsyncValue<void>.loading()}): _upcomingEvents = upcomingEvents,_liveEvents = liveEvents,_recruitingEvents = recruitingEvents,_preparingEvents = preparingEvents,_activeParties = activeParties,_draftParties = draftParties,_draftEvents = draftEvents;
   
 
 @override@JsonKey() final  int pendingReviewCount;
@@ -279,6 +281,8 @@ class _PartnerDashboardState implements PartnerDashboardState {
 // Using upcomingEvents for onboarding check caused the guide to reappear
 // after all events ended or were more than 7 days away.
 @override@JsonKey() final  bool hasAnyEvents;
+@override@JsonKey() final  bool bankAccountReady;
+@override@JsonKey() final  String bankVerificationStatus;
 @override@JsonKey() final  AsyncValue<void> status;
 
 /// Create a copy of PartnerDashboardState
@@ -291,16 +295,16 @@ _$PartnerDashboardStateCopyWith<_PartnerDashboardState> get copyWith => __$Partn
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PartnerDashboardState&&(identical(other.pendingReviewCount, pendingReviewCount) || other.pendingReviewCount == pendingReviewCount)&&const DeepCollectionEquality().equals(other._upcomingEvents, _upcomingEvents)&&const DeepCollectionEquality().equals(other._liveEvents, _liveEvents)&&const DeepCollectionEquality().equals(other._recruitingEvents, _recruitingEvents)&&const DeepCollectionEquality().equals(other._preparingEvents, _preparingEvents)&&const DeepCollectionEquality().equals(other._activeParties, _activeParties)&&const DeepCollectionEquality().equals(other._draftParties, _draftParties)&&const DeepCollectionEquality().equals(other._draftEvents, _draftEvents)&&(identical(other.totalPartyCount, totalPartyCount) || other.totalPartyCount == totalPartyCount)&&(identical(other.totalAttendees, totalAttendees) || other.totalAttendees == totalAttendees)&&(identical(other.hasAnyEvents, hasAnyEvents) || other.hasAnyEvents == hasAnyEvents)&&(identical(other.status, status) || other.status == status));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PartnerDashboardState&&(identical(other.pendingReviewCount, pendingReviewCount) || other.pendingReviewCount == pendingReviewCount)&&const DeepCollectionEquality().equals(other._upcomingEvents, _upcomingEvents)&&const DeepCollectionEquality().equals(other._liveEvents, _liveEvents)&&const DeepCollectionEquality().equals(other._recruitingEvents, _recruitingEvents)&&const DeepCollectionEquality().equals(other._preparingEvents, _preparingEvents)&&const DeepCollectionEquality().equals(other._activeParties, _activeParties)&&const DeepCollectionEquality().equals(other._draftParties, _draftParties)&&const DeepCollectionEquality().equals(other._draftEvents, _draftEvents)&&(identical(other.totalPartyCount, totalPartyCount) || other.totalPartyCount == totalPartyCount)&&(identical(other.totalAttendees, totalAttendees) || other.totalAttendees == totalAttendees)&&(identical(other.hasAnyEvents, hasAnyEvents) || other.hasAnyEvents == hasAnyEvents)&&(identical(other.bankAccountReady, bankAccountReady) || other.bankAccountReady == bankAccountReady)&&(identical(other.bankVerificationStatus, bankVerificationStatus) || other.bankVerificationStatus == bankVerificationStatus)&&(identical(other.status, status) || other.status == status));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,pendingReviewCount,const DeepCollectionEquality().hash(_upcomingEvents),const DeepCollectionEquality().hash(_liveEvents),const DeepCollectionEquality().hash(_recruitingEvents),const DeepCollectionEquality().hash(_preparingEvents),const DeepCollectionEquality().hash(_activeParties),const DeepCollectionEquality().hash(_draftParties),const DeepCollectionEquality().hash(_draftEvents),totalPartyCount,totalAttendees,hasAnyEvents,status);
+int get hashCode => Object.hash(runtimeType,pendingReviewCount,const DeepCollectionEquality().hash(_upcomingEvents),const DeepCollectionEquality().hash(_liveEvents),const DeepCollectionEquality().hash(_recruitingEvents),const DeepCollectionEquality().hash(_preparingEvents),const DeepCollectionEquality().hash(_activeParties),const DeepCollectionEquality().hash(_draftParties),const DeepCollectionEquality().hash(_draftEvents),totalPartyCount,totalAttendees,hasAnyEvents,bankAccountReady,bankVerificationStatus,status);
 
 @override
 String toString() {
-  return 'PartnerDashboardState(pendingReviewCount: $pendingReviewCount, upcomingEvents: $upcomingEvents, liveEvents: $liveEvents, recruitingEvents: $recruitingEvents, preparingEvents: $preparingEvents, activeParties: $activeParties, draftParties: $draftParties, draftEvents: $draftEvents, totalPartyCount: $totalPartyCount, totalAttendees: $totalAttendees, hasAnyEvents: $hasAnyEvents, status: $status)';
+  return 'PartnerDashboardState(pendingReviewCount: $pendingReviewCount, upcomingEvents: $upcomingEvents, liveEvents: $liveEvents, recruitingEvents: $recruitingEvents, preparingEvents: $preparingEvents, activeParties: $activeParties, draftParties: $draftParties, draftEvents: $draftEvents, totalPartyCount: $totalPartyCount, totalAttendees: $totalAttendees, hasAnyEvents: $hasAnyEvents, bankAccountReady: $bankAccountReady, bankVerificationStatus: $bankVerificationStatus, status: $status)';
 }
 
 
@@ -311,7 +315,7 @@ abstract mixin class _$PartnerDashboardStateCopyWith<$Res> implements $PartnerDa
   factory _$PartnerDashboardStateCopyWith(_PartnerDashboardState value, $Res Function(_PartnerDashboardState) _then) = __$PartnerDashboardStateCopyWithImpl;
 @override @useResult
 $Res call({
- int pendingReviewCount, List<Event> upcomingEvents, List<Event> liveEvents, List<Event> recruitingEvents, List<Event> preparingEvents, List<Party> activeParties, List<Party> draftParties, List<EventCreateDraft> draftEvents, int totalPartyCount, int totalAttendees, bool hasAnyEvents, AsyncValue<void> status
+ int pendingReviewCount, List<Event> upcomingEvents, List<Event> liveEvents, List<Event> recruitingEvents, List<Event> preparingEvents, List<Party> activeParties, List<Party> draftParties, List<EventCreateDraft> draftEvents, int totalPartyCount, int totalAttendees, bool hasAnyEvents, bool bankAccountReady, String bankVerificationStatus, AsyncValue<void> status
 });
 
 
@@ -328,7 +332,7 @@ class __$PartnerDashboardStateCopyWithImpl<$Res>
 
 /// Create a copy of PartnerDashboardState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? pendingReviewCount = null,Object? upcomingEvents = null,Object? liveEvents = null,Object? recruitingEvents = null,Object? preparingEvents = null,Object? activeParties = null,Object? draftParties = null,Object? draftEvents = null,Object? totalPartyCount = null,Object? totalAttendees = null,Object? hasAnyEvents = null,Object? status = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? pendingReviewCount = null,Object? upcomingEvents = null,Object? liveEvents = null,Object? recruitingEvents = null,Object? preparingEvents = null,Object? activeParties = null,Object? draftParties = null,Object? draftEvents = null,Object? totalPartyCount = null,Object? totalAttendees = null,Object? hasAnyEvents = null,Object? bankAccountReady = null,Object? bankVerificationStatus = null,Object? status = null,}) {
   return _then(_PartnerDashboardState(
 pendingReviewCount: null == pendingReviewCount ? _self.pendingReviewCount : pendingReviewCount // ignore: cast_nullable_to_non_nullable
 as int,upcomingEvents: null == upcomingEvents ? _self._upcomingEvents : upcomingEvents // ignore: cast_nullable_to_non_nullable
@@ -341,7 +345,9 @@ as List<Party>,draftEvents: null == draftEvents ? _self._draftEvents : draftEven
 as List<EventCreateDraft>,totalPartyCount: null == totalPartyCount ? _self.totalPartyCount : totalPartyCount // ignore: cast_nullable_to_non_nullable
 as int,totalAttendees: null == totalAttendees ? _self.totalAttendees : totalAttendees // ignore: cast_nullable_to_non_nullable
 as int,hasAnyEvents: null == hasAnyEvents ? _self.hasAnyEvents : hasAnyEvents // ignore: cast_nullable_to_non_nullable
-as bool,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,bankAccountReady: null == bankAccountReady ? _self.bankAccountReady : bankAccountReady // ignore: cast_nullable_to_non_nullable
+as bool,bankVerificationStatus: null == bankVerificationStatus ? _self.bankVerificationStatus : bankVerificationStatus // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as AsyncValue<void>,
   ));
 }

--- a/apps/app_partner/lib/src/features/home/partner_dashboard_controller.g.dart
+++ b/apps/app_partner/lib/src/features/home/partner_dashboard_controller.g.dart
@@ -44,7 +44,7 @@ final class PartnerDashboardControllerProvider
 }
 
 String _$partnerDashboardControllerHash() =>
-    r'899e6138643104840ee0bf6656d89ef7c19047af';
+    r'27191443292b4bbeef92bab89dce4d5f1c860cfb';
 
 abstract class _$PartnerDashboardController
     extends $Notifier<PartnerDashboardState> {

--- a/apps/app_partner/lib/src/features/home/partner_home_coordinator.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_coordinator.dart
@@ -36,6 +36,10 @@ class PartnerHomeCoordinator {
     _router.go(const SettlementRoute().location);
   }
 
+  void pushBankAccount() {
+    unawaited(_router.push(const BankAccountRoute().location));
+  }
+
   // Fix #845: ApplicationList/Checkin 탭 전환을 coordinator를 통해 위임
   void goToApplicationList() {
     _router.go(const ApplicationListRoute().location);

--- a/apps/app_partner/lib/src/features/home/partner_home_page.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_page.dart
@@ -148,13 +148,23 @@ class PartnerHomePage extends ConsumerWidget {
                     totalPartyCount: state.totalPartyCount,
                     pendingApplications: state.pendingReviewCount,
                   ),
+                  if (state.hasAnyEvents && !state.bankAccountReady) ...[
+                    const SizedBox(height: MinglitSpacing.medium),
+                    _BankAccountTodoCard(
+                      verificationStatus: state.bankVerificationStatus,
+                      onTap: coordinator.pushBankAccount,
+                    ),
+                  ],
                   const SizedBox(height: MinglitSpacing.medium),
                   if (!state.hasAnyEvents) ...[
                     LocationGuideBanner(onTap: coordinator.pushLocationGuide),
                     const SizedBox(height: MinglitSpacing.medium),
                     OnboardingStepGuide(
                       hasParty: state.activeParties.isNotEmpty,
+                      bankAccountReady: state.bankAccountReady,
+                      bankVerificationStatus: state.bankVerificationStatus,
                       partyName: state.activeParties.firstOrNull?.title,
+                      onOpenBankAccount: coordinator.pushBankAccount,
                       onCreateParty: coordinator.pushPartyCreate,
                       onCreateEvent: openFirstEventCreate,
                       draftEventCard: state.draftEvents.isEmpty
@@ -304,6 +314,59 @@ class PartnerHomePage extends ConsumerWidget {
             ),
           );
         },
+      ),
+    );
+  }
+}
+
+class _BankAccountTodoCard extends StatelessWidget {
+  const _BankAccountTodoCard({
+    required this.verificationStatus,
+    required this.onTap,
+  });
+
+  final String verificationStatus;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final title = verificationStatus == bankVerificationStatusPending
+        ? '계좌 확인 중'
+        : '계좌 등록';
+    final subtitle = verificationStatus == bankVerificationStatusFailed
+        ? '계좌 정보를 다시 확인해주세요'
+        : verificationStatus == bankVerificationStatusPending
+        ? '운영 확인이 완료되면 사라져요'
+        : '정산 받을 계좌를 등록해주세요';
+
+    return Card(
+      child: ListTile(
+        onTap: onTap,
+        leading: Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: colorScheme.tertiary.withValues(
+              alpha: MinglitOpacity.highlight,
+            ),
+            borderRadius: BorderRadius.circular(MinglitRadius.input),
+          ),
+          child: Icon(
+            Icons.account_balance_wallet_outlined,
+            color: colorScheme.tertiary,
+            size: MinglitIconSize.small,
+          ),
+        ),
+        title: Text(
+          title,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        subtitle: Text(subtitle),
+        trailing: const Icon(Icons.chevron_right),
       ),
     );
   }

--- a/apps/app_partner/lib/src/features/home/widgets/onboarding_step_guide.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/onboarding_step_guide.dart
@@ -6,7 +6,10 @@ import 'package:minglit_kit/minglit_kit.dart';
 class OnboardingStepGuide extends StatelessWidget {
   const OnboardingStepGuide({
     required this.hasParty,
+    required this.bankAccountReady,
+    required this.bankVerificationStatus,
     required this.partyName,
+    required this.onOpenBankAccount,
     required this.onCreateParty,
     required this.onCreateEvent,
     this.draftEventCard,
@@ -15,7 +18,10 @@ class OnboardingStepGuide extends StatelessWidget {
   });
 
   final bool hasParty;
+  final bool bankAccountReady;
+  final String bankVerificationStatus;
   final String? partyName;
+  final VoidCallback onOpenBankAccount;
   final VoidCallback onCreateParty;
   final VoidCallback onCreateEvent;
   final Widget? draftEventCard;
@@ -25,7 +31,7 @@ class OnboardingStepGuide extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final progress = hasParty ? 3 : 2;
+    final progress = 1 + (bankAccountReady ? 1 : 0) + (hasParty ? 1 : 0);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -110,11 +116,13 @@ class OnboardingStepGuide extends StatelessWidget {
                 colorScheme: colorScheme,
               ),
               const Divider(height: 1),
-              // Step 2: Done
               _StepRow(
                 number: 2,
-                title: '계좌 등록',
-                isDone: true,
+                title: _bankStepTitle,
+                isDone: bankAccountReady,
+                isCurrent: !bankAccountReady,
+                subtitle: _bankStepSubtitle,
+                onTap: onOpenBankAccount,
                 theme: theme,
                 colorScheme: colorScheme,
               ),
@@ -297,6 +305,23 @@ class OnboardingStepGuide extends StatelessWidget {
       ],
     );
   }
+
+  String get _bankStepTitle {
+    if (bankAccountReady) return '계좌 확인 완료';
+    if (bankVerificationStatus == 'manual_review_pending') return '계좌 확인 중';
+    return '계좌 등록';
+  }
+
+  String get _bankStepSubtitle {
+    if (bankAccountReady) return '정산 받을 계좌가 준비되었어요';
+    if (bankVerificationStatus == 'verification_failed') {
+      return '계좌 정보를 다시 확인해주세요';
+    }
+    if (bankVerificationStatus == 'manual_review_pending') {
+      return '운영 확인이 완료되면 사라져요';
+    }
+    return '정산 받을 계좌를 등록해주세요';
+  }
 }
 
 class _StepRow extends StatelessWidget {
@@ -309,6 +334,7 @@ class _StepRow extends StatelessWidget {
     this.isCurrent = false,
     this.isLocked = false,
     this.subtitle,
+    this.onTap,
   });
 
   final int number;
@@ -317,6 +343,7 @@ class _StepRow extends StatelessWidget {
   final bool isCurrent;
   final bool isLocked;
   final String? subtitle;
+  final VoidCallback? onTap;
   final ThemeData theme;
   final ColorScheme colorScheme;
 
@@ -326,76 +353,87 @@ class _StepRow extends StatelessWidget {
 
     return Opacity(
       opacity: opacity,
-      child: Container(
-        color: isCurrent
-            ? colorScheme.primary.withValues(alpha: MinglitOpacity.tintFill)
-            : null,
-        padding: const EdgeInsets.symmetric(
-          horizontal: MinglitSpacing.medium,
-          vertical: MinglitSpacing.sm,
-        ),
-        child: Row(
-          children: [
-            // Number/check circle
-            Container(
-              width: 28,
-              height: 28,
-              decoration: BoxDecoration(
-                color: isDone
-                    ? MinglitColors.success
-                    : isCurrent
-                    ? colorScheme.primary
-                    : theme.colorScheme.surfaceContainerHighest,
-                shape: BoxShape.circle,
-              ),
-              child: Center(
-                child: isDone
-                    ? Icon(Icons.check, color: colorScheme.onPrimary, size: 16)
-                    : Text(
-                        number.toString(),
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: isCurrent ? colorScheme.onPrimary : null,
-                          fontWeight: FontWeight.w800,
+      child: InkWell(
+        onTap: isLocked ? null : onTap,
+        child: Container(
+          color: isCurrent
+              ? colorScheme.primary.withValues(alpha: MinglitOpacity.tintFill)
+              : null,
+          padding: const EdgeInsets.symmetric(
+            horizontal: MinglitSpacing.medium,
+            vertical: MinglitSpacing.sm,
+          ),
+          child: Row(
+            children: [
+              // Number/check circle
+              Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  color: isDone
+                      ? MinglitColors.success
+                      : isCurrent
+                      ? colorScheme.primary
+                      : theme.colorScheme.surfaceContainerHighest,
+                  shape: BoxShape.circle,
+                ),
+                child: Center(
+                  child: isDone
+                      ? Icon(
+                          Icons.check,
+                          color: colorScheme.onPrimary,
+                          size: 16,
+                        )
+                      : Text(
+                          number.toString(),
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: isCurrent ? colorScheme.onPrimary : null,
+                            fontWeight: FontWeight.w800,
+                          ),
                         ),
-                      ),
+                ),
               ),
-            ),
-            const SizedBox(width: MinglitSpacing.sm),
-            // Title + subtitle
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: theme.textTheme.labelLarge?.copyWith(
-                      fontWeight: isCurrent ? FontWeight.w800 : FontWeight.w600,
-                      decoration: isDone ? TextDecoration.lineThrough : null,
-                      color: isDone ? theme.colorScheme.onSurfaceVariant : null,
-                    ),
-                  ),
-                  if (subtitle != null)
+              const SizedBox(width: MinglitSpacing.sm),
+              // Title + subtitle
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Text(
-                      subtitle!,
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: isDone && subtitle == '방금 완료!'
-                            ? MinglitColors.success
-                            : theme.colorScheme.onSurfaceVariant,
-                        fontWeight: isDone && subtitle == '방금 완료!'
-                            ? FontWeight.w600
+                      title,
+                      style: theme.textTheme.labelLarge?.copyWith(
+                        fontWeight: isCurrent
+                            ? FontWeight.w800
+                            : FontWeight.w600,
+                        decoration: isDone ? TextDecoration.lineThrough : null,
+                        color: isDone
+                            ? theme.colorScheme.onSurfaceVariant
                             : null,
                       ),
                     ),
-                ],
+                    if (subtitle != null)
+                      Text(
+                        subtitle!,
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: isDone && subtitle == '방금 완료!'
+                              ? MinglitColors.success
+                              : theme.colorScheme.onSurfaceVariant,
+                          fontWeight: isDone && subtitle == '방금 완료!'
+                              ? FontWeight.w600
+                              : null,
+                        ),
+                      ),
+                  ],
+                ),
               ),
-            ),
-            if (isCurrent)
-              Icon(
-                Icons.chevron_right,
-                color: colorScheme.primary,
-                size: MinglitIconSize.small,
-              ),
-          ],
+              if (isCurrent)
+                Icon(
+                  Icons.chevron_right,
+                  color: colorScheme.primary,
+                  size: MinglitIconSize.small,
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/app_partner/lib/src/features/settlement/bank_account_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/bank_account_page.dart
@@ -1,10 +1,23 @@
 import 'dart:async' show unawaited;
 
+import 'package:app_partner/src/features/settlement/bank_catalog.dart';
 import 'package:app_partner/src/features/settlement/settlement_coordinator.dart';
 import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:app_partner/src/logic/dashboard_refresh_notifier.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:minglit_kit/minglit_kit.dart';
+
+const _bankStatusNotStarted = 'not_started';
+const _bankStatusFailed = 'verification_failed';
+const _bankStatusPending = 'manual_review_pending';
+const _bankStatusManualApproved = 'manual_review_approved';
+const _bankStatusVerified = 'verified';
+
+String _bankStatus(Map<String, dynamic>? accountData) {
+  return accountData?['bank_verification_status'] as String? ??
+      _bankStatusNotStarted;
+}
 
 class BankAccountPage extends ConsumerStatefulWidget {
   const BankAccountPage({super.key});
@@ -16,6 +29,7 @@ class BankAccountPage extends ConsumerStatefulWidget {
 class _BankAccountPageState extends ConsumerState<BankAccountPage> {
   Map<String, dynamic>? _accountData;
   bool _isLoading = true;
+  bool _isRequestingManualReview = false;
 
   @override
   void initState() {
@@ -45,6 +59,34 @@ class _BankAccountPageState extends ConsumerState<BankAccountPage> {
     }
   }
 
+  Future<void> _handleSaved() async {
+    await _loadAccount();
+    ref.read(dashboardRefreshProvider.notifier).bump();
+  }
+
+  Future<void> _requestManualReview() async {
+    setState(() => _isRequestingManualReview = true);
+    try {
+      final partner = await ref.read(currentPartnerInfoProvider.future);
+      if (partner == null) return;
+      await ref
+          .read(settlementRepositoryProvider)
+          .requestManualBankAccountReview(partnerId: partner.id);
+      await _handleSaved();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('수동 검증 요청이 접수되었습니다.')),
+      );
+    } on Exception catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('수동 검증 요청 실패: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _isRequestingManualReview = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -56,11 +98,15 @@ class _BankAccountPageState extends ConsumerState<BankAccountPage> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  AccountCard(accountData: _accountData),
+                  AccountCard(
+                    accountData: _accountData,
+                    isRequestingManualReview: _isRequestingManualReview,
+                    onRequestManualReview: _requestManualReview,
+                  ),
                   const SizedBox(height: MinglitSpacing.medium),
                   AccountEditForm(
                     accountData: _accountData,
-                    onSaved: _loadAccount,
+                    onSaved: () => unawaited(_handleSaved()),
                   ),
                 ],
               ),
@@ -70,8 +116,15 @@ class _BankAccountPageState extends ConsumerState<BankAccountPage> {
 }
 
 class AccountCard extends StatelessWidget {
-  const AccountCard({required this.accountData, super.key});
+  const AccountCard({
+    required this.accountData,
+    required this.isRequestingManualReview,
+    required this.onRequestManualReview,
+    super.key,
+  });
   final Map<String, dynamic>? accountData;
+  final bool isRequestingManualReview;
+  final VoidCallback onRequestManualReview;
 
   @override
   Widget build(BuildContext context) {
@@ -86,6 +139,7 @@ class AccountCard extends StatelessWidget {
     final bankName = accountData!['bank_name'] as String? ?? '-';
     final holder = accountData!['account_holder'] as String? ?? '-';
     final number = accountData!['account_number'] as String? ?? '';
+    final status = _bankStatus(accountData);
     final masked = number.length > 4
         ? '${'*' * (number.length - 4)}${number.substring(number.length - 4)}'
         : number;
@@ -101,8 +155,130 @@ class AccountCard extends StatelessWidget {
             _InfoRow('은행', bankName),
             _InfoRow('예금주', holder),
             _InfoRow('계좌번호', masked),
+            _InfoRow('확인 상태', _statusLabel(status)),
+            const SizedBox(height: MinglitSpacing.sm),
+            _BankStatusCallout(
+              status: status,
+              isRequestingManualReview: isRequestingManualReview,
+              onRequestManualReview: onRequestManualReview,
+            ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+String _statusLabel(String status) {
+  switch (status) {
+    case _bankStatusVerified:
+      return '확인 완료';
+    case _bankStatusManualApproved:
+      return '운영 확인 완료';
+    case _bankStatusFailed:
+      return '확인 실패';
+    case _bankStatusPending:
+      return '확인 중';
+    case _bankStatusNotStarted:
+    default:
+      return '미확인';
+  }
+}
+
+class _BankStatusCallout extends StatelessWidget {
+  const _BankStatusCallout({
+    required this.status,
+    required this.isRequestingManualReview,
+    required this.onRequestManualReview,
+  });
+
+  final String status;
+  final bool isRequestingManualReview;
+  final VoidCallback onRequestManualReview;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final isReady =
+        status == _bankStatusVerified || status == _bankStatusManualApproved;
+    final isFailed = status == _bankStatusFailed;
+    final color = isReady
+        ? MinglitColors.success
+        : isFailed
+        ? colorScheme.error
+        : colorScheme.primary;
+    final title = isReady
+        ? '정산 받을 계좌로 확인되었습니다.'
+        : isFailed
+        ? '계좌 정보를 다시 확인해주세요.'
+        : '운영팀이 계좌를 확인 중입니다.';
+    final body = isReady
+        ? '다음 정산부터 이 계좌 정보가 사용됩니다.'
+        : isFailed
+        ? '은행, 계좌번호, 예금주를 수정해 다시 저장하거나 수동 검증을 요청할 수 있습니다.'
+        : '확인이 끝나기 전까지 PartnerHome의 계좌 todo는 유지됩니다.';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(MinglitSpacing.sm),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: MinglitOpacity.tintFill),
+        border: Border.all(
+          color: color.withValues(alpha: MinglitOpacity.subtle),
+        ),
+        borderRadius: BorderRadius.circular(MinglitRadius.input),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                isReady
+                    ? Icons.check_circle_outline
+                    : isFailed
+                    ? Icons.error_outline
+                    : Icons.hourglass_top_outlined,
+                color: color,
+                size: MinglitIconSize.small,
+              ),
+              const SizedBox(width: MinglitSpacing.xsmall),
+              Expanded(
+                child: Text(
+                  title,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: MinglitSpacing.xsmall),
+          Text(
+            body,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          if (isFailed) ...[
+            const SizedBox(height: MinglitSpacing.small),
+            OutlinedButton.icon(
+              onPressed: isRequestingManualReview
+                  ? null
+                  : onRequestManualReview,
+              icon: isRequestingManualReview
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.support_agent_outlined),
+              label: Text(isRequestingManualReview ? '요청 중...' : '수동 검증 요청'),
+            ),
+          ],
+        ],
       ),
     );
   }
@@ -153,20 +329,35 @@ class _AccountEditFormState extends ConsumerState<AccountEditForm> {
   late final TextEditingController _bankCtrl;
   late final TextEditingController _holderCtrl;
   late final TextEditingController _numberCtrl;
+  BankOption? _selectedBank;
   bool _isSaving = false;
 
   @override
   void initState() {
     super.initState();
-    _bankCtrl = TextEditingController(
-      text: widget.accountData?['bank_name'] as String? ?? '',
-    );
-    _holderCtrl = TextEditingController(
-      text: widget.accountData?['account_holder'] as String? ?? '',
-    );
-    _numberCtrl = TextEditingController(
-      text: widget.accountData?['account_number'] as String? ?? '',
-    );
+    _bankCtrl = TextEditingController();
+    _holderCtrl = TextEditingController();
+    _numberCtrl = TextEditingController();
+    _syncFromAccountData();
+  }
+
+  @override
+  void didUpdateWidget(covariant AccountEditForm oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.accountData != widget.accountData) {
+      _syncFromAccountData();
+    }
+  }
+
+  void _syncFromAccountData() {
+    _selectedBank =
+        bankOptionByCode(widget.accountData?['bank_code'] as String?) ??
+        bankOptionByName(widget.accountData?['bank_name'] as String?);
+    _bankCtrl.text =
+        _selectedBank?.name ??
+        (widget.accountData?['bank_name'] as String? ?? '');
+    _holderCtrl.text = widget.accountData?['account_holder'] as String? ?? '';
+    _numberCtrl.text = widget.accountData?['account_number'] as String? ?? '';
   }
 
   @override
@@ -177,8 +368,44 @@ class _AccountEditFormState extends ConsumerState<AccountEditForm> {
     super.dispose();
   }
 
+  Future<void> _showBankSheet() async {
+    final selected = await showMinglitBottomSheet<BankOption>(
+      context: context,
+      title: '은행 선택',
+      isScrollControlled: true,
+      padding: const EdgeInsets.only(
+        left: MinglitSpacing.small,
+        right: MinglitSpacing.small,
+        bottom: MinglitSpacing.medium,
+      ),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ...partnerBankCatalog.map(
+              (bank) => MinglitListTile(
+                title: bank.name,
+                trailing: _selectedBank?.code == bank.code
+                    ? const Icon(Icons.check)
+                    : null,
+                onTap: () => Navigator.of(context).pop(bank),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (selected == null || !mounted) return;
+    setState(() {
+      _selectedBank = selected;
+      _bankCtrl.text = selected.name;
+    });
+  }
+
   Future<void> _save() async {
     if (!(_formKey.currentState?.validate() ?? false)) return;
+    final bank = _selectedBank;
+    if (bank == null) return;
     setState(() => _isSaving = true);
     try {
       final partner = await ref.read(currentPartnerInfoProvider.future);
@@ -186,13 +413,14 @@ class _AccountEditFormState extends ConsumerState<AccountEditForm> {
       final repo = ref.read(settlementRepositoryProvider);
       await repo.upsertBankAccount(
         partnerId: partner.id,
-        bankName: _bankCtrl.text.trim(),
+        bankCode: bank.code,
+        bankName: bank.name,
         accountHolder: _holderCtrl.text.trim(),
         accountNumber: _numberCtrl.text.trim(),
       );
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('계좌 정보가 저장되었습니다.')),
+        const SnackBar(content: Text('계좌 확인 요청이 접수되었습니다.')),
       );
       widget.onSaved();
     } on Exception catch (e) {
@@ -215,13 +443,20 @@ class _AccountEditFormState extends ConsumerState<AccountEditForm> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Text('계좌 수정', style: Theme.of(context).textTheme.titleSmall),
+              Text(
+                widget.accountData == null ? '계좌 등록' : '계좌 수정',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
               const SizedBox(height: MinglitSpacing.sm),
               TextFormField(
                 controller: _bankCtrl,
-                decoration: const InputDecoration(labelText: '은행명'),
-                validator: (v) =>
-                    (v == null || v.isEmpty) ? '은행명을 입력해 주세요.' : null,
+                readOnly: true,
+                onTap: _isSaving ? null : _showBankSheet,
+                decoration: const InputDecoration(
+                  labelText: '은행 선택',
+                  suffixIcon: Icon(Icons.expand_more),
+                ),
+                validator: (_) => _selectedBank == null ? '은행을 선택해 주세요.' : null,
               ),
               const SizedBox(height: MinglitSpacing.small),
               TextFormField(
@@ -235,7 +470,8 @@ class _AccountEditFormState extends ConsumerState<AccountEditForm> {
                 controller: _numberCtrl,
                 decoration: const InputDecoration(labelText: '계좌번호'),
                 keyboardType: TextInputType.number,
-                // Fix #1938: reject non-digit keystrokes; regex validates 10–16 digit range
+                // Fix #1938: reject non-digit keystrokes; regex validates
+                // the 10-16 digit range.
                 inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                 validator: (v) {
                   if (v == null || v.isEmpty) return '계좌번호를 입력해 주세요.';
@@ -248,7 +484,7 @@ class _AccountEditFormState extends ConsumerState<AccountEditForm> {
               const SizedBox(height: MinglitSpacing.medium),
               FilledButton(
                 onPressed: _isSaving ? null : _save,
-                child: Text(_isSaving ? '저장 중...' : '저장'),
+                child: Text(_isSaving ? '확인 중...' : '저장하고 확인 요청'),
               ),
             ],
           ),
@@ -286,7 +522,8 @@ class _RetryPayoutButtonState extends ConsumerState<RetryPayoutButton> {
             payoutId: widget.payoutId,
             partnerId: widget.partnerId,
           );
-      // Fix #1928: coordinator already shows success toast via showMinglitSuccess
+      // Fix #1928: coordinator already shows success toast via
+      // showMinglitSuccess.
       if (!mounted) return;
       widget.onSuccess();
     } on Exception catch (e) {

--- a/apps/app_partner/lib/src/features/settlement/bank_catalog.dart
+++ b/apps/app_partner/lib/src/features/settlement/bank_catalog.dart
@@ -1,0 +1,34 @@
+class BankOption {
+  const BankOption({required this.code, required this.name});
+
+  final String code;
+  final String name;
+}
+
+const partnerBankCatalog = [
+  BankOption(code: 'kb', name: 'KB국민은행'),
+  BankOption(code: 'shinhan', name: '신한은행'),
+  BankOption(code: 'hana', name: '하나은행'),
+  BankOption(code: 'woori', name: '우리은행'),
+  BankOption(code: 'ibk', name: 'IBK기업은행'),
+  BankOption(code: 'nh', name: 'NH농협은행'),
+  BankOption(code: 'kakao', name: '카카오뱅크'),
+  BankOption(code: 'toss', name: '토스뱅크'),
+  BankOption(code: 'kbank', name: '케이뱅크'),
+];
+
+BankOption? bankOptionByCode(String? code) {
+  if (code == null || code.isEmpty) return null;
+  for (final bank in partnerBankCatalog) {
+    if (bank.code == code) return bank;
+  }
+  return null;
+}
+
+BankOption? bankOptionByName(String? name) {
+  if (name == null || name.isEmpty) return null;
+  for (final bank in partnerBankCatalog) {
+    if (bank.name == name) return bank;
+  }
+  return null;
+}

--- a/apps/app_partner/test/src/features/home/partner_dashboard_controller_test.dart
+++ b/apps/app_partner/test/src/features/home/partner_dashboard_controller_test.dart
@@ -64,10 +64,12 @@ class _FakeEventCreateDraftRepository implements EventCreateDraftRepository {
 void main() {
   late MockEventRepository mockEventRepo;
   late MockPartyRepository mockPartyRepo;
+  late MockSettlementRepository mockSettlementRepo;
 
   setUp(() {
     mockEventRepo = MockEventRepository();
     mockPartyRepo = MockPartyRepository();
+    mockSettlementRepo = MockSettlementRepository();
 
     when(
       () => mockEventRepo.getPendingApplicationCount(any()),
@@ -87,6 +89,15 @@ void main() {
     when(
       () => mockPartyRepo.getPartiesByPartnerId(any()),
     ).thenAnswer((_) async => [_testParty]);
+    when(() => mockSettlementRepo.getBankAccount(any())).thenAnswer(
+      (_) async => {
+        'bank_code': 'kakao',
+        'bank_name': '카카오뱅크',
+        'account_holder': '테스트 파트너',
+        'account_number': '3333011234567',
+        'bank_verification_status': 'manual_review_approved',
+      },
+    );
   });
 
   /// Creates container, subscribes to the dashboard provider, and pumps
@@ -102,6 +113,7 @@ void main() {
         eventCreateDraftRepositoryProvider.overrideWithValue(
           const _FakeEventCreateDraftRepository(),
         ),
+        settlementRepositoryProvider.overrideWithValue(mockSettlementRepo),
       ],
     );
 
@@ -131,6 +143,7 @@ void main() {
           eventCreateDraftRepositoryProvider.overrideWithValue(
             const _FakeEventCreateDraftRepository(),
           ),
+          settlementRepositoryProvider.overrideWithValue(mockSettlementRepo),
         ],
       );
 
@@ -158,6 +171,26 @@ void main() {
       expect(state.upcomingEvents, contains(_testEvent));
       expect(state.activeParties, contains(_testParty));
       expect(state.hasAnyEvents, isTrue);
+      expect(state.bankAccountReady, isTrue);
+      expect(state.bankVerificationStatus, 'manual_review_approved');
+    });
+
+    test('bankAccountReady is false while verification is pending', () async {
+      when(() => mockSettlementRepo.getBankAccount(any())).thenAnswer(
+        (_) async => {
+          'bank_code': 'kakao',
+          'bank_name': '카카오뱅크',
+          'account_holder': '테스트 파트너',
+          'account_number': '3333011234567',
+          'bank_verification_status': 'manual_review_pending',
+        },
+      );
+
+      final container = await buildAndPump();
+      final state = container.read(partnerDashboardControllerProvider);
+
+      expect(state.bankAccountReady, isFalse);
+      expect(state.bankVerificationStatus, 'manual_review_pending');
     });
 
     // Regression test for #1215: partner with past events (no upcoming events)
@@ -256,6 +289,7 @@ void main() {
           eventCreateDraftRepositoryProvider.overrideWithValue(
             const _FakeEventCreateDraftRepository(),
           ),
+          settlementRepositoryProvider.overrideWithValue(mockSettlementRepo),
         ],
       );
       final sub = container.listen(

--- a/apps/app_partner/test/src/features/home/partner_home_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/home/partner_home_coordinator_test.dart
@@ -79,15 +79,27 @@ void main() {
       verifyNever(() => mockRouter.push(any()));
     });
 
+    test('pushBankAccount pushes bank account route', () {
+      final container = createContainer(
+        overrides: [goRouterProvider.overrideWithValue(mockRouter)],
+      );
+
+      container.read(partnerHomeCoordinatorProvider).pushBankAccount();
+
+      verify(
+        () => mockRouter.push(
+          any(that: equals('/settlement/bank-account')),
+        ),
+      ).called(1);
+    });
+
     test(
       'pushNotificationCenter and pushApplicationList push different routes',
       () {
         final container = createContainer(
           overrides: [goRouterProvider.overrideWithValue(mockRouter)],
         );
-        final coordinator = container.read(partnerHomeCoordinatorProvider);
-
-        coordinator
+        container.read(partnerHomeCoordinatorProvider)
           ..pushNotificationCenter()
           ..pushApplicationList();
 

--- a/apps/app_partner/test/src/features/home/partner_home_page_test.dart
+++ b/apps/app_partner/test/src/features/home/partner_home_page_test.dart
@@ -6,9 +6,9 @@ import 'package:app_partner/src/features/home/partner_dashboard_controller.dart'
 import 'package:app_partner/src/features/home/partner_home_coordinator.dart';
 import 'package:app_partner/src/features/home/partner_home_page.dart';
 import 'package:app_partner/src/features/home/widgets/weekly_stats_row.dart';
-import 'package:app_partner/src/logic/event_create_draft_repository.dart';
 import 'package:app_partner/src/features/party/logic/recurrence_settings_controller.dart';
 import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:app_partner/src/logic/event_create_draft_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -30,6 +30,8 @@ class _LoadedDashboardController extends PartnerDashboardController {
 PartnerDashboardState _dashboardState = const PartnerDashboardState(
   status: AsyncValue.data(null),
   hasAnyEvents: true,
+  bankAccountReady: true,
+  bankVerificationStatus: 'manual_review_approved',
 );
 
 Party _makeParty() {
@@ -52,9 +54,12 @@ Widget _buildPage({
       const PartnerDashboardState(
         status: AsyncValue.data(null),
         hasAnyEvents: true,
+        bankAccountReady: true,
+        bankVerificationStatus: 'manual_review_approved',
       );
   final coord = coordinator ?? _MockPartnerHomeCoordinator();
   when(coord.pushNotificationCenter).thenReturn(null);
+  when(coord.pushBankAccount).thenReturn(null);
   when(() => coord.pushEventCreate(any())).thenReturn(null);
   return ProviderScope(
     overrides: [
@@ -165,5 +170,31 @@ void main() {
         verify(() => coord.pushEventCreate('party-1')).called(1);
       },
     );
+
+    testWidgets('pending bank account todo opens BankAccountRoute owner', (
+      tester,
+    ) async {
+      final coordinator = _MockPartnerHomeCoordinator();
+      when(coordinator.pushNotificationCenter).thenReturn(null);
+      when(coordinator.pushBankAccount).thenReturn(null);
+      when(() => coordinator.pushEventCreate(any())).thenReturn(null);
+
+      await tester.pumpWidget(
+        _buildPage(
+          coordinator: coordinator,
+          dashboardState: const PartnerDashboardState(
+            status: AsyncValue.data(null),
+            hasAnyEvents: true,
+            bankVerificationStatus: 'manual_review_pending',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('계좌 확인 중'), findsOneWidget);
+      await tester.tap(find.text('계좌 확인 중'));
+
+      verify(coordinator.pushBankAccount).called(1);
+    });
   });
 }

--- a/apps/app_partner/test/src/features/home/widgets/onboarding_step_guide_test.dart
+++ b/apps/app_partner/test/src/features/home/widgets/onboarding_step_guide_test.dart
@@ -3,109 +3,137 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
+Widget _buildGuide({
+  required bool hasParty,
+  required bool bankAccountReady,
+  required VoidCallback onCreateParty,
+  required VoidCallback onCreateEvent,
+  required VoidCallback onOpenBankAccount,
+  String bankVerificationStatus = 'manual_review_approved',
+  String? partyName,
+  VoidCallback? onOpenGuide,
+}) {
+  return MaterialApp(
+    theme: MinglitTheme.materialTheme,
+    home: Scaffold(
+      body: SingleChildScrollView(
+        child: OnboardingStepGuide(
+          hasParty: hasParty,
+          bankAccountReady: bankAccountReady,
+          bankVerificationStatus: bankVerificationStatus,
+          partyName: partyName,
+          onOpenBankAccount: onOpenBankAccount,
+          onCreateParty: onCreateParty,
+          onCreateEvent: onCreateEvent,
+          onOpenGuide: onOpenGuide,
+        ),
+      ),
+    ),
+  );
+}
+
 void main() {
   group('OnboardingStepGuide', () {
     testWidgets(
-      'shows welcome message and 2/4 progress and create-party CTA when hasParty is false',
+      'shows 2/4 progress and create-party CTA when bank is ready',
       (tester) async {
         await tester.pumpWidget(
-          MaterialApp(
-            theme: MinglitTheme.materialTheme,
-            home: Scaffold(
-              body: SingleChildScrollView(
-                child: OnboardingStepGuide(
-                  hasParty: false,
-                  partyName: null,
-                  onCreateParty: () {},
-                  onCreateEvent: () {},
-                ),
-              ),
-            ),
+          _buildGuide(
+            hasParty: false,
+            bankAccountReady: true,
+            onOpenBankAccount: () {},
+            onCreateParty: () {},
+            onCreateEvent: () {},
           ),
         );
 
         expect(find.text('환영합니다!'), findsOneWidget);
         expect(find.text('2/4 완료'), findsOneWidget);
-        // CTA icon uniquely identifies the FilledButton.icon in the hasParty=false state.
         expect(find.byIcon(Icons.celebration_outlined), findsOneWidget);
       },
     );
 
     testWidgets(
-      'shows 3/4 progress and partyName and create-event CTA when hasParty is true',
+      'shows 3/4 progress and partyName and create-event CTA when bank and party are ready',
       (tester) async {
         await tester.pumpWidget(
-          MaterialApp(
-            theme: MinglitTheme.materialTheme,
-            home: Scaffold(
-              body: SingleChildScrollView(
-                child: OnboardingStepGuide(
-                  hasParty: true,
-                  partyName: '테스트 파티',
-                  onCreateParty: () {},
-                  onCreateEvent: () {},
-                ),
-              ),
-            ),
+          _buildGuide(
+            hasParty: true,
+            bankAccountReady: true,
+            partyName: '테스트 파티',
+            onOpenBankAccount: () {},
+            onCreateParty: () {},
+            onCreateEvent: () {},
           ),
         );
 
         expect(find.text('3/4 완료'), findsOneWidget);
         expect(find.text('테스트 파티'), findsOneWidget);
-        // CTA icon uniquely identifies the FilledButton.icon in the hasParty=true state.
         expect(find.byIcon(Icons.event_outlined), findsOneWidget);
       },
     );
 
     testWidgets(
-      'calls onCreateParty callback when CTA button tapped and hasParty is false',
+      'keeps account step current while verification is pending',
+      (tester) async {
+        var openBankCount = 0;
+
+        await tester.pumpWidget(
+          _buildGuide(
+            hasParty: false,
+            bankAccountReady: false,
+            bankVerificationStatus: 'manual_review_pending',
+            onOpenBankAccount: () => openBankCount++,
+            onCreateParty: () {},
+            onCreateEvent: () {},
+          ),
+        );
+
+        expect(find.text('1/4 완료'), findsOneWidget);
+        expect(find.text('계좌 확인 중'), findsOneWidget);
+        expect(find.text('운영 확인이 완료되면 사라져요'), findsOneWidget);
+
+        await tester.tap(find.text('계좌 확인 중'));
+        expect(openBankCount, 1);
+      },
+    );
+
+    testWidgets(
+      'calls onCreateParty when CTA button is tapped',
       (tester) async {
         var callCount = 0;
 
         await tester.pumpWidget(
-          MaterialApp(
-            theme: MinglitTheme.materialTheme,
-            home: Scaffold(
-              body: SingleChildScrollView(
-                child: OnboardingStepGuide(
-                  hasParty: false,
-                  partyName: null,
-                  onCreateParty: () => callCount++,
-                  onCreateEvent: () {},
-                ),
-              ),
-            ),
+          _buildGuide(
+            hasParty: false,
+            bankAccountReady: true,
+            onOpenBankAccount: () {},
+            onCreateParty: () => callCount++,
+            onCreateEvent: () {},
           ),
         );
 
-        // Tap the CTA via its unique icon (celebration = create party).
         await tester.tap(find.byIcon(Icons.celebration_outlined));
         expect(callCount, 1);
       },
     );
 
     testWidgets(
-      'calls onCreateEvent callback when CTA button tapped and hasParty is true',
+      'calls onCreateEvent when CTA button is tapped',
       (tester) async {
         var callCount = 0;
 
         await tester.pumpWidget(
-          MaterialApp(
-            theme: MinglitTheme.materialTheme,
-            home: Scaffold(
-              body: SingleChildScrollView(
-                child: OnboardingStepGuide(
-                  hasParty: true,
-                  partyName: '테스트 파티',
-                  onCreateParty: () {},
-                  onCreateEvent: () => callCount++,
-                ),
-              ),
-            ),
+          _buildGuide(
+            hasParty: true,
+            bankAccountReady: true,
+            partyName: '테스트 파티',
+            onOpenBankAccount: () {},
+            onCreateParty: () {},
+            onCreateEvent: () => callCount++,
           ),
         );
 
-        // Tap the CTA via its unique icon (event_outlined = create event).
         await tester.tap(find.byIcon(Icons.event_outlined));
         expect(callCount, 1);
       },
@@ -117,19 +145,13 @@ void main() {
       var callCount = 0;
 
       await tester.pumpWidget(
-        MaterialApp(
-          theme: MinglitTheme.materialTheme,
-          home: Scaffold(
-            body: SingleChildScrollView(
-              child: OnboardingStepGuide(
-                hasParty: false,
-                partyName: null,
-                onCreateParty: () {},
-                onCreateEvent: () {},
-                onOpenGuide: () => callCount++,
-              ),
-            ),
-          ),
+        _buildGuide(
+          hasParty: false,
+          bankAccountReady: true,
+          onOpenBankAccount: () {},
+          onCreateParty: () {},
+          onCreateEvent: () {},
+          onOpenGuide: () => callCount++,
         ),
       );
 

--- a/apps/app_partner/test/src/features/settlement/bank_account_page_test.dart
+++ b/apps/app_partner/test/src/features/settlement/bank_account_page_test.dart
@@ -26,24 +26,62 @@ Widget _buildForm({Map<String, dynamic>? accountData}) {
   );
 }
 
+Future<void> _selectBank(
+  WidgetTester tester, {
+  String bankName = 'KB국민은행',
+}) async {
+  await tester.tap(find.widgetWithText(TextFormField, '은행 선택'));
+  await tester.pumpAndSettle();
+  final bankFinder = find.text(bankName).last;
+  await tester.ensureVisible(bankFinder);
+  await tester.pumpAndSettle();
+  await tester.tap(bankFinder);
+  await tester.pumpAndSettle();
+}
+
 Future<void> _fillAndSubmit(
   WidgetTester tester, {
-  String bank = '국민은행',
   String holder = '홍길동',
   String accountNumber = '',
 }) async {
-  await tester.enterText(find.widgetWithText(TextFormField, '은행명'), bank);
+  await _selectBank(tester);
   await tester.enterText(find.widgetWithText(TextFormField, '예금주'), holder);
   await tester.enterText(
     find.widgetWithText(TextFormField, '계좌번호'),
     accountNumber,
   );
-  await tester.tap(find.text('저장'));
+  await tester.tap(find.text('저장하고 확인 요청'));
   await tester.pump();
 }
 
 void main() {
   group('AccountEditForm — account number validation (Fix #1938)', () {
+    testWidgets('empty account state uses registration title', (tester) async {
+      await tester.pumpWidget(_buildForm());
+      await tester.pump();
+
+      expect(find.text('계좌 등록'), findsOneWidget);
+      expect(find.text('계좌 수정'), findsNothing);
+    });
+
+    testWidgets('registered account state uses edit title', (tester) async {
+      await tester.pumpWidget(
+        _buildForm(
+          accountData: const {
+            'bank_code': 'kb',
+            'bank_name': 'KB국민은행',
+            'account_holder': '홍길동',
+            'account_number': '1234567890',
+            'bank_verification_status': 'manual_review_pending',
+          },
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('계좌 수정'), findsOneWidget);
+      expect(find.text('계좌 등록'), findsNothing);
+    });
+
     testWidgets('empty account number shows required error', (tester) async {
       await tester.pumpWidget(_buildForm());
       await tester.pump();
@@ -76,7 +114,7 @@ void main() {
       await tester.pump();
 
       // FilteringTextInputFormatter blocks non-digits at keystroke level,
-      // but validator catches any that bypass (e.g. programmatic entry in tests)
+      // Validator catches any non-digits that bypass the input formatter.
       await _fillAndSubmit(tester, accountNumber: 'asdf1234567');
 
       expect(find.text('계좌번호는 10~16자리 숫자여야 합니다.'), findsOneWidget);
@@ -89,6 +127,7 @@ void main() {
       when(
         () => mockSettlementRepo.upsertBankAccount(
           partnerId: any(named: 'partnerId'),
+          bankCode: any(named: 'bankCode'),
           bankName: any(named: 'bankName'),
           accountHolder: any(named: 'accountHolder'),
           accountNumber: any(named: 'accountNumber'),
@@ -117,6 +156,15 @@ void main() {
       // No format error shown
       expect(find.text('계좌번호는 10~16자리 숫자여야 합니다.'), findsNothing);
       expect(find.text('계좌번호를 입력해 주세요.'), findsNothing);
+      verify(
+        () => mockSettlementRepo.upsertBankAccount(
+          partnerId: 'partner-1',
+          bankCode: 'kb',
+          bankName: 'KB국민은행',
+          accountHolder: '홍길동',
+          accountNumber: '1234567890',
+        ),
+      ).called(1);
     });
 
     testWidgets('16-digit valid account number passes validation', (
@@ -126,6 +174,7 @@ void main() {
       when(
         () => mockSettlementRepo.upsertBankAccount(
           partnerId: any(named: 'partnerId'),
+          bankCode: any(named: 'bankCode'),
           bankName: any(named: 'bankName'),
           accountHolder: any(named: 'accountHolder'),
           accountNumber: any(named: 'accountNumber'),
@@ -153,6 +202,85 @@ void main() {
 
       expect(find.text('계좌번호는 10~16자리 숫자여야 합니다.'), findsNothing);
       expect(find.text('계좌번호를 입력해 주세요.'), findsNothing);
+    });
+
+    testWidgets('bank selection sheet stores selected bank code', (
+      tester,
+    ) async {
+      final mockSettlementRepo = MockSettlementRepository();
+      when(
+        () => mockSettlementRepo.upsertBankAccount(
+          partnerId: any(named: 'partnerId'),
+          bankCode: any(named: 'bankCode'),
+          bankName: any(named: 'bankName'),
+          accountHolder: any(named: 'accountHolder'),
+          accountNumber: any(named: 'accountNumber'),
+        ),
+      ).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            currentPartnerInfoProvider.overrideWith(
+              (ref) async => const Partner(id: 'partner-1', name: 'Test'),
+            ),
+            settlementRepositoryProvider.overrideWithValue(mockSettlementRepo),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: AccountEditForm(onSaved: _noop),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await _selectBank(tester, bankName: '카카오뱅크');
+      await tester.enterText(find.widgetWithText(TextFormField, '예금주'), '홍길동');
+      await tester.enterText(
+        find.widgetWithText(TextFormField, '계좌번호'),
+        '1234567890',
+      );
+      await tester.tap(find.text('저장하고 확인 요청'));
+      await tester.pump();
+
+      verify(
+        () => mockSettlementRepo.upsertBankAccount(
+          partnerId: 'partner-1',
+          bankCode: 'kakao',
+          bankName: '카카오뱅크',
+          accountHolder: '홍길동',
+          accountNumber: '1234567890',
+        ),
+      ).called(1);
+    });
+  });
+
+  group('AccountCard — verification status', () {
+    testWidgets('failed status exposes manual review fallback', (tester) async {
+      var requested = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AccountCard(
+              accountData: const {
+                'bank_name': '카카오뱅크',
+                'account_holder': '홍길동',
+                'account_number': '3333011234567',
+                'bank_verification_status': 'verification_failed',
+              },
+              isRequestingManualReview: false,
+              onRequestManualReview: () => requested = true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('확인 실패'), findsOneWidget);
+      expect(find.text('수동 검증 요청'), findsOneWidget);
+
+      await tester.tap(find.text('수동 검증 요청'));
+      expect(requested, isTrue);
     });
   });
 

--- a/shared/packages/minglit_demo/lib/overrides/partner_overrides.dart
+++ b/shared/packages/minglit_demo/lib/overrides/partner_overrides.dart
@@ -39,15 +39,16 @@ class _DemoPartnerRepository extends PartnerRepository {
   @override
   Future<Map<String, dynamic>?> getMyMemberRole(String partnerId) async {
     if (partnerId == DemoWorld.selfPartnerId) {
-      return {'role': 'owner', 'permissions': ['ALL']};
+      return {
+        'role': 'owner',
+        'permissions': ['ALL'],
+      };
     }
     return null;
   }
 
   @override
-  Future<Map<String, dynamic>> getPartnerRevenueStats(
-    String partnerId,
-  ) async {
+  Future<Map<String, dynamic>> getPartnerRevenueStats(String partnerId) async {
     if (partnerId != DemoWorld.selfPartnerId) {
       return {
         'partner_id': partnerId,
@@ -60,10 +61,8 @@ class _DemoPartnerRepository extends PartnerRepository {
     final completed = demoSettlementItems
         .where((s) => s.status == 'COMPLETED')
         .toList();
-    final totalGross =
-        completed.fold<int>(0, (sum, s) => sum + s.grossAmount);
-    final totalNet =
-        completed.fold<int>(0, (sum, s) => sum + s.netAmount);
+    final totalGross = completed.fold<int>(0, (sum, s) => sum + s.grossAmount);
+    final totalNet = completed.fold<int>(0, (sum, s) => sum + s.netAmount);
     return {
       'partner_id': partnerId,
       'total_sales': totalGross,
@@ -99,9 +98,7 @@ class _DemoPartnerRepository extends PartnerRepository {
   // ── Member management (mixin forwarded) ──────────────────────────────────
 
   @override
-  Future<List<Map<String, dynamic>>> getPartnerMembers(
-    String partnerId,
-  ) async {
+  Future<List<Map<String, dynamic>>> getPartnerMembers(String partnerId) async {
     if (partnerId != DemoWorld.selfPartnerId) return [];
     return List<Map<String, dynamic>>.from(demoPartnerMembers);
   }
@@ -186,21 +183,17 @@ class _DemoSettlementRepository extends SettlementRepository {
       items = items.where((s) => s.status == status).toList();
     }
     if (dateStart != null) {
-      items =
-          items.where((s) => !s.createdAt.isBefore(dateStart)).toList();
+      items = items.where((s) => !s.createdAt.isBefore(dateStart)).toList();
     }
     if (dateEnd != null) {
-      items =
-          items.where((s) => !s.createdAt.isAfter(dateEnd)).toList();
+      items = items.where((s) => !s.createdAt.isAfter(dateEnd)).toList();
     }
     final end = (offset + limit).clamp(0, items.length);
     return offset >= items.length ? [] : items.sublist(offset, end);
   }
 
   @override
-  Future<SettlementItemDetail?> getSettlementItemDetail(
-    String itemId,
-  ) async {
+  Future<SettlementItemDetail?> getSettlementItemDetail(String itemId) async {
     try {
       return demoSettlementItems.firstWhere((s) => s.id == itemId);
     } on StateError {
@@ -250,18 +243,28 @@ class _DemoSettlementRepository extends SettlementRepository {
   Future<Map<String, dynamic>?> getBankAccount(String partnerId) async {
     if (partnerId != DemoWorld.selfPartnerId) return null;
     return {
+      'bank_code': 'kakao',
       'bank_name': demoBankAccount['bank_name'],
       'account_holder': demoBankAccount['account_holder'],
       'account_number': demoBankAccount['account_number'],
+      'bank_verification_status': 'manual_review_approved',
     };
   }
 
   @override
   Future<void> upsertBankAccount({
     required String partnerId,
+    required String bankCode,
     required String bankName,
     required String accountHolder,
     required String accountNumber,
+  }) async {
+    // Demo: accept silently.
+  }
+
+  @override
+  Future<void> requestManualBankAccountReview({
+    required String partnerId,
   }) async {
     // Demo: accept silently.
   }
@@ -278,8 +281,7 @@ class _DemoSettlementRepository extends SettlementRepository {
   Future<Map<String, dynamic>> retryPayout({
     required String payoutId,
     required String partnerId,
-  }) async =>
-      {'status': 'queued', 'payout_id': payoutId};
+  }) async => {'status': 'queued', 'payout_id': payoutId};
 }
 
 // ── Staff Repository ──────────────────────────────────────────────────────────
@@ -305,10 +307,7 @@ class _DemoStaffRepository extends StaffRepository {
 
 class _DemoCheckinRepository extends CheckinRepository {
   _DemoCheckinRepository()
-    : super(
-        crypto: TicketCrypto(),
-        supabase: const PoisonSupabaseClient(),
-      );
+    : super(crypto: TicketCrypto(), supabase: const PoisonSupabaseClient());
 
   @override
   Future<bool> verifyAndCheckin({
@@ -321,9 +320,7 @@ class _DemoCheckinRepository extends CheckinRepository {
 
 List<Override> partnerDomainOverrides() => [
   partnerRepositoryProvider.overrideWith((_) => _DemoPartnerRepository()),
-  settlementRepositoryProvider.overrideWith(
-    (_) => _DemoSettlementRepository(),
-  ),
+  settlementRepositoryProvider.overrideWith((_) => _DemoSettlementRepository()),
   staffRepositoryProvider.overrideWith((_) => _DemoStaffRepository()),
   checkinRepositoryProvider.overrideWith((_) => _DemoCheckinRepository()),
 ];

--- a/shared/packages/minglit_kit/lib/src/data/repositories/settlement_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/settlement_repository.dart
@@ -110,11 +110,11 @@ class SettlementRepository {
           await _supabase
                   .from('settlement_histories')
                   .select(
-                    // Fix #1566: settlement_histories has event_at, not created_at
+                    // Fix #1566: use event_at, not created_at.
                     'event_type, from_status, to_status, details, event_at',
                   )
                   .eq('settlement_item_id', itemId)
-                  // Fix #1566: order by event_at (not created_at — that column doesn't exist)
+                  // Fix #1566: order by event_at; created_at does not exist.
                   .order('event_at', ascending: false)
               as List;
 
@@ -129,7 +129,7 @@ class SettlementRepository {
                   .select(
                     'id, adjustment_type, amount_signed, reason_code, status',
                   )
-                  // Fix #1739: adjustment_items FK 컬럼명은 related_settlement_item_id
+                  // Fix #1739: adjustment_items FK name.
                   .eq('related_settlement_item_id', itemId)
               as List;
 
@@ -218,7 +218,7 @@ class SettlementRepository {
     try {
       final data = await _supabase
           .from('events')
-          // Fix #1937: 'date' column does not exist; actual column is start_time
+          // Fix #1937: date does not exist; actual column is start_time.
           .select('id, title, start_time, parties(name)')
           .eq('id', eventId)
           .maybeSingle();
@@ -244,7 +244,11 @@ class SettlementRepository {
     try {
       final data = await _supabase
           .from('partner_settlements')
-          .select('bank_name, account_holder, account_number')
+          .select(
+            'bank_code, bank_name, account_holder, account_number, '
+            'bank_verification_status, bank_verification_reason, '
+            'bank_verification_requested_at, bank_verified_at',
+          )
           .eq('partner_id', partnerId)
           .maybeSingle();
 
@@ -266,6 +270,7 @@ class SettlementRepository {
   /// Creates or updates the bank account record in partner_settlements table.
   Future<void> upsertBankAccount({
     required String partnerId,
+    required String bankCode,
     required String bankName,
     required String accountHolder,
     required String accountNumber,
@@ -279,6 +284,7 @@ class SettlementRepository {
         body: {
           'action': 'upsert_bank_account',
           'partner_id': partnerId,
+          'bank_code': bankCode,
           'bank_name': bankName,
           'account_holder': accountHolder,
           'account_number': accountNumber,
@@ -294,6 +300,38 @@ class SettlementRepository {
       Log.d('upsertBankAccount success | partnerId: $partnerId');
     } catch (e, st) {
       Log.e('❌ [SettlementRepo] upsertBankAccount Error', e, st);
+      rethrow;
+    }
+  }
+
+  /// Requests manual review for a failed or uncertain bank account.
+  Future<void> requestManualBankAccountReview({
+    required String partnerId,
+  }) async {
+    Log.d('requestManualBankAccountReview called | partnerId: $partnerId');
+    try {
+      final response = await _supabase.functions.invoke(
+        'partner-manage-settlement',
+        body: {
+          'action': 'request_manual_bank_account_review',
+          'partner_id': partnerId,
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ??
+                  'Failed to request manual bank account review'
+            : 'Failed to request manual bank account review';
+        throw Exception(error);
+      }
+
+      Log.d('requestManualBankAccountReview success | partnerId: $partnerId');
+    } catch (e, st) {
+      Log.e(
+        '❌ [SettlementRepo] requestManualBankAccountReview Error',
+        e,
+        st,
+      );
       rethrow;
     }
   }

--- a/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
@@ -437,9 +437,11 @@ void main() {
     group('getBankAccount', () {
       test('returns bank account map', () async {
         final bankJson = {
+          'bank_code': 'kb',
           'bank_name': '국민은행',
           'account_holder': '홍길동',
           'account_number': '123-456-789',
+          'bank_verification_status': 'manual_review_pending',
         };
         mockTable(
           mockClient,
@@ -450,8 +452,10 @@ void main() {
         final result = await repository.getBankAccount('partner_1');
 
         expect(result, isNotNull);
-        expect(result!['bank_name'], '국민은행');
+        expect(result!['bank_code'], 'kb');
+        expect(result['bank_name'], '국민은행');
         expect(result['account_holder'], '홍길동');
+        expect(result['bank_verification_status'], 'manual_review_pending');
       });
 
       test('returns null when not found', () async {
@@ -496,6 +500,7 @@ void main() {
         await expectLater(
           repository.upsertBankAccount(
             partnerId: 'partner_1',
+            bankCode: 'kb',
             bankName: '국민은행',
             accountHolder: '홍길동',
             accountNumber: '123-456-789',
@@ -520,10 +525,57 @@ void main() {
         await expectLater(
           repository.upsertBankAccount(
             partnerId: 'partner_1',
+            bankCode: 'kb',
             bankName: '국민은행',
             accountHolder: '홍길동',
             accountNumber: '123-456-789',
           ),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // requestManualBankAccountReview
+    // -------------------------------------------------------------------------
+    group('requestManualBankAccountReview', () {
+      test('completes without error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-settlement',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {
+              'success': true,
+              'bank_verification_status': 'manual_review_pending',
+            },
+          ),
+        );
+
+        await expectLater(
+          repository.requestManualBankAccountReview(partnerId: 'partner_1'),
+          completes,
+        );
+      });
+
+      test('throws on backend error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-settlement',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 500,
+            data: {'error': 'manual review failed'},
+          ),
+        );
+
+        await expectLater(
+          repository.requestManualBankAccountReview(partnerId: 'partner_1'),
           throwsA(isA<Exception>()),
         );
       });

--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -32,4 +32,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-06-04 22:43_
+_Reviewed: 2026-06-05 01:53_

--- a/supabase/functions/partner-manage-settlement/index.ts
+++ b/supabase/functions/partner-manage-settlement/index.ts
@@ -2,32 +2,67 @@
 // Issue #312: RLS write strategy 전환
 // Fix #2185 (Batch 6): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
 import { parseAction } from "../_shared/request_utils.ts";
 import { log } from "../_shared/logger.ts";
 
 const FN = "partner-manage-settlement";
 
-// Fields allowed in upsert_bank_account action
-const UPSERT_FIELDS = [
-  "bank_name",
-  "account_holder",
-  "account_number",
+type BankOption = {
+  readonly code: string;
+  readonly name: string;
+};
+
+const BANK_CATALOG: readonly BankOption[] = [
+  { code: "kb", name: "KB국민은행" },
+  { code: "shinhan", name: "신한은행" },
+  { code: "hana", name: "하나은행" },
+  { code: "woori", name: "우리은행" },
+  { code: "ibk", name: "IBK기업은행" },
+  { code: "nh", name: "NH농협은행" },
+  { code: "kakao", name: "카카오뱅크" },
+  { code: "toss", name: "토스뱅크" },
+  { code: "kbank", name: "케이뱅크" },
 ] as const;
 
-// Fix #312: 계좌번호 형식 검증 — 하이픈/공백 제거 후 숫자 6~20자리
-const ACCOUNT_NUMBER_RE = /^[0-9]{6,20}$/;
+const BANK_BY_CODE = new Map<string, BankOption>(
+  BANK_CATALOG.map((bank) => [bank.code, bank]),
+);
+const BANK_BY_NAME = new Map<string, BankOption>(
+  BANK_CATALOG.map((bank) => [bank.name, bank]),
+);
 
-export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+// Issue #3047: BankAccountPage spec keeps the 10-16 digit client contract.
+const ACCOUNT_NUMBER_RE = /^[0-9]{10,16}$/;
+
+function resolveBank(body: Record<string, unknown>) {
+  const bankCode = typeof body.bank_code === "string"
+    ? body.bank_code.trim()
+    : "";
+  if (bankCode) return BANK_BY_CODE.get(bankCode);
+
+  // Backward-compatible fallback for clients still sending only bank_name.
+  const bankName = typeof body.bank_name === "string"
+    ? body.bank_name.trim()
+    : "";
+  return BANK_BY_NAME.get(bankName);
+}
+
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
   const { supabase } = ctx;
-  if (ctx.auth.type !== "user") return errorResponse("Unexpected auth type", 500);
+  if (ctx.auth.type !== "user") {
+    return errorResponse("Unexpected auth type", 500);
+  }
   const userId = ctx.auth.userId;
 
   try {
@@ -46,12 +81,9 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
         return errorResponse("Missing partner_id", 400);
       }
 
-      // Validate required fields with trim
-      const bankName = typeof body.bank_name === "string"
-        ? body.bank_name.trim()
-        : "";
-      if (!bankName) {
-        return errorResponse("Missing bank_name", 400);
+      const bank = resolveBank(body);
+      if (!bank) {
+        return errorResponse("Missing or unsupported bank_code", 400);
       }
 
       const accountHolder = typeof body.account_holder === "string"
@@ -68,22 +100,32 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
         return errorResponse("Missing account_number", 400);
       }
 
-      // Fix #312: 계좌번호 포맷 검증 — 하이픈/공백 제거 후 숫자만 6~20자리
+      // Fix #312 / Issue #3047: strip separators, then enforce 10-16 digits.
       const accountNumber = rawAccountNumber.replace(/[-\s]/g, "");
       if (!ACCOUNT_NUMBER_RE.test(accountNumber)) {
         return errorResponse("Invalid account_number format", 400);
       }
 
       // Check partner permission
-      const permCheck = await requirePartnerPermission(supabase, partnerId, userId, ["SETTLEMENT_EDIT"]);
+      const permCheck = await requirePartnerPermission(
+        supabase,
+        partnerId,
+        userId,
+        ["SETTLEMENT_EDIT"],
+      );
       if (permCheck) return permCheck;
 
       // Build upsert record — only allow whitelisted fields, use validated values
       const record: Record<string, unknown> = {
         partner_id: partnerId,
-        bank_name: bankName,
+        bank_code: bank.code,
+        bank_name: bank.name,
         account_holder: accountHolder,
         account_number: accountNumber,
+        bank_verification_status: "manual_review_pending",
+        bank_verification_reason: "partner_submitted_bank_account",
+        bank_verification_requested_at: new Date().toISOString(),
+        bank_verified_at: null,
       };
 
       const { error: upsertError } = await supabase
@@ -97,7 +139,50 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
         );
       }
 
-      return successResponse({ success: true });
+      return successResponse({
+        success: true,
+        bank_verification_status: "manual_review_pending",
+      });
+    }
+
+    // ─── request_manual_bank_account_review ───
+    if (action === "request_manual_bank_account_review") {
+      const partnerId = typeof body.partner_id === "string"
+        ? body.partner_id.trim()
+        : "";
+      if (!partnerId) {
+        return errorResponse("Missing partner_id", 400);
+      }
+
+      const permCheck = await requirePartnerPermission(
+        supabase,
+        partnerId,
+        userId,
+        ["SETTLEMENT_EDIT"],
+      );
+      if (permCheck) return permCheck;
+
+      const { error: updateError } = await supabase
+        .from("partner_settlements")
+        .update({
+          bank_verification_status: "manual_review_pending",
+          bank_verification_reason: "partner_requested_manual_review",
+          bank_verification_requested_at: new Date().toISOString(),
+          bank_verified_at: null,
+        })
+        .eq("partner_id", partnerId);
+
+      if (updateError) {
+        return errorResponse(
+          `Failed to request manual bank account review: ${updateError.message}`,
+          500,
+        );
+      }
+
+      return successResponse({
+        success: true,
+        bank_verification_status: "manual_review_pending",
+      });
     }
 
     return errorResponse(`Unknown action: ${action}`, 400);

--- a/supabase/functions/partner-manage-settlement/index.ts
+++ b/supabase/functions/partner-manage-settlement/index.ts
@@ -18,6 +18,11 @@ type BankOption = {
   readonly name: string;
 };
 
+type ResolvedBank = {
+  readonly code: string | null;
+  readonly name: string;
+};
+
 const BANK_CATALOG: readonly BankOption[] = [
   { code: "kb", name: "KB국민은행" },
   { code: "shinhan", name: "신한은행" },
@@ -40,17 +45,25 @@ const BANK_BY_NAME = new Map<string, BankOption>(
 // Issue #3047: BankAccountPage spec keeps the 10-16 digit client contract.
 const ACCOUNT_NUMBER_RE = /^[0-9]{10,16}$/;
 
-function resolveBank(body: Record<string, unknown>) {
+function resolveBank(body: Record<string, unknown>): ResolvedBank | undefined {
   const bankCode = typeof body.bank_code === "string"
     ? body.bank_code.trim()
     : "";
-  if (bankCode) return BANK_BY_CODE.get(bankCode);
+  if (bankCode) {
+    const bank = BANK_BY_CODE.get(bankCode);
+    return bank ? { code: bank.code, name: bank.name } : undefined;
+  }
 
   // Backward-compatible fallback for clients still sending only bank_name.
   const bankName = typeof body.bank_name === "string"
     ? body.bank_name.trim()
     : "";
-  return BANK_BY_NAME.get(bankName);
+  if (!bankName) return undefined;
+
+  const bank = BANK_BY_NAME.get(bankName);
+  if (bank) return { code: bank.code, name: bank.name };
+
+  return { code: null, name: bankName };
 }
 
 export const handler = async (

--- a/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
+++ b/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
@@ -254,6 +254,53 @@ Deno.test({
   },
 });
 
+// ─── UPSERT: legacy bank_name-only clients ───
+Deno.test({
+  name: "upsert_bank_account: accepts legacy bank_name-only requests",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    let upsertBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/partner_settlements") &&
+          req.method === "POST",
+        handler: async (req) => {
+          upsertBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "upsert_bank_account",
+            partner_id: TEST_PARTNER_ID,
+            bank_name: "국민은행",
+            account_holder: "홍길동",
+            account_number: "3333-01-1234567",
+          }),
+        );
+        assertEquals(res.status, 200);
+        const parsed = JSON.parse(upsertBody!);
+        assertEquals(parsed.partner_id, TEST_PARTNER_ID);
+        assertEquals(parsed.bank_code, null);
+        assertEquals(parsed.bank_name, "국민은행");
+        assertEquals(parsed.account_holder, "홍길동");
+        assertEquals(parsed.account_number, "3333011234567");
+        assertEquals(parsed.bank_verification_status, "manual_review_pending");
+      });
+    });
+  },
+});
+
 // ─── UPSERT: extra fields ignored ───
 Deno.test({
   name: "upsert_bank_account: ignores non-whitelisted fields",

--- a/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
+++ b/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
@@ -3,11 +3,11 @@ import {
   authenticatedJsonRequest,
   captureServeHandler,
   createFetchMock,
+  type FetchRoute,
   jsonResponse,
   readJson,
   withEnv,
   withMockedFetch,
-  type FetchRoute,
 } from "../_test_utils/mock_http.ts";
 
 const TEST_USER_ID = "user-partner-owner";
@@ -23,7 +23,8 @@ const ENV = {
 function authRoute(): FetchRoute {
   return {
     matcher: "/auth/v1/user",
-    handler: () => jsonResponse({ id: TEST_USER_ID, email: "partner@test.com" }),
+    handler: () =>
+      jsonResponse({ id: TEST_USER_ID, email: "partner@test.com" }),
   };
 }
 
@@ -40,7 +41,9 @@ function permRoute(hasPermission = true): FetchRoute {
     handler: () =>
       jsonResponse(
         hasPermission
-          ? { permissions: ["PARTNER_EDIT", "SETTLEMENT_EDIT", "SETTLEMENT_VIEW"] }
+          ? {
+            permissions: ["PARTNER_EDIT", "SETTLEMENT_EDIT", "SETTLEMENT_VIEW"],
+          }
           : null,
       ),
   };
@@ -70,11 +73,22 @@ function upsertErrorRoute(): FetchRoute {
   };
 }
 
+function manualReviewRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/partner_settlements") &&
+      req.method === "PATCH",
+    handler: () => new Response(null, { status: 200 }),
+  };
+}
+
 // ─── CORS preflight ───
 Deno.test({
   name: "handles OPTIONS preflight request",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([]);
 
     await withEnv(ENV, async () => {
@@ -92,7 +106,9 @@ Deno.test({
 Deno.test({
   name: "returns 401 without authorization",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authFailRoute()]);
 
     await withEnv(ENV, async () => {
@@ -113,7 +129,9 @@ Deno.test({
 Deno.test({
   name: "returns 400 for missing action",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -123,7 +141,7 @@ Deno.test({
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing or invalid \"action\" field");
+        assertEquals(body.error, 'Missing or invalid "action" field');
       });
     });
   },
@@ -133,7 +151,9 @@ Deno.test({
 Deno.test({
   name: "returns 400 for unknown action",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -153,7 +173,9 @@ Deno.test({
 Deno.test({
   name: "upsert_bank_account: upserts bank account successfully",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       permRoute(),
@@ -166,7 +188,7 @@ Deno.test({
           authenticatedJsonRequest("http://localhost", {
             action: "upsert_bank_account",
             partner_id: TEST_PARTNER_ID,
-            bank_name: "카카오뱅크",
+            bank_code: "kakao",
             account_holder: "홍길동",
             account_number: "3333-01-1234567",
           }),
@@ -183,7 +205,9 @@ Deno.test({
 Deno.test({
   name: "upsert_bank_account: sends correct payload to DB",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     let upsertBody: string | null = null;
 
     const { fetchMock } = createFetchMock([
@@ -191,7 +215,8 @@ Deno.test({
       permRoute(),
       {
         matcher: (req) =>
-          req.url.includes("/rest/v1/partner_settlements") && req.method === "POST",
+          req.url.includes("/rest/v1/partner_settlements") &&
+          req.method === "POST",
         handler: async (req) => {
           upsertBody = await req.clone().text();
           return new Response(null, { status: 200 });
@@ -205,7 +230,7 @@ Deno.test({
           authenticatedJsonRequest("http://localhost", {
             action: "upsert_bank_account",
             partner_id: TEST_PARTNER_ID,
-            bank_name: "카카오뱅크",
+            bank_code: "kakao",
             account_holder: "홍길동",
             account_number: "3333-01-1234567",
           }),
@@ -213,10 +238,17 @@ Deno.test({
         assertEquals(res.status, 200);
         const parsed = JSON.parse(upsertBody!);
         assertEquals(parsed.partner_id, TEST_PARTNER_ID);
+        assertEquals(parsed.bank_code, "kakao");
         assertEquals(parsed.bank_name, "카카오뱅크");
         assertEquals(parsed.account_holder, "홍길동");
         // account_number is normalized: hyphens stripped
         assertEquals(parsed.account_number, "3333011234567");
+        assertEquals(parsed.bank_verification_status, "manual_review_pending");
+        assertEquals(
+          parsed.bank_verification_reason,
+          "partner_submitted_bank_account",
+        );
+        assertEquals(parsed.bank_verified_at, null);
       });
     });
   },
@@ -226,7 +258,9 @@ Deno.test({
 Deno.test({
   name: "upsert_bank_account: ignores non-whitelisted fields",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     let upsertBody: string | null = null;
 
     const { fetchMock } = createFetchMock([
@@ -234,7 +268,8 @@ Deno.test({
       permRoute(),
       {
         matcher: (req) =>
-          req.url.includes("/rest/v1/partner_settlements") && req.method === "POST",
+          req.url.includes("/rest/v1/partner_settlements") &&
+          req.method === "POST",
         handler: async (req) => {
           upsertBody = await req.clone().text();
           return new Response(null, { status: 200 });
@@ -248,7 +283,7 @@ Deno.test({
           authenticatedJsonRequest("http://localhost", {
             action: "upsert_bank_account",
             partner_id: TEST_PARTNER_ID,
-            bank_name: "카카오뱅크",
+            bank_code: "kakao",
             account_holder: "홍길동",
             account_number: "3333-01-1234567",
             biz_name: "해킹시도",
@@ -260,8 +295,8 @@ Deno.test({
         // Non-whitelisted fields should NOT be in the payload
         assertEquals(parsed.biz_name, undefined);
         assertEquals(parsed.tax_email, undefined);
-        // Only partner_id + 3 bank fields
-        assertEquals(Object.keys(parsed).length, 4);
+        assertEquals(parsed.bank_code, "kakao");
+        assertEquals(parsed.bank_verification_status, "manual_review_pending");
       });
     });
   },
@@ -271,7 +306,9 @@ Deno.test({
 Deno.test({
   name: "upsert_bank_account: returns 400 for missing partner_id",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -294,9 +331,11 @@ Deno.test({
 
 // ─── UPSERT: missing bank_name → 400 ───
 Deno.test({
-  name: "upsert_bank_account: returns 400 for missing bank_name",
+  name: "upsert_bank_account: returns 400 for missing bank_code",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -311,7 +350,7 @@ Deno.test({
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing bank_name");
+        assertEquals(body.error, "Missing or unsupported bank_code");
       });
     });
   },
@@ -321,7 +360,9 @@ Deno.test({
 Deno.test({
   name: "upsert_bank_account: returns 400 for missing account_holder",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -346,7 +387,9 @@ Deno.test({
 Deno.test({
   name: "upsert_bank_account: returns 400 for missing account_number",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -369,9 +412,12 @@ Deno.test({
 
 // ─── UPSERT: 403 no permission ───
 Deno.test({
-  name: "upsert_bank_account: returns 403 when user lacks SETTLEMENT_EDIT permission",
+  name:
+    "upsert_bank_account: returns 403 when user lacks SETTLEMENT_EDIT permission",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       permRoute(false),
@@ -383,7 +429,7 @@ Deno.test({
           authenticatedJsonRequest("http://localhost", {
             action: "upsert_bank_account",
             partner_id: TEST_PARTNER_ID,
-            bank_name: "카카오뱅크",
+            bank_code: "kakao",
             account_holder: "홍길동",
             account_number: "3333-01-1234567",
           }),
@@ -398,7 +444,9 @@ Deno.test({
 Deno.test({
   name: "upsert_bank_account: returns 500 when permission query fails",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       permErrorRoute(),
@@ -410,7 +458,7 @@ Deno.test({
           authenticatedJsonRequest("http://localhost", {
             action: "upsert_bank_account",
             partner_id: TEST_PARTNER_ID,
-            bank_name: "카카오뱅크",
+            bank_code: "kakao",
             account_holder: "홍길동",
             account_number: "3333-01-1234567",
           }),
@@ -423,11 +471,13 @@ Deno.test({
   },
 });
 
-// ─── UPSERT: whitespace-only bank_name → 400 ───
+// ─── UPSERT: whitespace-only bank_code → 400 ───
 Deno.test({
-  name: "upsert_bank_account: returns 400 for whitespace-only bank_name",
+  name: "upsert_bank_account: returns 400 for whitespace-only bank_code",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -436,14 +486,14 @@ Deno.test({
           authenticatedJsonRequest("http://localhost", {
             action: "upsert_bank_account",
             partner_id: TEST_PARTNER_ID,
-            bank_name: "   ",
+            bank_code: "   ",
             account_holder: "홍길동",
             account_number: "3333011234567",
           }),
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing bank_name");
+        assertEquals(body.error, "Missing or unsupported bank_code");
       });
     });
   },
@@ -453,7 +503,9 @@ Deno.test({
 Deno.test({
   name: "upsert_bank_account: returns 400 for invalid account_number format",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -462,7 +514,7 @@ Deno.test({
           authenticatedJsonRequest("http://localhost", {
             action: "upsert_bank_account",
             partner_id: TEST_PARTNER_ID,
-            bank_name: "카카오뱅크",
+            bank_code: "kakao",
             account_holder: "홍길동",
             account_number: "abc",
           }),
@@ -479,7 +531,9 @@ Deno.test({
 Deno.test({
   name: "upsert_bank_account: normalizes account_number by stripping hyphens",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     let upsertBody: string | null = null;
 
     const { fetchMock } = createFetchMock([
@@ -487,7 +541,8 @@ Deno.test({
       permRoute(),
       {
         matcher: (req) =>
-          req.url.includes("/rest/v1/partner_settlements") && req.method === "POST",
+          req.url.includes("/rest/v1/partner_settlements") &&
+          req.method === "POST",
         handler: async (req) => {
           upsertBody = await req.clone().text();
           return new Response(null, { status: 200 });
@@ -501,7 +556,7 @@ Deno.test({
           authenticatedJsonRequest("http://localhost", {
             action: "upsert_bank_account",
             partner_id: TEST_PARTNER_ID,
-            bank_name: "카카오뱅크",
+            bank_code: "kakao",
             account_holder: "홍길동",
             account_number: "3333-01-1234567",
           }),
@@ -518,7 +573,9 @@ Deno.test({
 Deno.test({
   name: "upsert_bank_account: returns 500 when upsert fails",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       permRoute(),
@@ -531,12 +588,89 @@ Deno.test({
           authenticatedJsonRequest("http://localhost", {
             action: "upsert_bank_account",
             partner_id: TEST_PARTNER_ID,
-            bank_name: "카카오뱅크",
+            bank_code: "kakao",
             account_holder: "홍길동",
             account_number: "3333-01-1234567",
           }),
         );
         assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+// ─── MANUAL REVIEW: success ───
+Deno.test({
+  name:
+    "request_manual_bank_account_review: moves account to manual_review_pending",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    let updateBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/partner_settlements") &&
+          req.method === "PATCH",
+        handler: async (req) => {
+          updateBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "request_manual_bank_account_review",
+            partner_id: TEST_PARTNER_ID,
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+        assertEquals(body.bank_verification_status, "manual_review_pending");
+
+        const parsed = JSON.parse(updateBody!);
+        assertEquals(parsed.bank_verification_status, "manual_review_pending");
+        assertEquals(
+          parsed.bank_verification_reason,
+          "partner_requested_manual_review",
+        );
+        assertEquals(parsed.bank_verified_at, null);
+      });
+    });
+  },
+});
+
+// ─── MANUAL REVIEW: 403 no permission ───
+Deno.test({
+  name:
+    "request_manual_bank_account_review: returns 403 without SETTLEMENT_EDIT",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(false),
+      manualReviewRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "request_manual_bank_account_review",
+            partner_id: TEST_PARTNER_ID,
+          }),
+        );
+        assertEquals(res.status, 403);
       });
     });
   },

--- a/supabase/migrations/20260604163000_partner_bank_account_verification_status.sql
+++ b/supabase/migrations/20260604163000_partner_bank_account_verification_status.sql
@@ -1,0 +1,41 @@
+-- Issue #3047: Partner bank account onboarding verification state.
+-- Existing account rows were previously treated as complete after a plain upsert.
+-- Backfill them as manual_review_approved to avoid re-opening onboarding todos.
+
+ALTER TABLE public.partner_settlements
+  ADD COLUMN IF NOT EXISTS bank_code text,
+  ADD COLUMN IF NOT EXISTS bank_verification_status text NOT NULL DEFAULT 'not_started',
+  ADD COLUMN IF NOT EXISTS bank_verification_reason text,
+  ADD COLUMN IF NOT EXISTS bank_verification_requested_at timestamptz,
+  ADD COLUMN IF NOT EXISTS bank_verified_at timestamptz;
+
+ALTER TABLE public.partner_settlements
+  DROP CONSTRAINT IF EXISTS partner_settlements_bank_verification_status_check;
+
+ALTER TABLE public.partner_settlements
+  ADD CONSTRAINT partner_settlements_bank_verification_status_check
+  CHECK (
+    bank_verification_status IN (
+      'not_started',
+      'verification_failed',
+      'manual_review_pending',
+      'manual_review_approved',
+      'verified'
+    )
+  );
+
+UPDATE public.partner_settlements
+SET
+  bank_verification_status = 'manual_review_approved',
+  bank_verification_reason = COALESCE(
+    bank_verification_reason,
+    'legacy_account_backfill'
+  ),
+  bank_verified_at = COALESCE(bank_verified_at, updated_at, now())
+WHERE bank_name IS NOT NULL
+  AND account_number IS NOT NULL
+  AND account_holder IS NOT NULL
+  AND bank_verification_status = 'not_started';
+
+CREATE INDEX IF NOT EXISTS partner_settlements_bank_verification_status_idx
+  ON public.partner_settlements(bank_verification_status);

--- a/supabase/migrations/20260605012500_gate_payouts_by_bank_verification.sql
+++ b/supabase/migrations/20260605012500_gate_payouts_by_bank_verification.sql
@@ -1,0 +1,131 @@
+-- Issue #3047: Do not assemble payouts until the partner bank account is verified
+-- or approved by manual review.
+
+create or replace function public.assemble_payouts()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_partner       record;
+  v_payout_id     uuid;
+  v_bank_snapshot jsonb;
+  v_idem_key      text;
+  v_seq           int;
+  v_today         text;
+begin
+  v_today := to_char(now() at time zone 'Asia/Seoul', 'YYYYMMDD');
+
+  -- Process each partner that has READY items without a payout_id.
+  -- Bank verification is checked below so unapproved partners remain READY.
+  for v_partner in
+    select
+      si.partner_id,
+      si.currency,
+      count(*)                          as item_count,
+      sum(si.gross_amount)              as total_gross,
+      sum(si.platform_fee_amount)       as total_platform_fee,
+      sum(si.pg_fee_amount)             as total_pg_fee,
+      sum(si.vat_amount)                as total_vat,
+      sum(si.net_amount)                as total_net,
+      min(si.settlement_period_start)   as period_start,
+      max(si.settlement_period_end)     as period_end
+    from public.settlement_items si
+    where si.status = 'READY'
+      and si.payout_id is null
+    group by si.partner_id, si.currency
+  loop
+    -- Get bank account snapshot only from a verified or manually approved account.
+    select jsonb_build_object(
+      'bank_name',      ps.bank_name,
+      'account_holder', ps.account_holder,
+      'account_number', ps.account_number,
+      'account_last4',  right(ps.account_number, 4)
+    )
+    into v_bank_snapshot
+    from public.partner_settlements ps
+    where ps.partner_id = v_partner.partner_id
+      and ps.bank_verification_status in ('verified', 'manual_review_approved')
+    order by ps.updated_at desc nulls last
+    limit 1;
+
+    if v_bank_snapshot is null then
+      continue;
+    end if;
+
+    -- Generate idempotency key with sequential suffix (REQ-5.3.27)
+    select coalesce(
+      max(
+        (regexp_match(payout_request_idempotency_key, '-(\d+)$'))[1]::int
+      ), 0
+    ) + 1
+    into v_seq
+    from public.payouts
+    where partner_id = v_partner.partner_id
+      and payout_request_idempotency_key like
+          'prod:payout:' || v_partner.partner_id || ':' || v_partner.currency || ':' || v_today || '-%';
+
+    v_idem_key := 'prod:payout:' || v_partner.partner_id
+                  || ':' || v_partner.currency
+                  || ':' || v_today
+                  || '-' || lpad(v_seq::text, 3, '0');
+
+    -- Insert payout record
+    insert into public.payouts (
+      partner_id,
+      payout_period_start,
+      payout_period_end,
+      currency,
+      status,
+      scheduled_at,
+      item_count,
+      total_gross_amount,
+      total_platform_fee_amount,
+      total_pg_fee_amount,
+      total_vat_amount,
+      total_net_amount,
+      bank_account_snapshot,
+      payout_request_idempotency_key
+    ) values (
+      v_partner.partner_id,
+      v_partner.period_start,
+      v_partner.period_end,
+      v_partner.currency,
+      'CREATED',
+      calculate_scheduled_at((now() at time zone 'Asia/Seoul')::date),
+      v_partner.item_count,
+      v_partner.total_gross,
+      v_partner.total_platform_fee,
+      v_partner.total_pg_fee,
+      v_partner.total_vat,
+      v_partner.total_net,
+      v_bank_snapshot,
+      v_idem_key
+    )
+    on conflict (partner_id, payout_request_idempotency_key)
+      where payout_request_idempotency_key is not null
+      do nothing
+    returning id into v_payout_id;
+
+    if v_payout_id is null then
+      select id into v_payout_id
+      from public.payouts
+      where partner_id = v_partner.partner_id
+        and payout_request_idempotency_key = v_idem_key;
+    end if;
+
+    -- Link settlement_items to this payout
+    update public.settlement_items
+    set payout_id = v_payout_id
+    where status = 'READY'
+      and payout_id is null
+      and partner_id = v_partner.partner_id
+      and currency = v_partner.currency;
+
+  end loop;
+end;
+$$;
+
+revoke execute on function public.assemble_payouts() from public;
+grant execute on function public.assemble_payouts() to service_role;

--- a/supabase/tests/database/36_settlement_payout_assembly_test.sql
+++ b/supabase/tests/database/36_settlement_payout_assembly_test.sql
@@ -18,10 +18,10 @@ BEGIN
   -- Insert partner_settlements (bank account info)
   INSERT INTO public.partner_settlements (
     partner_id, biz_type, biz_name, biz_number, representative_name,
-    bank_name, account_number, account_holder
+    bank_name, account_number, account_holder, bank_verification_status
   ) VALUES (
     v_partner_id, 'individual', 'Test Biz', '123-45-67890', 'Test Rep',
-    'Kakao Bank', '3333-01-1234567', 'Test Rep'
+    'Kakao Bank', '3333-01-1234567', 'Test Rep', 'manual_review_approved'
   );
 
   v_cs := repeat('a', 64);
@@ -113,10 +113,10 @@ BEGIN
 
   INSERT INTO public.partner_settlements (
     partner_id, biz_type, biz_name, biz_number, representative_name,
-    bank_name, account_number, account_holder
+    bank_name, account_number, account_holder, bank_verification_status
   ) VALUES (
     v_partner2_id, 'individual', 'Test Biz 2', '987-65-43210', 'Test Rep 2',
-    'Shinhan Bank', '110-123-456789', 'Test Rep 2'
+    'Shinhan Bank', '110-123-456789', 'Test Rep 2', 'verified'
   );
 
   v_cs := repeat('b', 64);
@@ -192,6 +192,93 @@ SELECT results_eq(
   WHERE partner_id = (SELECT val FROM payout_test_state WHERE key='partner_id_1')::uuid$$,
   $$VALUES (true)$$,
   'payout_request_idempotency_key matches format prod:payout:{partner_id}:{currency}:{yyyyMMdd}-001'
+);
+
+-- ============================================================
+-- 8. 미승인 계좌는 payout 생성/연결에서 제외
+-- ============================================================
+DO $$
+DECLARE
+  v_pending_partner_id uuid;
+  v_failed_partner_id  uuid;
+  v_cs                 char(64);
+BEGIN
+  INSERT INTO public.partners (name)
+  VALUES ('Payout Assembly Pending Bank Partner')
+  RETURNING id INTO v_pending_partner_id;
+
+  INSERT INTO public.partners (name)
+  VALUES ('Payout Assembly Failed Bank Partner')
+  RETURNING id INTO v_failed_partner_id;
+
+  INSERT INTO public.partner_settlements (
+    partner_id, biz_type, biz_name, biz_number, representative_name,
+    bank_name, account_number, account_holder, bank_verification_status
+  ) VALUES
+    (
+      v_pending_partner_id, 'individual', 'Pending Biz', '111-22-33333',
+      'Pending Rep', 'Kakao Bank', '3333-01-7654321', 'Pending Rep',
+      'manual_review_pending'
+    ),
+    (
+      v_failed_partner_id, 'individual', 'Failed Biz', '222-33-44444',
+      'Failed Rep', 'Shinhan Bank', '110-987-654321', 'Failed Rep',
+      'verification_failed'
+    );
+
+  v_cs := repeat('c', 64);
+
+  INSERT INTO public.settlement_items (
+    partner_id, settlement_period_start, settlement_period_end,
+    currency, source_type, source_id, status,
+    gross_amount, platform_fee_rate, platform_fee_amount,
+    pg_fee_rate, pg_fee_amount, vat_rate, vat_amount, net_amount, calc_checksum
+  ) VALUES
+    (
+      v_pending_partner_id, '2026-02-01', '2026-02-28', 'KRW', 'TEST',
+      'payout-test-pending-bank-001', 'READY',
+      70000, 5.00, 3500, 3.50, 2450, 10.00, 605, 63445, v_cs
+    ),
+    (
+      v_failed_partner_id, '2026-02-01', '2026-02-28', 'KRW', 'TEST',
+      'payout-test-failed-bank-001', 'READY',
+      90000, 5.00, 4500, 3.50, 3150, 10.00, 765, 81585, v_cs
+    );
+
+  INSERT INTO payout_test_state (key, val)
+  VALUES
+    ('pending_bank_partner_id', v_pending_partner_id::text),
+    ('failed_bank_partner_id', v_failed_partner_id::text);
+END;
+$$;
+
+SELECT lives_ok(
+  $$SELECT assemble_payouts()$$,
+  'assemble_payouts() skips unapproved bank accounts without error'
+);
+
+SELECT results_eq(
+  $$SELECT count(*)::int
+    FROM payouts
+    WHERE partner_id IN (
+      (SELECT val FROM payout_test_state WHERE key='pending_bank_partner_id')::uuid,
+      (SELECT val FROM payout_test_state WHERE key='failed_bank_partner_id')::uuid
+    )$$,
+  $$VALUES (0)$$,
+  'pending/failed bank verification statuses do not create payouts'
+);
+
+SELECT results_eq(
+  $$SELECT count(*)::int
+    FROM settlement_items
+    WHERE partner_id IN (
+      (SELECT val FROM payout_test_state WHERE key='pending_bank_partner_id')::uuid,
+      (SELECT val FROM payout_test_state WHERE key='failed_bank_partner_id')::uuid
+    )
+      AND status = 'READY'
+      AND payout_id IS NULL$$,
+  $$VALUES (2)$$,
+  'pending/failed bank verification statuses leave READY settlement_items unlinked'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/database/74_partner_settlements_insert_rls_test.sql
+++ b/supabase/tests/database/74_partner_settlements_insert_rls_test.sql
@@ -1,7 +1,14 @@
 -- Fix #2322: partner_settlements INSERT RLS 회귀 방지 테스트
 -- upsertBankAccount() 경로 — SETTLEMENT_EDIT 권한 보유자만 INSERT 가능
 BEGIN;
-SELECT plan(5);
+SELECT plan(10);
+
+-- Issue #3047: bank account verification status contract
+SELECT has_column('partner_settlements', 'bank_code');
+SELECT has_column('partner_settlements', 'bank_verification_status');
+SELECT has_column('partner_settlements', 'bank_verification_reason');
+SELECT has_column('partner_settlements', 'bank_verification_requested_at');
+SELECT has_column('partner_settlements', 'bank_verified_at');
 
 SELECT tests.create_supabase_user('owner_user', 'settlement_insert_owner@test.com');
 SELECT tests.create_supabase_user('outsider_user', 'settlement_insert_outsider@test.com');
@@ -44,12 +51,14 @@ SELECT throws_ok(
 SELECT tests.authenticate_as_service_role();
 SELECT lives_ok(
   format(
-    $$INSERT INTO public.partner_settlements (partner_id, bank_name, account_number, account_holder)
-      VALUES (%L, 'Kakaobank', '111-222-333', 'Test Owner')
+    $$INSERT INTO public.partner_settlements (partner_id, bank_code, bank_name, account_number, account_holder, bank_verification_status)
+      VALUES (%L, 'kakao', 'Kakaobank', '111-222-333', 'Test Owner', 'manual_review_pending')
       ON CONFLICT (partner_id) DO UPDATE
-        SET bank_name      = EXCLUDED.bank_name,
-            account_number = EXCLUDED.account_number,
-            account_holder = EXCLUDED.account_holder$$,
+        SET bank_code                = EXCLUDED.bank_code,
+            bank_name                = EXCLUDED.bank_name,
+            account_number           = EXCLUDED.account_number,
+            account_holder           = EXCLUDED.account_holder,
+            bank_verification_status = EXCLUDED.bank_verification_status$$,
     current_setting('tests.partner_id')
   ),
   'service_role can upsert (INSERT path) bank account into partner_settlements'
@@ -58,12 +67,14 @@ SELECT lives_ok(
 -- Test 3: service_role/EF path — upsert UPDATE 경로도 성공
 SELECT lives_ok(
   format(
-    $$INSERT INTO public.partner_settlements (partner_id, bank_name, account_number, account_holder)
-      VALUES (%L, 'Kookmin', '444-555-666', 'Test Owner Updated')
+    $$INSERT INTO public.partner_settlements (partner_id, bank_code, bank_name, account_number, account_holder, bank_verification_status)
+      VALUES (%L, 'kb', 'Kookmin', '444-555-666', 'Test Owner Updated', 'manual_review_approved')
       ON CONFLICT (partner_id) DO UPDATE
-        SET bank_name      = EXCLUDED.bank_name,
-            account_number = EXCLUDED.account_number,
-            account_holder = EXCLUDED.account_holder$$,
+        SET bank_code                = EXCLUDED.bank_code,
+            bank_name                = EXCLUDED.bank_name,
+            account_number           = EXCLUDED.account_number,
+            account_holder           = EXCLUDED.account_holder,
+            bank_verification_status = EXCLUDED.bank_verification_status$$,
     current_setting('tests.partner_id')
   ),
   'service_role can upsert (UPDATE path) bank account into partner_settlements'


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## Summary
- Adds a partner bank-account verification status contract on `partner_settlements` (`not_started`, `manual_review_pending`, `manual_review_approved`, `verified`, `verification_failed`) with legacy account backfill.
- Updates `partner-manage-settlement` and `SettlementRepository` so bank account upserts validate a bank catalog/code, normalize account numbers, and move saved accounts into manual review pending.
- Updates Partner Home onboarding so the bank todo only clears for `verified` or `manual_review_approved`, and routes pending/failed bank states to `BankAccountPage`.
- Updates `BankAccountPage` with bank selection, status callouts, failed-state manual review fallback, and dashboard refresh after save/review request.

Closes #3047

## MDS Spec Citations
- `apps/mds/docs/public/specs/bank_account_page/index.html` — `Canonical onboarding contract`, `Interaction contract`, `State 1 — Default(empty)`, `State 2 — Bank select sheet`, `Verification failure / manual review states`, and `Implementation tracking` sections.
- `apps/mds/docs/public/specs/partner_home_page/index.html` — `Onboarding · 계좌 등록/확인 필요`, state transition notes for `bankAccountReady == false`, and `Tap destinations` sections.
- `apps/mds/docs/src/lib/components.ts` — `MinglitBottomSheet`, `MinglitListTile`, `MinglitButton`, and card/status display component guidance reviewed; no new design-system component or spec change introduced.

## Verification
- `flutter test test/src/features/settlement/bank_account_page_test.dart test/src/features/home/partner_dashboard_controller_test.dart test/src/features/home/partner_home_page_test.dart test/src/features/home/widgets/onboarding_step_guide_test.dart test/src/features/home/partner_home_coordinator_test.dart` (from `apps/app_partner`)
- `flutter analyze lib/src/features/settlement/bank_account_page.dart lib/src/features/settlement/bank_catalog.dart lib/src/features/home/partner_dashboard_controller.dart lib/src/features/home/partner_home_page.dart lib/src/features/home/partner_home_coordinator.dart lib/src/features/home/widgets/onboarding_step_guide.dart test/src/features/settlement/bank_account_page_test.dart test/src/features/home/partner_dashboard_controller_test.dart test/src/features/home/partner_home_page_test.dart test/src/features/home/widgets/onboarding_step_guide_test.dart test/src/features/home/partner_home_coordinator_test.dart` (from `apps/app_partner`)
- `flutter test test/src/data/repositories/settlement_repository_test.dart` (from `shared/packages/minglit_kit`)
- `flutter analyze lib/src/data/repositories/settlement_repository.dart test/src/data/repositories/settlement_repository_test.dart` (from `shared/packages/minglit_kit`)
- `deno check --config supabase/deno.json supabase/functions/partner-manage-settlement/index.ts supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts`
- `deno test --allow-all --config supabase/deno.json supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts`
- `supabase migration up --local --include-all --yes` before local pgTAP rerun
- `supabase test db supabase/tests/database/74_partner_settlements_insert_rls_test.sql`
- `git diff --check`

## Residual Risk
- This does not add an external bank verification provider or admin approval UI. It establishes the repo-side status contract and partner fallback flow; operations or a future verifier can transition rows to `verified`, `manual_review_approved`, or `verification_failed`.
