### PR TITLE
test(partner): wait for checkin CUJ page

### DIFF
--- a/apps/app_partner/integration_test/cuj/event/partner_dashboard_test.dart
+++ b/apps/app_partner/integration_test/cuj/event/partner_dashboard_test.dart
@@ -223,6 +223,11 @@ Future<void> _pumpUntilFound(
     if (finder.evaluate().isNotEmpty) return;
     await tester.pump(step);
   }
+  expect(
+    finder,
+    findsWidgets,
+    reason: 'Timed out waiting for $finder after $timeout',
+  );
 }
 
 /// 이벤트가 있는 홈 기본 상태.
@@ -799,6 +804,7 @@ void main() {
       ],
       afterPump: const Duration(seconds: 2),
       body: (t) async {
+        await _pumpUntilFound(t, find.byType(OngoingEventListPage));
         expect(find.byType(OngoingEventListPage), findsOneWidget);
         await _pumpUntilFound(t, find.byType(QRScannerScreen));
         expect(find.byType(QRScannerScreen), findsOneWidget);


### PR DESCRIPTION
Scheduler: swe-codex-gpt55-medium-1

## Summary
- Wait for `OngoingEventListPage` before asserting the single-event check-in CUJ path.
- Make `_pumpUntilFound` fail explicitly on timeout instead of silently continuing.

## Why
Closes #3067

The failing dev-soak run asserted `OngoingEventListPage` immediately after an async Riverpod provider override settled. The same CUJ already uses polling for the scanner; this applies that wait to the parent page as well so CI timing does not race the provider rebuild.

## Verification
- `dart format apps/app_partner/integration_test/cuj/event/partner_dashboard_test.dart`
- `flutter analyze apps/app_partner/integration_test/cuj/event/partner_dashboard_test.dart`
- `git diff --check`

## Not Run
- `flutter test integration_test/cuj/event/partner_dashboard_test.dart --plain-name "happy: 운영 이벤트 1건"` locally: initial run required explicit device selection; Linux retry failed because local Linux desktop testing is missing CMake. CI Android emulator remains the authoritative integration sensor.

## Residual Risk
- Low: test-only timing hardening for the failing CUJ case; Android emulator CI should confirm the integration path.