### PR TITLE
fix(db): clear notification auth initplan advisor warning

### DIFF
--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -32,4 +32,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-06-05 01:53_
+_Reviewed: 2026-06-05 07:21_

--- a/supabase/migrations/20260605073500_fix_notification_insert_policy_initplan.sql
+++ b/supabase/migrations/20260605073500_fix_notification_insert_policy_initplan.sql
@@ -1,0 +1,13 @@
+-- Fix #2934: remove redundant auth.role() call from the service-role-only
+-- notification insert RLS policy. The policy target already limits execution
+-- to service_role, so the auth helper only triggers Performance Advisor
+-- auth_rls_initplan without adding an access boundary.
+
+DROP POLICY IF EXISTS "Service role can insert notifications"
+  ON public.user_notifications;
+
+CREATE POLICY "Service role can insert notifications"
+  ON public.user_notifications
+  FOR INSERT
+  TO service_role
+  WITH CHECK (true);

--- a/supabase/tests/database/104_rls_auth_initplan_advisor_test.sql
+++ b/supabase/tests/database/104_rls_auth_initplan_advisor_test.sql
@@ -1,5 +1,7 @@
--- Issue #2797: Supabase Performance Advisor auth_rls_initplan regression.
--- The affected policies should use scalar subqueries around auth helpers.
+-- Issue #2797 / #2934: Supabase Performance Advisor auth_rls_initplan
+-- regression. Policies that use auth helpers should wrap them in scalar
+-- subqueries, and service-role-only policies should avoid redundant auth
+-- helper predicates entirely.
 BEGIN;
 
 SELECT plan(2);
@@ -45,6 +47,7 @@ VALUES
   ('public', 'tag_usage_monthly', 'tag_usage_monthly_service'),
   ('public', 'user_consents', 'user_read_own_consents'),
   ('public', 'user_interest_tags', 'user_interest_tags_read_own'),
+  ('public', 'user_notifications', 'Service role can insert notifications'),
   ('public', 'user_notifications', 'Users can view their own notifications'),
   ('public', 'user_profiles', 'Users can read own profile'),
   ('public', 'user_settings', 'Users can view their own settings'),


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## What changed
- Added an append-only migration that recreates `public.user_notifications` policy `Service role can insert notifications` as `TO service_role WITH CHECK (true)`.
- Extended `104_rls_auth_initplan_advisor_test.sql` so this historically advisor-flagged policy is covered by the existing initplan regression gate.

## Why
Refs #2934.

The latest Performance Advisor artifact reports one WARN: `auth_rls_initplan` on `public.user_notifications` policy `Service role can insert notifications`. After #3021 the policy target is already `service_role`, so `auth.role() = 'service_role'` is redundant and only causes per-row auth helper evaluation.

This PR does not close #2934 because the aggregate tracker still has INFO findings: 9 `unindexed_foreign_keys` and 39 `unused_index`. Those need separate index/usage review rather than being mixed with this RLS policy fix.

## Verification
- `supabase db reset --no-seed`
- `supabase test db supabase/tests/database/104_rls_auth_initplan_advisor_test.sql`
- `git diff --check`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`

## Residual risk
- Hosted dev Advisor will not show the WARN reduction until #3063/#3068 unblocks Supabase migration deploy and a new `monitor-security-advisor` run is captured.
- INFO-level index findings remain classified in #2934 comments for separate follow-up.
