### PR TITLE
fix(db): guard residual hardening legacy trigger grant

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -16,6 +16,7 @@
 | [`check-android-deploy-workflow-contract.py`](./check-android-deploy-workflow-contract.py) | Android deploy release archive token 계약 + merge promotion 뒤 snapshot metadata 탐색 회귀 검증 | `pr-gate.static-checks` |
 | [`check-dev-soak-workflow-contract.py`](./check-dev-soak-workflow-contract.py) | dev event-flow cron install + `monitor-dev-cuj` + `dev-rc-cut-gate` + `shared-soak-gate` 판정 계약 검증 | `pr-gate.static-checks` |
 | [`check-dev-cut-workflow-contract.py`](./check-dev-cut-workflow-contract.py) | promotion cut workflow 의 full-history checkout, merge auto-merge mode, `shared-notify` repo 컨텍스트 계약 검증 | `pr-gate.static-checks` |
+| [`check-residual-db-hardening-guards.py`](./check-residual-db-hardening-guards.py) | dev drift 가 가능한 residual DB hardening migration 의 조건부 권한 보정 가드 검증 | `pr-gate.static-checks` |
 | [`check-ios-connectivity-plus-cap.sh`](./check-ios-connectivity-plus-cap.sh) | iOS deploy runner 가 지원할 때까지 `connectivity_plus <7.1.0` resolution 강제 | `pr-gate.guard-ios-connectivity-plus-cap` |
 | [`scan-build-artifact-secrets.py`](./scan-build-artifact-secrets.py) | APK/AAB/`.next` 등 빌드 산출물에서 Supabase service-role secret 패턴을 redacted summary 로 검사 | `pr-gate.scan-build-artifact-secrets` |
 | [`install-dev-event-flow-cron.sh`](./install-dev-event-flow-cron.sh) | dev Supabase `dev-event-flow-simulator` pg_cron 설치/검증 | `deploy-dev-event-flow-cron` |
@@ -36,4 +37,4 @@
 - [.github/BLUEDOC.md](../BLUEDOC.md) — 상위 진입점
 
 ---
-_Reviewed: 2026-06-04 07:16_
+_Reviewed: 2026-06-05 07:25_

--- a/.github/scripts/check-residual-db-hardening-guards.py
+++ b/.github/scripts/check-residual-db-hardening-guards.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Validate drift-tolerant guards in residual DB hardening migrations."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = ROOT / "supabase/migrations/20260604003000_residual_db_hardening_execute_grants.sql"
+LEGACY_TRIGGER_SIGNATURE = "public.handle_partner_application_approved()"
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> None:
+    text = MIGRATION.read_text(encoding="utf-8")
+
+    if f"to_regprocedure('{LEGACY_TRIGGER_SIGNATURE}')" not in text:
+        fail(f"{LEGACY_TRIGGER_SIGNATURE} hardening must be guarded with to_regprocedure")
+
+    guard_pattern = re.compile(
+        r"IF\s+to_regprocedure\('public\.handle_partner_application_approved\(\)'\)"
+        r"\s+IS\s+NOT\s+NULL\s+THEN(?P<body>.*?)END\s+IF;",
+        re.IGNORECASE | re.DOTALL,
+    )
+    match = guard_pattern.search(text)
+    if match is None:
+        fail(f"{LEGACY_TRIGGER_SIGNATURE} guard block is missing or malformed")
+
+    body = match.group("body")
+    required_fragments = [
+        "REVOKE EXECUTE ON FUNCTION public.handle_partner_application_approved()",
+        "GRANT EXECUTE ON FUNCTION public.handle_partner_application_approved()",
+    ]
+    for fragment in required_fragments:
+        if fragment not in body:
+            fail(f"{LEGACY_TRIGGER_SIGNATURE} guard block missing: {fragment}")
+
+    unguarded = re.compile(
+        r"(?<!EXECUTE ')(REVOKE|GRANT)\s+EXECUTE\s+ON\s+FUNCTION\s+"
+        r"public\.handle_partner_application_approved\(\)",
+        re.IGNORECASE,
+    )
+    if unguarded.search(text):
+        fail(f"{LEGACY_TRIGGER_SIGNATURE} must not be referenced by unguarded GRANT/REVOKE")
+
+    print("Residual DB hardening guard contract OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -123,6 +123,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: python3 .github/scripts/check-dev-cut-workflow-contract.py
 
+      - name: Check residual DB hardening guards
+        if: ${{ !cancelled() }}
+        run: python3 .github/scripts/check-residual-db-hardening-guards.py
+
       - name: Check iOS deploy workflow contract
         if: ${{ !cancelled() }}
         run: bash .github/scripts/check-ios-deploy-branch-conditions.sh

--- a/supabase/migrations/20260604003000_residual_db_hardening_execute_grants.sql
+++ b/supabase/migrations/20260604003000_residual_db_hardening_execute_grants.sql
@@ -206,10 +206,17 @@ REVOKE EXECUTE ON FUNCTION public.handle_new_user_settings()
 GRANT EXECUTE ON FUNCTION public.handle_new_user_settings()
   TO service_role;
 
-REVOKE EXECUTE ON FUNCTION public.handle_partner_application_approved()
-  FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.handle_partner_application_approved()
-  TO service_role;
+DO $$
+BEGIN
+  -- Some long-lived dev databases predate the partner application wizard trigger
+  -- function even though fresh databases create it from the historical migration.
+  -- Guard this legacy-only hardening step so the rest of the migration can apply.
+  IF to_regprocedure('public.handle_partner_application_approved()') IS NOT NULL THEN
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.handle_partner_application_approved() FROM PUBLIC, anon, authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.handle_partner_application_approved() TO service_role';
+  END IF;
+END;
+$$;
 
 REVOKE EXECUTE ON FUNCTION public.handle_storage_object_created()
   FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
Scheduler: swe-codex-gpt55-medium-1

## Summary
- Guard the residual DB hardening grant/revoke for `public.handle_partner_application_approved()` with `to_regprocedure` so long-lived dev databases that lack the legacy trigger function can continue applying the migration.
- Add a static PR gate check that fails if this dev-drift guard is removed or malformed.
- Register the new script in `.github/scripts/BLUEDOC.md` and `pr-gate` static checks.

## Why
Closes #3063

The dev deploy failed before recording migration `20260604003000_residual_db_hardening_execute_grants.sql` because the migration directly referenced a function that does not exist on the current dev database. A later migration cannot run until this failing migration passes, so this PR updates the failing migration with a narrow existence guard for that legacy-only trigger function.

## Verification
- `python3 .github/scripts/check-residual-db-hardening-guards.py`
- `python3 .github/scripts/check-dev-cut-workflow-contract.py && python3 .github/scripts/check-dev-soak-workflow-contract.py`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-gate.yml'))"`
- `python3 -m py_compile .github/scripts/check-residual-db-hardening-guards.py`
- `git diff --check`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`

## Residual Risk
- I did not run a live Supabase dev migration deploy locally; the fix is targeted from the completed deploy failure log and validated with static PR gate coverage.