### PR TITLE
fix(event-flow-simulator): restore create and apply actions

### DIFF
--- a/supabase/functions/_test_utils/mock_supabase_client.ts
+++ b/supabase/functions/_test_utils/mock_supabase_client.ts
@@ -5,25 +5,48 @@ export type MockResult<T> = {
   error: MockError;
 };
 
+export type MockRange = { from: number; to: number };
+
 export type MockTableHandlers = {
-  select?: (input: { filters: Record<string, unknown> }) => MockResult<unknown> | Promise<MockResult<unknown>>;
-  update?: (input: { values: unknown; filters: Record<string, unknown> }) => MockResult<unknown> | Promise<MockResult<unknown>>;
-  insert?: (input: { values: unknown }) => MockResult<unknown> | Promise<MockResult<unknown>>;
-  upsert?: (input: { values: unknown }) => MockResult<unknown> | Promise<MockResult<unknown>>;
-  delete?: (input: { filters: Record<string, unknown> }) => MockResult<unknown> | Promise<MockResult<unknown>>;
+  select?: (input: {
+    filters: Record<string, unknown>;
+    range?: MockRange;
+  }) => MockResult<unknown> | Promise<MockResult<unknown>>;
+  update?: (
+    input: { values: unknown; filters: Record<string, unknown> },
+  ) => MockResult<unknown> | Promise<MockResult<unknown>>;
+  insert?: (
+    input: { values: unknown },
+  ) => MockResult<unknown> | Promise<MockResult<unknown>>;
+  upsert?: (
+    input: { values: unknown },
+  ) => MockResult<unknown> | Promise<MockResult<unknown>>;
+  delete?: (
+    input: { filters: Record<string, unknown> },
+  ) => MockResult<unknown> | Promise<MockResult<unknown>>;
 };
 
 export type MockSupabaseHandlers = {
   tables?: Record<string, MockTableHandlers>;
-  rpcs?: Record<string, (args: Record<string, unknown>) => MockResult<unknown> | Promise<MockResult<unknown>>>;
+  rpcs?: Record<
+    string,
+    (
+      args: Record<string, unknown>,
+    ) => MockResult<unknown> | Promise<MockResult<unknown>>
+  >;
   authUser?: { id: string } | null;
-  authAdminGetUserById?: (userId: string) => MockResult<{ user: { email: string } | null }> | Promise<MockResult<{ user: { email: string } | null }>>;
+  authAdminGetUserById?: (
+    userId: string,
+  ) =>
+    | MockResult<{ user: { email: string } | null }>
+    | Promise<MockResult<{ user: { email: string } | null }>>;
 };
 
 class MockQueryBuilder {
   private filters: Record<string, unknown> = {};
   private operation: "select" | "update" | "delete" | null = null;
   private values: unknown = null;
+  private rangeBounds?: MockRange;
 
   constructor(
     private table: string,
@@ -43,12 +66,16 @@ class MockQueryBuilder {
 
   insert(values: unknown) {
     const handler = this.handlers.tables?.[this.table]?.insert;
-    return Promise.resolve(handler ? handler({ values }) : { data: null, error: null });
+    return Promise.resolve(
+      handler ? handler({ values }) : { data: null, error: null },
+    );
   }
 
   upsert(values: unknown) {
     const handler = this.handlers.tables?.[this.table]?.upsert;
-    return Promise.resolve(handler ? handler({ values }) : { data: null, error: null });
+    return Promise.resolve(
+      handler ? handler({ values }) : { data: null, error: null },
+    );
   }
 
   delete() {
@@ -67,6 +94,11 @@ class MockQueryBuilder {
   }
 
   limit(_count: number) {
+    return this;
+  }
+
+  range(from: number, to: number) {
+    this.rangeBounds = { from, to };
     return this;
   }
 
@@ -96,7 +128,9 @@ class MockQueryBuilder {
   }
 
   then<TResult1 = MockResult<unknown>, TResult2 = never>(
-    onfulfilled?: ((value: MockResult<unknown>) => TResult1 | PromiseLike<TResult1>) | null,
+    onfulfilled?:
+      | ((value: MockResult<unknown>) => TResult1 | PromiseLike<TResult1>)
+      | null,
     onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
   ): Promise<TResult1 | TResult2> {
     return this.execute().then(onfulfilled, onrejected);
@@ -105,18 +139,26 @@ class MockQueryBuilder {
   private async execute(): Promise<MockResult<unknown>> {
     if (this.operation === "select") {
       const handler = this.handlers.tables?.[this.table]?.select;
-      return await Promise.resolve(handler ? handler({ filters: this.filters }) : { data: null, error: null });
+      return await Promise.resolve(
+        handler
+          ? handler({ filters: this.filters, range: this.rangeBounds })
+          : { data: null, error: null },
+      );
     }
     if (this.operation === "update") {
       const handler = this.handlers.tables?.[this.table]?.update;
       return await Promise.resolve(
-        handler ? handler({ values: this.values, filters: this.filters }) : { data: null, error: null },
+        handler
+          ? handler({ values: this.values, filters: this.filters })
+          : { data: null, error: null },
       );
     }
     if (this.operation === "delete") {
       const handler = this.handlers.tables?.[this.table]?.delete;
       return await Promise.resolve(
-        handler ? handler({ filters: this.filters }) : { data: null, error: null },
+        handler
+          ? handler({ filters: this.filters })
+          : { data: null, error: null },
       );
     }
     return { data: null, error: null };
@@ -128,18 +170,21 @@ export function createMockSupabaseClient(handlers: MockSupabaseHandlers = {}) {
     from: (table: string) => new MockQueryBuilder(table, handlers),
     rpc: (name: string, args: Record<string, unknown>) => {
       const handler = handlers.rpcs?.[name];
-      return Promise.resolve(handler ? handler(args) : { data: null, error: null });
+      return Promise.resolve(
+        handler ? handler(args) : { data: null, error: null },
+      );
     },
     auth: {
       getUser: (_token?: string) =>
-        Promise.resolve({ data: { user: handlers.authUser ?? null }, error: null }),
+        Promise.resolve({
+          data: { user: handlers.authUser ?? null },
+          error: null,
+        }),
       admin: {
         getUserById: (userId: string) => {
           const handler = handlers.authAdminGetUserById;
           return Promise.resolve(
-            handler
-              ? handler(userId)
-              : { data: { user: null }, error: null },
+            handler ? handler(userId) : { data: { user: null }, error: null },
           );
         },
       },

--- a/supabase/functions/_test_utils/mock_supabase_client.ts
+++ b/supabase/functions/_test_utils/mock_supabase_client.ts
@@ -8,38 +8,18 @@ export type MockResult<T> = {
 export type MockRange = { from: number; to: number };
 
 export type MockTableHandlers = {
-  select?: (input: {
-    filters: Record<string, unknown>;
-    range?: MockRange;
-  }) => MockResult<unknown> | Promise<MockResult<unknown>>;
-  update?: (
-    input: { values: unknown; filters: Record<string, unknown> },
-  ) => MockResult<unknown> | Promise<MockResult<unknown>>;
-  insert?: (
-    input: { values: unknown },
-  ) => MockResult<unknown> | Promise<MockResult<unknown>>;
-  upsert?: (
-    input: { values: unknown },
-  ) => MockResult<unknown> | Promise<MockResult<unknown>>;
-  delete?: (
-    input: { filters: Record<string, unknown> },
-  ) => MockResult<unknown> | Promise<MockResult<unknown>>;
+  select?: (input: { filters: Record<string, unknown>; range?: MockRange }) => MockResult<unknown> | Promise<MockResult<unknown>>;
+  update?: (input: { values: unknown; filters: Record<string, unknown> }) => MockResult<unknown> | Promise<MockResult<unknown>>;
+  insert?: (input: { values: unknown }) => MockResult<unknown> | Promise<MockResult<unknown>>;
+  upsert?: (input: { values: unknown }) => MockResult<unknown> | Promise<MockResult<unknown>>;
+  delete?: (input: { filters: Record<string, unknown> }) => MockResult<unknown> | Promise<MockResult<unknown>>;
 };
 
 export type MockSupabaseHandlers = {
   tables?: Record<string, MockTableHandlers>;
-  rpcs?: Record<
-    string,
-    (
-      args: Record<string, unknown>,
-    ) => MockResult<unknown> | Promise<MockResult<unknown>>
-  >;
+  rpcs?: Record<string, (args: Record<string, unknown>) => MockResult<unknown> | Promise<MockResult<unknown>>>;
   authUser?: { id: string } | null;
-  authAdminGetUserById?: (
-    userId: string,
-  ) =>
-    | MockResult<{ user: { email: string } | null }>
-    | Promise<MockResult<{ user: { email: string } | null }>>;
+  authAdminGetUserById?: (userId: string) => MockResult<{ user: { email: string } | null }> | Promise<MockResult<{ user: { email: string } | null }>>;
 };
 
 class MockQueryBuilder {
@@ -66,16 +46,12 @@ class MockQueryBuilder {
 
   insert(values: unknown) {
     const handler = this.handlers.tables?.[this.table]?.insert;
-    return Promise.resolve(
-      handler ? handler({ values }) : { data: null, error: null },
-    );
+    return Promise.resolve(handler ? handler({ values }) : { data: null, error: null });
   }
 
   upsert(values: unknown) {
     const handler = this.handlers.tables?.[this.table]?.upsert;
-    return Promise.resolve(
-      handler ? handler({ values }) : { data: null, error: null },
-    );
+    return Promise.resolve(handler ? handler({ values }) : { data: null, error: null });
   }
 
   delete() {
@@ -128,9 +104,7 @@ class MockQueryBuilder {
   }
 
   then<TResult1 = MockResult<unknown>, TResult2 = never>(
-    onfulfilled?:
-      | ((value: MockResult<unknown>) => TResult1 | PromiseLike<TResult1>)
-      | null,
+    onfulfilled?: ((value: MockResult<unknown>) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
   ): Promise<TResult1 | TResult2> {
     return this.execute().then(onfulfilled, onrejected);
@@ -148,17 +122,13 @@ class MockQueryBuilder {
     if (this.operation === "update") {
       const handler = this.handlers.tables?.[this.table]?.update;
       return await Promise.resolve(
-        handler
-          ? handler({ values: this.values, filters: this.filters })
-          : { data: null, error: null },
+        handler ? handler({ values: this.values, filters: this.filters }) : { data: null, error: null },
       );
     }
     if (this.operation === "delete") {
       const handler = this.handlers.tables?.[this.table]?.delete;
       return await Promise.resolve(
-        handler
-          ? handler({ filters: this.filters })
-          : { data: null, error: null },
+        handler ? handler({ filters: this.filters }) : { data: null, error: null },
       );
     }
     return { data: null, error: null };
@@ -170,16 +140,11 @@ export function createMockSupabaseClient(handlers: MockSupabaseHandlers = {}) {
     from: (table: string) => new MockQueryBuilder(table, handlers),
     rpc: (name: string, args: Record<string, unknown>) => {
       const handler = handlers.rpcs?.[name];
-      return Promise.resolve(
-        handler ? handler(args) : { data: null, error: null },
-      );
+      return Promise.resolve(handler ? handler(args) : { data: null, error: null });
     },
     auth: {
       getUser: (_token?: string) =>
-        Promise.resolve({
-          data: { user: handlers.authUser ?? null },
-          error: null,
-        }),
+        Promise.resolve({ data: { user: handlers.authUser ?? null }, error: null }),
       admin: {
         getUserById: (userId: string) => {
           const handler = handlers.authAdminGetUserById;

--- a/supabase/functions/event-flow-simulator/BLUEDOC.md
+++ b/supabase/functions/event-flow-simulator/BLUEDOC.md
@@ -46,4 +46,4 @@ curl -X POST "https://<project>.supabase.co/functions/v1/event-flow-simulator" \
 - 단위 테스트: `cd supabase/functions && deno test event-flow-simulator/`
 
 ---
-_Reviewed: 2026-05-25 16:20_
+_Reviewed: 2026-06-05 10:15_

--- a/supabase/functions/event-flow-simulator/action/new_actions_test.ts
+++ b/supabase/functions/event-flow-simulator/action/new_actions_test.ts
@@ -3,7 +3,7 @@
 // apply.ts 의 apply_test.ts 가 자세한 패턴 모범. 본 파일은 7 액션의 식별자/기본
 // 분기만 검증해서 PR 회귀 가드 역할. 추후 액션별 *_test.ts 분리 가능 (#TBD issue).
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { refundAction } from "./refund.ts";
 import { checkinAction } from "./checkin.ts";
 import { discoverAction } from "./discover.ts";
@@ -230,6 +230,17 @@ Deno.test({
       myEvents: [{ status: "scheduled" }, { status: "scheduled" }],
     };
     assertEquals(partnerCreateEventAction.canExecute(state), false);
+  },
+});
+
+Deno.test({
+  name: "partnerCreateEventAction.buildPayload - throws without an existing party",
+  fn: () => {
+    assertThrows(
+      () => partnerCreateEventAction.buildPayload({ myParties: [] }, rng),
+      Error,
+      "without an existing party",
+    );
   },
 });
 

--- a/supabase/functions/event-flow-simulator/action/new_actions_test.ts
+++ b/supabase/functions/event-flow-simulator/action/new_actions_test.ts
@@ -59,7 +59,7 @@ Deno.test({
 
     assertEquals(partnerCreateEventAction.type, "partner_create_event");
     assertEquals(partnerCreateEventAction.role, "partner");
-    assertEquals(partnerCreateEventAction.ef, "partner-manage-party");
+    assertEquals(partnerCreateEventAction.ef, "partner-manage-event");
   },
 });
 
@@ -70,7 +70,10 @@ Deno.test({
 Deno.test({
   name: "refundAction.canExecute - false when no approved/paid application",
   fn: () => {
-    assertEquals(refundAction.canExecute({ myApplications: [], visibleEvents: [] }), false);
+    assertEquals(
+      refundAction.canExecute({ myApplications: [], visibleEvents: [] }),
+      false,
+    );
   },
 });
 
@@ -87,7 +90,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "refundAction.canExecute - true when application approved + event ≥7 days away",
+  name:
+    "refundAction.canExecute - true when application approved + event ≥7 days away",
   fn: () => {
     const future = new Date(Date.now() + 10 * 86400_000).toISOString();
     const state = {
@@ -99,7 +103,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "checkinAction.canExecute - true when ticket_issued participant in active event",
+  name:
+    "checkinAction.canExecute - true when ticket_issued participant in active event",
   fn: () => {
     const state = {
       myParticipations: [{ id: "p1", event_id: "e1", status: "ticket_issued" }],
@@ -121,7 +126,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "discoverAction.canExecute - always true (read-only, rate-driven sampling)",
+  name:
+    "discoverAction.canExecute - always true (read-only, rate-driven sampling)",
   fn: () => {
     assertEquals(discoverAction.canExecute({}), true);
   },
@@ -139,7 +145,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "blockAction.canExecute - true when applied event partner not yet blocked",
+  name:
+    "blockAction.canExecute - true when applied event partner not yet blocked",
   fn: () => {
     const state = {
       myApplications: [{ event_id: "e1", status: "approved" }],
@@ -151,7 +158,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "blockAction.canExecute - false when already blocked all applied partners",
+  name:
+    "blockAction.canExecute - false when already blocked all applied partners",
   fn: () => {
     const state = {
       myApplications: [{ event_id: "e1", status: "approved" }],
@@ -163,44 +171,59 @@ Deno.test({
 });
 
 Deno.test({
-  name: "partnerApproveAction.canExecute - true when pending applications exist",
+  name:
+    "partnerApproveAction.canExecute - true when pending applications exist",
   fn: () => {
-    assertEquals(partnerApproveAction.canExecute({ pendingApplications: [{ id: "a1" }] }), true);
-    assertEquals(partnerApproveAction.canExecute({ pendingApplications: [] }), false);
+    assertEquals(
+      partnerApproveAction.canExecute({ pendingApplications: [{ id: "a1" }] }),
+      true,
+    );
+    assertEquals(
+      partnerApproveAction.canExecute({ pendingApplications: [] }),
+      false,
+    );
   },
 });
 
 Deno.test({
   name: "partnerRejectAction.canExecute - true when pending applications exist",
   fn: () => {
-    assertEquals(partnerRejectAction.canExecute({ pendingApplications: [{ id: "a1" }] }), true);
-    assertEquals(partnerRejectAction.canExecute({ pendingApplications: [] }), false);
-  },
-});
-
-Deno.test({
-  name: "partnerCreateEventAction.canExecute - true when no parties yet",
-  fn: () => {
     assertEquals(
-      partnerCreateEventAction.canExecute({ myParties: [], myEvents: [] }),
+      partnerRejectAction.canExecute({ pendingApplications: [{ id: "a1" }] }),
       true,
+    );
+    assertEquals(
+      partnerRejectAction.canExecute({ pendingApplications: [] }),
+      false,
     );
   },
 });
 
 Deno.test({
-  name: "partnerCreateEventAction.canExecute - true when scheduled events below min(2)",
+  name: "partnerCreateEventAction.canExecute - false when no parties yet",
+  fn: () => {
+    assertEquals(
+      partnerCreateEventAction.canExecute({ myParties: [], myEvents: [] }),
+      false,
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "partnerCreateEventAction.canExecute - true when scheduled events below min(2)",
   fn: () => {
     const state = {
       myParties: [{ id: "p1" }],
-      myEvents: [{ status: "scheduled" }],  // 1 < 2
+      myEvents: [{ status: "scheduled" }], // 1 < 2
     };
     assertEquals(partnerCreateEventAction.canExecute(state), true);
   },
 });
 
 Deno.test({
-  name: "partnerCreateEventAction.canExecute - false when scheduled events ≥ min(2)",
+  name:
+    "partnerCreateEventAction.canExecute - false when scheduled events ≥ min(2)",
   fn: () => {
     const state = {
       myParties: [{ id: "p1" }],
@@ -215,7 +238,8 @@ Deno.test({
 // ============================================================
 
 Deno.test({
-  name: "buildPayload smoke — refund / checkin / vote / block / partner_approve / partner_reject / partner_create",
+  name:
+    "buildPayload smoke — refund / checkin / vote / block / partner_approve / partner_reject / partner_create",
   fn: () => {
     const future = new Date(Date.now() + 10 * 86400_000).toISOString();
 
@@ -254,8 +278,20 @@ Deno.test({
     }, rng);
     assertEquals(rejectPayload, { application_id: "a1" });
 
-    const createPayload = partnerCreateEventAction.buildPayload({}, rng);
+    const createPayload = partnerCreateEventAction.buildPayload({
+      myParties: [{ id: "party1", status: "active" }],
+      myEvents: [],
+    }, rng);
     assertEquals(createPayload.action, "create");
-    assertEquals(Array.isArray((createPayload.party as Record<string, unknown>).description), false);
+    assertEquals(createPayload.party_id, "party1");
+    assertEquals(
+      typeof (createPayload.event as Record<string, unknown>).start_time,
+      "string",
+    );
+    assertEquals(
+      typeof (createPayload.event as Record<string, unknown>).end_time,
+      "string",
+    );
+    assertEquals((createPayload.tickets as Array<unknown>).length, 1);
   },
 });

--- a/supabase/functions/event-flow-simulator/action/partner_create_event.ts
+++ b/supabase/functions/event-flow-simulator/action/partner_create_event.ts
@@ -1,58 +1,66 @@
-// action/partner_create_event.ts — PartnerActionCreateEvent (EF: partner-manage-party)
-//
-// Fix #1540: 시드 이미지 URL 사용 — 홈/이벤트 화면 이미지 깨짐 방지.
+// action/partner_create_event.ts — PartnerActionCreateEvent (EF: partner-manage-event)
 
 import type { ActionDef } from "./_registry.ts";
 import { registerAction } from "./_registry.ts";
 
-const SEED_IMAGE_FILENAMES = [
-  "party_cafe_warm.jpg",
-  "party_lounge_bright.jpg",
-  "party_premium_lounge.jpg",
-];
-
 const MIN_SCHEDULED_EVENTS = 2;
+const EVENT_DURATION_MS = 2 * 60 * 60 * 1000;
+const MIN_START_DELAY_DAYS = 7;
+const START_DELAY_WINDOW_DAYS = 21;
+
+type PartnerParty = {
+  id: string;
+  status?: string;
+};
 
 export const partnerCreateEventAction: ActionDef = {
   type: "partner_create_event",
   role: "partner",
-  ef: "partner-manage-party",
+  ef: "partner-manage-event",
 
   canExecute(state) {
     const myEvents = (state.myEvents as Array<{ status: string }>) ?? [];
-    const myParties = (state.myParties as Array<unknown>) ?? [];
-    // 파티 없거나 scheduled event 가 임계치 미만 → 신규 생성
-    if (myParties.length === 0) return true;
+    const myParties = ((state.myParties as PartnerParty[]) ?? []).filter(
+      (party) => typeof party.id === "string" && party.status !== "closed",
+    );
+    if (myParties.length === 0) return false;
     const scheduledCount =
       myEvents.filter((e) => e.status === "scheduled").length;
     return scheduledCount < MIN_SCHEDULED_EVENTS;
   },
 
-  buildPayload(_state, _rng) {
+  buildPayload(state, rng) {
     const now = Date.now();
-    // supabaseUrl 은 transport 단계에서 주입 (각 액션이 EF 호출 시 URL 알아야 함)
-    // 본 payload 는 placeholder — 실제 image_urls 빌드는 transport 가 수행
+    const myParties = ((state.myParties as PartnerParty[]) ?? []).filter(
+      (party) => typeof party.id === "string" && party.status !== "closed",
+    );
+    if (myParties.length === 0) {
+      throw new Error(
+        "partner_create_event.buildPayload called without an existing party",
+      );
+    }
+
+    const party = myParties[Math.floor(rng.next() * myParties.length)];
+    const startDelayDays = MIN_START_DELAY_DAYS +
+      Math.floor(rng.next() * START_DELAY_WINDOW_DAYS);
+    const startTime = new Date(now + startDelayDays * 86_400_000);
+    const endTime = new Date(startTime.getTime() + EVENT_DURATION_MS);
+
     return {
       action: "create",
-      _imageFilenames: SEED_IMAGE_FILENAMES,
-      party: {
-        title: `Event Flow Simulator Party ${now}`,
+      party_id: party.id,
+      event: {
+        title: `Event Flow Simulator Event ${now}`,
         description: {
-          ops: [{ insert: "Auto-generated tick simulation party\n" }],
+          ops: [{ insert: "Auto-generated tick simulation event\n" }],
         },
-        required_verification_ids: [],
+        start_time: startTime.toISOString(),
+        end_time: endTime.toISOString(),
         min_confirmed_count: 4,
         max_participants: 20,
-        status: "active",
         metadata: { show_participant_list: true, visibility: "public" },
       },
-      location: {
-        name: "Event Flow Simulator Venue",
-        address: "서울시 강남구",
-        region_1: "서울",
-        region_2: "강남구",
-      },
-      entry_group_templates: [
+      entry_groups: [
         {
           label: "남성",
           gender: "male",
@@ -66,7 +74,7 @@ export const partnerCreateEventAction: ActionDef = {
           birth_year_max: 2005,
         },
       ],
-      ticket_templates: [{ name: "일반", price: 15000, quantity: 20 }],
+      tickets: [{ name: "일반", price: 15000, quantity: 20 }],
     };
   },
 };

--- a/supabase/functions/event-flow-simulator/core/auth.ts
+++ b/supabase/functions/event-flow-simulator/core/auth.ts
@@ -26,9 +26,16 @@ export async function getSimUserToken(
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
   if (error || !data.session?.access_token) {
-    throw new Error(`getSimUserToken: failed to sign in ${email}: ${error?.message ?? "no session"}`);
+    throw new Error(
+      `getSimUserToken: failed to sign in ${email}: ${
+        error?.message ?? "no session"
+      }`,
+    );
   }
 
   const token = data.session.access_token;
@@ -94,9 +101,16 @@ export async function getSimPartnerToken(
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-  const { data, error } = await supabase.auth.signInWithPassword({ email: partnerEmail, password });
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: partnerEmail,
+    password,
+  });
   if (error || !data.session?.access_token) {
-    throw new Error(`getSimPartnerToken: failed to sign in ${partnerEmail}: ${error?.message ?? "no session"}`);
+    throw new Error(
+      `getSimPartnerToken: failed to sign in ${partnerEmail}: ${
+        error?.message ?? "no session"
+      }`,
+    );
   }
 
   const token = data.session.access_token;
@@ -106,7 +120,7 @@ export async function getSimPartnerToken(
 
 /**
  * Look up the email address for a partner's member account.
- * Queries partner_members to find a member for the given partner_id,
+ * Queries partner_member_permissions to find a member for the given partner_id,
  * then fetches the auth user record to retrieve their email.
  * Returns null if no member or auth user is found.
  */
@@ -115,7 +129,7 @@ export async function getPartnerEmail(
   partnerId: string,
 ): Promise<string | null> {
   const { data: members, error: memberErr } = await supabase
-    .from("partner_members")
+    .from("partner_member_permissions")
     .select("user_id")
     .eq("partner_id", partnerId)
     .limit(1);
@@ -123,7 +137,8 @@ export async function getPartnerEmail(
   if (memberErr || !members || members.length === 0) return null;
 
   const userId = (members[0] as { user_id: string }).user_id;
-  const { data: authUser, error: authErr } = await supabase.auth.admin.getUserById(userId);
+  const { data: authUser, error: authErr } = await supabase.auth.admin
+    .getUserById(userId);
   if (authErr || !authUser?.user?.email) return null;
 
   return authUser.user.email;

--- a/supabase/functions/event-flow-simulator/core/auth.ts
+++ b/supabase/functions/event-flow-simulator/core/auth.ts
@@ -26,16 +26,9 @@ export async function getSimUserToken(
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-  const { data, error } = await supabase.auth.signInWithPassword({
-    email,
-    password,
-  });
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
   if (error || !data.session?.access_token) {
-    throw new Error(
-      `getSimUserToken: failed to sign in ${email}: ${
-        error?.message ?? "no session"
-      }`,
-    );
+    throw new Error(`getSimUserToken: failed to sign in ${email}: ${error?.message ?? "no session"}`);
   }
 
   const token = data.session.access_token;
@@ -101,16 +94,9 @@ export async function getSimPartnerToken(
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-  const { data, error } = await supabase.auth.signInWithPassword({
-    email: partnerEmail,
-    password,
-  });
+  const { data, error } = await supabase.auth.signInWithPassword({ email: partnerEmail, password });
   if (error || !data.session?.access_token) {
-    throw new Error(
-      `getSimPartnerToken: failed to sign in ${partnerEmail}: ${
-        error?.message ?? "no session"
-      }`,
-    );
+    throw new Error(`getSimPartnerToken: failed to sign in ${partnerEmail}: ${error?.message ?? "no session"}`);
   }
 
   const token = data.session.access_token;
@@ -137,8 +123,7 @@ export async function getPartnerEmail(
   if (memberErr || !members || members.length === 0) return null;
 
   const userId = (members[0] as { user_id: string }).user_id;
-  const { data: authUser, error: authErr } = await supabase.auth.admin
-    .getUserById(userId);
+  const { data: authUser, error: authErr } = await supabase.auth.admin.getUserById(userId);
   if (authErr || !authUser?.user?.email) return null;
 
   return authUser.user.email;

--- a/supabase/functions/event-flow-simulator/core/auth_test.ts
+++ b/supabase/functions/event-flow-simulator/core/auth_test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "@std/assert";
+import {
+  createMockSupabaseClient,
+} from "../../_test_utils/mock_supabase_client.ts";
+import { getPartnerEmail } from "./auth.ts";
+
+Deno.test({
+  name: "getPartnerEmail reads partner_member_permissions",
+  fn: async () => {
+    let permissionsQueried = false;
+    let legacyTableQueried = false;
+    const supabase = createMockSupabaseClient({
+      tables: {
+        partner_member_permissions: {
+          select: ({ filters }) => {
+            permissionsQueried = true;
+            assertEquals(filters.partner_id, "partner-1");
+            return { data: [{ user_id: "user-1" }], error: null };
+          },
+        },
+        partner_members: {
+          select: () => {
+            legacyTableQueried = true;
+            return { data: [], error: null };
+          },
+        },
+      },
+      authAdminGetUserById: (userId) => {
+        assertEquals(userId, "user-1");
+        return {
+          data: { user: { email: "partner@example.com" } },
+          error: null,
+        };
+      },
+    });
+
+    const email = await getPartnerEmail(
+      // deno-lint-ignore no-explicit-any
+      supabase as any,
+      "partner-1",
+    );
+
+    assertEquals(email, "partner@example.com");
+    assertEquals(permissionsQueried, true);
+    assertEquals(legacyTableQueried, false);
+  },
+});

--- a/supabase/functions/event-flow-simulator/core/snapshot.ts
+++ b/supabase/functions/event-flow-simulator/core/snapshot.ts
@@ -8,75 +8,140 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { WorldSnapshot } from "./observable.ts";
 
+const PAGE_SIZE = 1000;
+const IN_CHUNK_SIZE = 200;
+
+type SelectError = { message?: string } | null;
+type SelectResult<T> = { data: T[] | null; error: SelectError };
+type SelectBuilder<T> = {
+  eq: (column: string, value: unknown) => SelectBuilder<T>;
+  in: (column: string, values: unknown[]) => SelectBuilder<T>;
+  range: (from: number, to: number) => PromiseLike<SelectResult<T>>;
+};
+
+type PartyRow = {
+  id: string;
+  partner_id: string;
+  status: string;
+};
+
+type EventRow = {
+  id: string;
+  party_id: string;
+  status: string;
+  start_time: string;
+};
+
+type TicketRow = {
+  id: string;
+  event_id: string;
+  price: number;
+};
+
+type ApplicationRow = {
+  id: string;
+  user_id: string;
+  event_id: string;
+  status: string;
+};
+
+type ParticipantRow = {
+  id: string;
+  user_id: string;
+  event_id: string;
+  status: string;
+};
+
+type VoteRow = {
+  event_id: string;
+  voter_id: string;
+  candidate_id: string;
+};
+
+type BlockRow = {
+  user_id: string;
+  target_id: string;
+  target_type: string;
+};
+
 export async function buildSnapshot(
   supabase: SupabaseClient,
 ): Promise<WorldSnapshot> {
-  const { data: partyRows } = await supabase
-    .from("parties")
-    .select("id, partner_id, status");
-  const parties = (partyRows ?? []) as Array<{
-    id: string;
-    partner_id: string;
-    status: string;
-  }>;
+  const parties = await selectAllRows<PartyRow>(
+    supabase,
+    "parties",
+    "id, partner_id, status",
+  );
   const partyIds = parties.map((p) => p.id);
 
   if (partyIds.length === 0) {
     return emptySnapshot();
   }
 
-  const { data: eventRows } = await supabase
-    .from("events")
-    .select("id, party_id, status, start_time")
-    .in("party_id", partyIds);
-  const events = (eventRows ?? []) as Array<{
-    id: string;
-    party_id: string;
-    status: string;
-    start_time: string;
-  }>;
+  const partyIdSet = new Set(partyIds);
+  const events = (await selectAllRows<EventRow>(
+    supabase,
+    "events",
+    "id, party_id, status, start_time",
+  )).filter((e) => partyIdSet.has(e.party_id));
   const eventIds = events.map((e) => e.id);
-  const partnerIds = parties.map((p) => p.partner_id);
+  const partnerIds = uniqueStrings(parties.map((p) => p.partner_id));
 
-  const [ticketRows, appRows, partRows, voteRows, blockRows] = await Promise
+  const [tickets, applications, participants, votes, blocks] = await Promise
     .all(
       [
         eventIds.length > 0
-          ? supabase.from("tickets").select("id, event_id, price").in(
+          ? selectByInChunks<TicketRow>(
+            supabase,
+            "tickets",
+            "id, event_id, price",
             "event_id",
             eventIds,
           )
-          : Promise.resolve({ data: [] }),
+          : Promise.resolve([]),
         eventIds.length > 0
-          ? supabase
-            .from("event_applications")
-            .select("id, user_id, event_id, status")
-            .in("event_id", eventIds)
-          : Promise.resolve({ data: [] }),
+          ? selectByInChunks<ApplicationRow>(
+            supabase,
+            "event_applications",
+            "id, user_id, event_id, status",
+            "event_id",
+            eventIds,
+          )
+          : Promise.resolve([]),
         eventIds.length > 0
-          ? supabase
-            .from("event_participants")
-            .select("id, user_id, event_id, status")
-            .in("event_id", eventIds)
-          : Promise.resolve({ data: [] }),
+          ? selectByInChunks<ParticipantRow>(
+            supabase,
+            "event_participants",
+            "id, user_id, event_id, status",
+            "event_id",
+            eventIds,
+          )
+          : Promise.resolve([]),
         eventIds.length > 0
-          ? supabase
-            .from("match_votes")
-            .select("event_id, voter_id, candidate_id")
-            .in("event_id", eventIds)
-          : Promise.resolve({ data: [] }),
-        supabase
-          .from("social_interactions")
-          .select("user_id, target_id, target_type")
-          .eq("interaction_type", "block")
-          .eq("target_type", "partner")
-          .in("target_id", partnerIds),
+          ? selectByInChunks<VoteRow>(
+            supabase,
+            "match_votes",
+            "event_id, voter_id, candidate_id",
+            "event_id",
+            eventIds,
+          )
+          : Promise.resolve([]),
+        partnerIds.length > 0
+          ? selectByInChunks<BlockRow>(
+            supabase,
+            "social_interactions",
+            "user_id, target_id, target_type",
+            "target_id",
+            partnerIds,
+            (query) =>
+              query.eq("interaction_type", "block").eq(
+                "target_type",
+                "partner",
+              ),
+          )
+          : Promise.resolve([]),
       ],
     );
-
-  const tickets = (ticketRows.data ?? []) as Array<
-    { id: string; event_id: string; price: number }
-  >;
 
   // tickets 를 event 에 attach (observable 모델이 event.tickets 기대)
   const ticketsByEvent = new Map<
@@ -95,28 +160,10 @@ export async function buildSnapshot(
   return {
     parties,
     events: eventsWithTickets,
-    applications: ((appRows.data ?? []) as Array<{
-      id: string;
-      user_id: string;
-      event_id: string;
-      status: string;
-    }>),
-    participants: ((partRows.data ?? []) as Array<{
-      id: string;
-      user_id: string;
-      event_id: string;
-      status: string;
-    }>),
-    votes: ((voteRows.data ?? []) as Array<{
-      event_id: string;
-      voter_id: string;
-      candidate_id: string;
-    }>),
-    blocks: ((blockRows.data ?? []) as Array<{
-      user_id: string;
-      target_id: string;
-      target_type: string;
-    }>),
+    applications,
+    participants,
+    votes,
+    blocks,
   };
 }
 
@@ -129,4 +176,73 @@ export function emptySnapshot(): WorldSnapshot {
     votes: [],
     blocks: [],
   };
+}
+
+function selectBuilder<T>(
+  supabase: SupabaseClient,
+  table: string,
+  columns: string,
+): SelectBuilder<T> {
+  return supabase.from(table).select(columns) as unknown as SelectBuilder<T>;
+}
+
+async function selectAllRows<T>(
+  supabase: SupabaseClient,
+  table: string,
+  columns: string,
+): Promise<T[]> {
+  return await selectPaged(
+    table,
+    () => selectBuilder<T>(supabase, table, columns),
+  );
+}
+
+async function selectByInChunks<T>(
+  supabase: SupabaseClient,
+  table: string,
+  columns: string,
+  column: string,
+  values: string[],
+  filter?: (query: SelectBuilder<T>) => SelectBuilder<T>,
+): Promise<T[]> {
+  const rows: T[] = [];
+  for (const valueChunk of chunks(uniqueStrings(values), IN_CHUNK_SIZE)) {
+    const chunkRows = await selectPaged(table, () => {
+      const query = selectBuilder<T>(supabase, table, columns);
+      return (filter ? filter(query) : query).in(column, valueChunk);
+    });
+    rows.push(...chunkRows);
+  }
+  return rows;
+}
+
+async function selectPaged<T>(
+  table: string,
+  queryFactory: () => SelectBuilder<T>,
+): Promise<T[]> {
+  const rows: T[] = [];
+  for (let from = 0; true; from += PAGE_SIZE) {
+    const to = from + PAGE_SIZE - 1;
+    const { data, error } = await queryFactory().range(from, to);
+    if (error) {
+      const message = error.message ?? String(error);
+      throw new Error(`buildSnapshot: failed to load ${table}: ${message}`);
+    }
+    const page = data ?? [];
+    rows.push(...page);
+    if (page.length < PAGE_SIZE) break;
+  }
+  return rows;
+}
+
+function chunks<T>(values: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < values.length; i += size) {
+    result.push(values.slice(i, i + size));
+  }
+  return result;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
 }

--- a/supabase/functions/event-flow-simulator/core/snapshot_test.ts
+++ b/supabase/functions/event-flow-simulator/core/snapshot_test.ts
@@ -1,0 +1,93 @@
+import { assertEquals } from "@std/assert";
+import {
+  createMockSupabaseClient,
+  type MockRange,
+} from "../../_test_utils/mock_supabase_client.ts";
+import { buildSnapshot } from "./snapshot.ts";
+
+type Row = Record<string, unknown>;
+
+function pageRows<T>(rows: T[], range?: MockRange): T[] {
+  if (!range) return rows;
+  return rows.slice(range.from, range.to + 1);
+}
+
+function filterIn<T extends Row>(
+  rows: T[],
+  filters: Record<string, unknown>,
+  column: string,
+): T[] {
+  const values = filters[column];
+  if (!Array.isArray(values)) return rows;
+  return rows.filter((row) => values.includes(row[column]));
+}
+
+Deno.test({
+  name:
+    "buildSnapshot paginates parties so late scheduled events remain visible",
+  fn: async () => {
+    const parties = Array.from({ length: 1001 }, (_, index) => ({
+      id: `party-${index}`,
+      partner_id: `partner-${index}`,
+      status: "active",
+    }));
+    const events = [
+      {
+        id: "event-late",
+        party_id: "party-1000",
+        status: "scheduled",
+        start_time: new Date(Date.now() + 10 * 86_400_000).toISOString(),
+      },
+    ];
+    const tickets = [
+      { id: "ticket-late", event_id: "event-late", price: 15000 },
+    ];
+
+    const supabase = createMockSupabaseClient({
+      tables: {
+        parties: {
+          select: ({ range }) => ({
+            data: pageRows(parties, range),
+            error: null,
+          }),
+        },
+        events: {
+          select: ({ range }) => ({
+            data: pageRows(events, range),
+            error: null,
+          }),
+        },
+        tickets: {
+          select: ({ filters, range }) => ({
+            data: pageRows(filterIn(tickets, filters, "event_id"), range),
+            error: null,
+          }),
+        },
+        event_applications: {
+          select: () => ({ data: [], error: null }),
+        },
+        event_participants: {
+          select: () => ({ data: [], error: null }),
+        },
+        match_votes: {
+          select: () => ({ data: [], error: null }),
+        },
+        social_interactions: {
+          select: () => ({ data: [], error: null }),
+        },
+      },
+    });
+
+    const snapshot = await buildSnapshot(
+      // deno-lint-ignore no-explicit-any
+      supabase as any,
+    );
+
+    assertEquals(snapshot.parties.length, 1001);
+    assertEquals(snapshot.events.length, 1);
+    assertEquals(snapshot.events[0].id, "event-late");
+    assertEquals(snapshot.events[0].tickets, [
+      { id: "ticket-late", price: 15000 },
+    ]);
+  },
+});

--- a/supabase/functions/event-flow-simulator/core/snapshot_test.ts
+++ b/supabase/functions/event-flow-simulator/core/snapshot_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import {
   createMockSupabaseClient,
   type MockRange,
@@ -42,6 +42,13 @@ Deno.test({
     const tickets = [
       { id: "ticket-late", event_id: "event-late", price: 15000 },
     ];
+    const blocks = [
+      {
+        user_id: "user-1",
+        target_id: "partner-1000",
+        target_type: "partner",
+      },
+    ];
 
     const supabase = createMockSupabaseClient({
       tables: {
@@ -73,7 +80,14 @@ Deno.test({
           select: () => ({ data: [], error: null }),
         },
         social_interactions: {
-          select: () => ({ data: [], error: null }),
+          select: ({ filters, range }) => {
+            assertEquals(filters.interaction_type, "block");
+            assertEquals(filters.target_type, "partner");
+            return {
+              data: pageRows(filterIn(blocks, filters, "target_id"), range),
+              error: null,
+            };
+          },
         },
       },
     });
@@ -89,5 +103,32 @@ Deno.test({
     assertEquals(snapshot.events[0].tickets, [
       { id: "ticket-late", price: 15000 },
     ]);
+    assertEquals(snapshot.blocks, blocks);
+  },
+});
+
+Deno.test({
+  name: "buildSnapshot surfaces select errors",
+  fn: async () => {
+    const supabase = createMockSupabaseClient({
+      tables: {
+        parties: {
+          select: () => ({
+            data: null,
+            error: { message: "load failed" },
+          }),
+        },
+      },
+    });
+
+    await assertRejects(
+      () =>
+        buildSnapshot(
+          // deno-lint-ignore no-explicit-any
+          supabase as any,
+        ),
+      Error,
+      "buildSnapshot: failed to load parties: load failed",
+    );
   },
 });

--- a/supabase/functions/event-flow-simulator/index.ts
+++ b/supabase/functions/event-flow-simulator/index.ts
@@ -210,6 +210,13 @@ export const handler = async (
     // 4. invariant 검증
     const violations = await checkAll(supabase);
     const summary = summarizeTrace(cascade.trace);
+    const actionCounts = cascade.trace.reduce<Record<string, number>>(
+      (counts, entry) => {
+        counts[entry.action.type] = (counts[entry.action.type] ?? 0) + 1;
+        return counts;
+      },
+      {},
+    );
     const githubIssueUrl = await reportFailure({
       runId,
       trace: cascade.trace,
@@ -225,8 +232,13 @@ export const handler = async (
       metadata: {
         runId,
         actorsCount: actors.length,
+        actorCounts: {
+          partner: actors.filter((actor) => actor.role === "partner").length,
+          user: actors.filter((actor) => actor.role === "user").length,
+        },
         usersPerTick,
         partnersPerTick,
+        actionCounts,
         traceTotal: summary.total,
         traceOk: summary.ok,
         traceFailed: summary.failed,


### PR DESCRIPTION
Fixes #3075

## Summary
- Fix partner actor email lookup to use `partner_member_permissions`
- Page/chunk simulator snapshots so scheduled events beyond PostgREST's default 1000-row window remain visible
- Route `partner_create_event` through `partner-manage-event` with direct event/ticket payloads
- Add action/actor counts to simulator Axiom completion logs
- Add regression tests for partner auth lookup and snapshot pagination

## Tests
- `deno test --allow-env event-flow-simulator/`