### PR TITLE
ci(mds): archive render snapshots on dev

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -9,7 +9,9 @@
 | [`create-dev-flutter-env.sh`](./create-dev-flutter-env.sh) | Actions secrets → `minglit_env/dev/flutter.env` 재생성 (CI 가 private submodule `minglit_env/` 를 받지 못해서 필요, Fix #1169) | `shared-cuj-integration`, `monitor-patrol-e2e` |
 | [`run-user-cuj.sh`](./run-user-cuj.sh) | `apps/app_user/integration_test/cuj/` 의 CUJ 테스트 실행. 모든 CUJ 파일을 실행한 뒤 실패 목록 aggregate | `shared-cuj-integration` (app-name=user 일 때), `monitor-dev-cuj` |
 | [`run-partner-cuj.sh`](./run-partner-cuj.sh) | `apps/app_partner/integration_test/cuj/` CUJ 실행. 모든 CUJ 파일을 실행한 뒤 실패 목록 aggregate | `shared-cuj-integration` (app-name=partner 일 때), `monitor-dev-cuj` |
-| [`run-mds-render-shard.sh`](./run-mds-render-shard.sh) | MDS emulator render catalog 를 app/shard 단위로 `flutter drive` 실행하고 PNG artifact 생성 | `monitor-mds-render-coverage` |
+| [`run-mds-render-shard.sh`](./run-mds-render-shard.sh) | MDS emulator render catalog 를 app/shard 단위로 `flutter drive` 실행하고 PNG artifact 생성 | `monitor-mds-render-coverage`, `sync-mds-render-snapshot` |
+| [`archive-mds-render-snapshot.sh`](./archive-mds-render-snapshot.sh) | 병합된 MDS render PNG 를 `artifacts/mds-render/snapshots/dev/<sha>/` 에 commit/push | `sync-mds-render-snapshot` |
+| [`triage-mds-render-snapshot-diff.sh`](./triage-mds-render-snapshot-diff.sh) | `artifacts/mds-render` 의 snapshot PNG diff 를 화면 단위 이슈로 파일링 | `triage-mds-render-snapshot-diff` |
 | [`check-bluedoc-freshness.sh`](./check-bluedoc-freshness.sh) | PR 에서 새/삭제 파일에 대해 가장 가까운 ancestor BLUEDOC.md 갱신 강제. 통과: 이정표 표 갱신 또는 BLUEDOC 의 `_Reviewed_` 날짜 bump. + 모든 BLUEDOC.md 의 Reviewed 형식 검증 | `pr-gate.check-bluedoc-freshness` (required check) |
 | [`check-pr-issue-reference.sh`](./check-pr-issue-reference.sh) | dev-staging PR 본문에 이슈 종료 의도(`Closes/Fixes/Resolves`) 또는 명시적 비종료 사유(`Refs` + 이유 / `No linked issue`)가 있는지 검사 | `pr-gate.static-checks` |
 | [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | iOS deploy 브랜치·runner SDK·timeout·heartbeat·Flutter SPM off 계약 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
@@ -37,4 +39,4 @@
 - [.github/BLUEDOC.md](../BLUEDOC.md) — 상위 진입점
 
 ---
-_Reviewed: 2026-06-05 07:25_
+_Reviewed: 2026-06-05 14:09_

--- a/.github/scripts/archive-mds-render-snapshot.sh
+++ b/.github/scripts/archive-mds-render-snapshot.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_SHA:?TARGET_SHA is required}"
+: "${RENDER_SOURCE_DIR:?RENDER_SOURCE_DIR is required}"
+: "${RELEASE_BOT_TOKEN:?RELEASE_BOT_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_SERVER_URL:?GITHUB_SERVER_URL is required}"
+
+ARCHIVE_BRANCH="${ARCHIVE_BRANCH:-artifacts/mds-render}"
+SNAPSHOT_CHANNEL="${SNAPSHOT_CHANNEL:-dev}"
+MAX_PUSH_ATTEMPTS="${MAX_PUSH_ATTEMPTS:-3}"
+SNAPSHOT_PATH="snapshots/${SNAPSHOT_CHANNEL}/${TARGET_SHA}"
+SHORT_SHA="${TARGET_SHA:0:8}"
+
+if [[ ! "${TARGET_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo "::error::TARGET_SHA must be a full 40-character commit SHA."
+  exit 1
+fi
+
+if [ ! -d "${RENDER_SOURCE_DIR}" ]; then
+  echo "::error::RENDER_SOURCE_DIR does not exist: ${RENDER_SOURCE_DIR}"
+  exit 1
+fi
+RENDER_SOURCE_DIR="$(cd "${RENDER_SOURCE_DIR}" && pwd -P)"
+
+PNG_COUNT="$(find "${RENDER_SOURCE_DIR}" -type f -name 'state-*.png' | wc -l | tr -d ' ')"
+if [ "${PNG_COUNT}" = "0" ]; then
+  echo "::error::No state PNG files found under ${RENDER_SOURCE_DIR}"
+  exit 1
+fi
+
+REMOTE_URL="https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+SNAPSHOT_URL=""
+ARCHIVE_COMMIT=""
+BEFORE_COMMIT=""
+CHANGED="false"
+CHANGED_SCREENS=""
+CHANGED_FILES=""
+
+for attempt in $(seq 1 "${MAX_PUSH_ATTEMPTS}"); do
+  WORK_DIR="$(mktemp -d)"
+  trap 'rm -rf "${WORK_DIR}"' RETURN
+
+  if git ls-remote --exit-code --heads "${REMOTE_URL}" "${ARCHIVE_BRANCH}" >/dev/null 2>&1; then
+    git clone --depth=1 --branch "${ARCHIVE_BRANCH}" "${REMOTE_URL}" "${WORK_DIR}/archive"
+    BEFORE_COMMIT="$(git -C "${WORK_DIR}/archive" rev-parse HEAD)"
+  else
+    mkdir -p "${WORK_DIR}/archive"
+    git -C "${WORK_DIR}/archive" init
+    git -C "${WORK_DIR}/archive" remote add origin "${REMOTE_URL}"
+    git -C "${WORK_DIR}/archive" checkout --orphan "${ARCHIVE_BRANCH}"
+    BEFORE_COMMIT="0000000000000000000000000000000000000000"
+    {
+      echo "# MDS Render Artifacts"
+      echo ""
+      echo "Git-backed visual evidence archive. Source branches do not merge this branch."
+    } > "${WORK_DIR}/archive/README.md"
+  fi
+
+  cd "${WORK_DIR}/archive"
+  git config user.name "minglit-release-bot"
+  git config user.email "minglit-release-bot@users.noreply.github.com"
+
+  rm -rf "${SNAPSHOT_PATH}"
+  mkdir -p "${SNAPSHOT_PATH}"
+  cp -a "${RENDER_SOURCE_DIR}/." "${SNAPSHOT_PATH}/"
+  rm -f "${SNAPSHOT_PATH}/artifact-root.txt"
+
+  {
+    echo "# MDS Render Snapshot"
+    echo ""
+    echo "| Field | Value |"
+    echo "|---|---|"
+    echo "| channel | \`${SNAPSHOT_CHANNEL}\` |"
+    echo "| source_sha | \`${TARGET_SHA}\` |"
+    echo "| png_count | ${PNG_COUNT} |"
+  } > "${SNAPSHOT_PATH}/_snapshot.md"
+
+  git add README.md "${SNAPSHOT_PATH}"
+
+  if git diff --cached --quiet; then
+    ARCHIVE_COMMIT="$(git rev-parse HEAD)"
+    SNAPSHOT_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${ARCHIVE_COMMIT}/${SNAPSHOT_PATH}"
+    CHANGED="false"
+    break
+  fi
+
+  CHANGED="true"
+  CHANGED_FILES="$(git diff --cached --name-status -- "${SNAPSHOT_PATH}" | sed -n '1,200p')"
+  CHANGED_SCREENS="$(
+    git diff --cached --name-only -- "${SNAPSHOT_PATH}" \
+      | awk -F/ 'NF >= 5 && $5 ~ /^state-.*\.png$/ { print $4 }' \
+      | sort -u \
+      | paste -sd ',' -
+  )"
+
+  git commit -m "chore(mds-render): snapshot ${SNAPSHOT_CHANNEL} ${SHORT_SHA}"
+
+  if git push origin "HEAD:refs/heads/${ARCHIVE_BRANCH}"; then
+    ARCHIVE_COMMIT="$(git rev-parse HEAD)"
+    SNAPSHOT_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${ARCHIVE_COMMIT}/${SNAPSHOT_PATH}"
+    break
+  fi
+
+  if [ "${attempt}" = "${MAX_PUSH_ATTEMPTS}" ]; then
+    echo "::error::Failed to push ${ARCHIVE_BRANCH} after ${MAX_PUSH_ATTEMPTS} attempts."
+    exit 1
+  fi
+
+  echo "[mds-render] push rejected; retrying with fresh ${ARCHIVE_BRANCH} (${attempt}/${MAX_PUSH_ATTEMPTS})"
+  cd - >/dev/null
+  rm -rf "${WORK_DIR}"
+  trap - RETURN
+done
+
+if [ -z "${SNAPSHOT_URL}" ] || [ -z "${ARCHIVE_COMMIT}" ]; then
+  echo "::error::Archive snapshot URL was not resolved."
+  exit 1
+fi
+
+{
+  echo "snapshot_path=${SNAPSHOT_PATH}"
+  echo "snapshot_url=${SNAPSHOT_URL}"
+  echo "archive_commit=${ARCHIVE_COMMIT}"
+  echo "before_commit=${BEFORE_COMMIT}"
+  echo "png_count=${PNG_COUNT}"
+  echo "changed=${CHANGED}"
+  echo "changed_screens=${CHANGED_SCREENS}"
+  echo "changed_files<<EOF"
+  printf '%s\n' "${CHANGED_FILES}"
+  echo "EOF"
+} >> "${GITHUB_OUTPUT}"
+
+{
+  echo "## MDS render snapshot archive"
+  echo ""
+  echo "| Field | Value |"
+  echo "|---|---|"
+  echo "| source_sha | \`${TARGET_SHA}\` |"
+  echo "| archive_branch | \`${ARCHIVE_BRANCH}\` |"
+  echo "| before_commit | \`${BEFORE_COMMIT}\` |"
+  echo "| archive_commit | \`${ARCHIVE_COMMIT}\` |"
+  echo "| snapshot_path | \`${SNAPSHOT_PATH}\` |"
+  echo "| png_count | ${PNG_COUNT} |"
+  echo "| changed | ${CHANGED} |"
+  echo "| snapshot_url | ${SNAPSHOT_URL} |"
+  if [ -n "${CHANGED_SCREENS}" ]; then
+    echo "| changed_screens | ${CHANGED_SCREENS} |"
+  fi
+} >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/scripts/check-dev-soak-workflow-contract.py
+++ b/.github/scripts/check-dev-soak-workflow-contract.py
@@ -342,6 +342,7 @@ def assert_dev_rc_cut_gate_contract() -> None:
 
     failure_contexts = str(with_config.get("failure_contexts", ""))
     success_contexts = str(with_config.get("success_contexts", ""))
+    required_success_contexts = str(with_config.get("required_success_contexts", ""))
     # cuj-* failure contexts stay as the manual block lever
     # (set-dev-soak-status); their success confirmations are removed with
     # the frozen CUJ monitor so the gate never writes fake CUJ evidence.
@@ -349,6 +350,8 @@ def assert_dev_rc_cut_gate_contract() -> None:
         "dev-soak/backend-simulator",
         "dev-soak/cuj-user",
         "dev-soak/cuj-partner",
+        "dev-soak/app-ai-review",
+        "mds-render/snapshot",
     ]
     for context in required_failure_contexts:
         if context not in failure_contexts:
@@ -358,6 +361,15 @@ def assert_dev_rc_cut_gate_contract() -> None:
     for context in ["dev-soak/cuj-user", "dev-soak/cuj-partner"]:
         if context in success_contexts:
             fail(f"dev-rc-cut-gate success_contexts must not confirm {context} while Flutter CUJ is frozen (web-mvp pivot)")
+    required_visual_contexts = [
+        "mds-render/snapshot",
+        "dev-soak/app-ai-review",
+    ]
+    for context in required_visual_contexts:
+        if context not in required_success_contexts:
+            fail(f"dev-rc-cut-gate required_success_contexts missing {context}")
+        if context in success_contexts:
+            fail(f"dev-rc-cut-gate success_contexts must not write required visual evidence {context}")
 
     if with_config.get("pass_context") != "dev-rc-cut-pass":
         fail("dev-rc-cut-gate pass_context must be dev-rc-cut-pass")
@@ -386,6 +398,9 @@ def assert_pr_gate_cuj_contract() -> None:
 def assert_shared_soak_gate_contract() -> None:
     workflow_text = SHARED_SOAK_GATE.read_text(encoding="utf-8")
     required_fragments = [
+        "required_success_contexts",
+        "INPUT_REQUIRED_SUCCESS_CONTEXTS",
+        "is ${state:-missing}",
         "run_limit = int(item.get",
         "run_limit < min_success",
         '--created ">=${COMMIT_ISO}"',

--- a/.github/scripts/triage-mds-render-snapshot-diff.sh
+++ b/.github/scripts/triage-mds-render-snapshot-diff.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_SERVER_URL:?GITHUB_SERVER_URL is required}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+
+BEFORE_SHA="${BEFORE_SHA:-}"
+AFTER_SHA="${AFTER_SHA:-$(git rev-parse HEAD)}"
+ARCHIVE_BRANCH="${ARCHIVE_BRANCH:-artifacts/mds-render}"
+DRY_RUN="${DRY_RUN:-false}"
+RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+ZERO_SHA="0000000000000000000000000000000000000000"
+
+if [ -n "${BEFORE_SHA}" ] && [ "${BEFORE_SHA}" != "${ZERO_SHA}" ] && git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+  DIFF_CMD=(git diff --name-status "${BEFORE_SHA}" "${AFTER_SHA}" -- snapshots/dev)
+  COMPARE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${BEFORE_SHA}...${AFTER_SHA}"
+else
+  DIFF_CMD=(git diff-tree --no-commit-id --name-status -r "${AFTER_SHA}" -- snapshots/dev)
+  COMPARE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${AFTER_SHA}/snapshots/dev"
+fi
+
+DIFF_FILE="$(mktemp)"
+"${DIFF_CMD[@]}" > "${DIFF_FILE}"
+
+PNG_PATHS_FILE="$(mktemp)"
+awk '
+  {
+    path=$NF
+    if (path ~ /^snapshots\/dev\/[0-9a-fA-F]{40}\/.*\/state-.*\.png$/) {
+      print path
+    }
+  }
+' "${DIFF_FILE}" | sort -u > "${PNG_PATHS_FILE}"
+
+if [ ! -s "${PNG_PATHS_FILE}" ]; then
+  echo "No MDS state PNG diff detected under snapshots/dev/**."
+  exit 0
+fi
+
+SOURCE_SHAS=()
+while IFS= read -r source_sha; do
+  SOURCE_SHAS+=("${source_sha}")
+done < <(awk -F/ '{ print $3 }' "${PNG_PATHS_FILE}" | sort -u)
+
+for SOURCE_SHA in "${SOURCE_SHAS[@]}"; do
+  SHORT_SHA="${SOURCE_SHA:0:8}"
+  SNAPSHOT_PATH="snapshots/dev/${SOURCE_SHA}"
+  SNAPSHOT_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${AFTER_SHA}/${SNAPSHOT_PATH}"
+  TITLE="[mds-render-snapshot-diff] dev ${SHORT_SHA} visual snapshot changed"
+
+  FILES_FOR_SHA="$(awk -v sha="${SOURCE_SHA}" '$0 ~ "snapshots/dev/" sha "/" { print }' "${DIFF_FILE}" | sed -n '1,200p')"
+  SCREENS_FOR_SHA="$(
+    awk -F/ -v sha="${SOURCE_SHA}" '$0 ~ "snapshots/dev/" sha "/" && $NF ~ /^state-.*\.png$/ { print $4 }' "${PNG_PATHS_FILE}" \
+      | sort -u \
+      | paste -sd ',' - \
+      | sed 's/,/, /g'
+  )"
+  COMPARISON_TARGETS_FILE="$(mktemp)"
+  {
+    echo "| Screen | Snapshot state | Diff | Snapshot PNG | MDS spec |"
+    echo "|---|---|---|---|---|"
+    awk -v sha="${SOURCE_SHA}" '$0 ~ "snapshots/dev/" sha "/" { print }' "${DIFF_FILE}" \
+      | while IFS=$'\t' read -r status path_a path_b; do
+        path="${path_b:-${path_a}}"
+        if [[ ! "${path}" =~ ^snapshots/dev/${SOURCE_SHA}/.*/state-.*\.png$ ]]; then
+          continue
+        fi
+        screen="$(printf '%s\n' "${path}" | awk -F/ '{ print $4 }')"
+        state_file="$(basename "${path}")"
+        snapshot_png_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/${AFTER_SHA}/${path}"
+        spec_dir_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${SOURCE_SHA}/apps/mds/docs/public/specs/${screen}"
+        echo "| ${screen} | ${state_file} | ${status} | [snapshot PNG](${snapshot_png_url}) | [MDS spec dir](${spec_dir_url}) |"
+      done
+  } > "${COMPARISON_TARGETS_FILE}"
+
+  BODY_FILE="$(mktemp)"
+  {
+    echo "## MDS render snapshot diff"
+    echo ""
+    echo "| Field | Value |"
+    echo "|---|---|"
+    echo "| Source dev SHA | \`${SOURCE_SHA}\` |"
+    echo "| Artifact branch | \`${ARCHIVE_BRANCH}\` |"
+    echo "| Snapshot path | \`${SNAPSHOT_PATH}\` |"
+    echo "| MDS spec root | \`apps/mds/docs/public/specs/<screen>/state_*.png\` |"
+    echo "| Snapshot URL | ${SNAPSHOT_URL} |"
+    echo "| Compare | ${COMPARE_URL} |"
+    echo "| Workflow run | ${RUN_URL} |"
+    echo "| Changed screens | ${SCREENS_FOR_SHA:-unknown} |"
+    echo ""
+    echo "## Changed files"
+    echo ""
+    echo '```text'
+    printf '%s\n' "${FILES_FOR_SHA}"
+    echo '```'
+    echo ""
+    echo "## Comparison targets"
+    echo ""
+    cat "${COMPARISON_TARGETS_FILE}"
+    echo ""
+    echo "> MDS spec 의 state 파일명은 \`state_1.png\`, \`state_2.png\` 처럼 순번 기반일 수 있다. Snapshot 의 \`state-*.png\` 와 이름이 직접 일치하지 않으면 MDS spec directory 의 \`index.md\` 와 state 순서를 확인해 같은 상태를 매칭한다."
+    echo "> MDS PNG 는 시각 참조이고, \`index.md\` 의 Layout / States / visual 섹션을 최종 contract 로 삼는다. PNG 와 텍스트가 충돌하면 그 사실을 코멘트에 명시하고 텍스트 contract 기준으로 판정한다."
+    echo ""
+    echo "## Agent Contract"
+    echo ""
+    echo "목표: 변경된 MDS emulator render snapshot 이 해당 dev SHA 의 의도된 화면 상태를 올바르게 반영하는지 확인한다. 이 이슈를 맡은 에이전트는 아래 절차를 직접 수행하고, 결과를 댓글과 finding issue/status 로 남긴다."
+    echo ""
+    echo "### 단계별 확인 절차"
+    echo ""
+    echo "1. Pairing: 변경된 각 \`state-*.png\` 를 \`apps/mds/docs/public/specs/<screen>/state_*.png\` 의 같은 screen/state 원본과 1:1 로 매칭한다."
+    echo "2. First pass: 전체 화면을 축소해서 hero/header/tab/body/bottom CTA 의 큰 구조, 잘림, 겹침, 빈 상태를 확인한다."
+    echo "3. Component pass: 변경 화면의 버튼, 탭, 카드, 리스트 row, form field, icon+text control 을 개별 확대해 확인한다."
+    echo "4. Sibling alignment pass: 같은 row 에 있는 형제 컨트롤의 top/bottom/center line, 높이, padding, icon baseline, text baseline 을 비교한다. 예: \`좋아요\` 와 \`공유하기\` 버튼은 같은 높이와 수직 정렬이어야 한다."
+    echo "5. State semantics pass: disabled/loading/error/empty/selected 상태가 MDS spec 의 의도와 같은지 확인한다."
+    echo "6. Regression pass: 변경이 최근 dev-staging -> dev 승격 내용으로 설명되는지 확인한다. 설명되지 않는 visual diff 는 blocker 후보로 본다."
+    echo ""
+    echo "### 반드시 코멘트에 남길 것"
+    echo ""
+    echo "- 확인한 screen/state 목록"
+    echo "- spec 대비 차이가 있던 항목과 의도된 변경인지 여부"
+    echo "- 버튼/탭/CTA 같은 같은-row 컨트롤의 수직 정렬 확인 결과"
+    echo "- blocker 가 아니라면 왜 허용 가능한지에 대한 근거"
+    echo "- blocker 라면 아래 Finding handling 절차로 만든 fix issue 링크"
+    echo ""
+    echo "### Finding handling"
+    echo ""
+    echo "- 이 review issue 는 visual diff 검토 태스크다. 확정된 visual blocker 를 이 이슈 하나에 묶어서 처리하지 않는다."
+    echo "- 확정된 blocker 는 finding 당 별도 GitHub issue 를 생성한다."
+    echo "- finding issue 는 AI worker 가 바로 수정할 수 있게 screen/state, snapshot URL, MDS spec 경로, 기대 동작, 실제 문제, 수정 완료 조건을 포함한다."
+    echo "- finding issue 라벨은 기본 \`needs-swe\`, \`P1-high\`, \`release-blocker\`, \`automated\` 를 사용한다. 설계 판단이 먼저 필요하면 \`needs-arch\` 를 추가한다."
+    echo "- 확정 blocker 가 1개 이상이면 source dev SHA 에 \`dev-soak/app-ai-review=failure\` commit status 를 즉시 남겨 RC cut gate 를 막는다."
+    echo "- status target URL 은 이 review issue 또는 대표 finding issue 로 둔다."
+    echo ""
+    echo "Status 기록 예:"
+    echo ""
+    echo '```bash'
+    echo "gh workflow run set-dev-soak-status.yml \\"
+    echo "  -f signal=app-ai-review \\"
+    echo "  -f state=failure \\"
+    echo "  -f sha=${SOURCE_SHA} \\"
+    echo "  -f target_url=<review-or-finding-issue-url> \\"
+    echo "  -f description=\"visual blocker found in MDS render snapshot\""
+    echo '```'
+    echo ""
+    echo "- blocker 가 없다고 확인되면 \`dev-soak/app-ai-review=success\` 를 같은 source dev SHA 에 남기고 근거 댓글 후 이슈를 닫는다."
+    echo ""
+    echo "### 종료 조건"
+    echo ""
+    echo "- 모든 변경 screen/state 를 위 절차로 확인했고, 변경이 의도된 결과이면 \`dev-soak/app-ai-review=success\` 근거를 댓글로 남기고 이슈를 닫는다."
+    echo "- blocker 를 발견했다면 finding 별 fix issue 를 만들고 \`dev-soak/app-ai-review=failure\` status 를 남긴 뒤, 이 review issue 에 생성한 issue 링크를 남긴다."
+    echo "- fix issue 가 해결되면 다음 dev 승격에서 새 snapshot 으로 재검증한다."
+    echo "- 인프라/렌더러 문제로 판단이 불가능하면 \`exec-report\` 라벨을 붙이고 필요한 사람 조치사항을 댓글로 남긴다."
+    echo ""
+    echo "### 하지 말 것"
+    echo ""
+    echo "- \`artifacts/mds-render\` 브랜치를 직접 수정하지 않는다."
+    echo "- PNG snapshot 을 \`dev-staging\`, \`dev\`, \`rc/*\`, \`main\` 에 커밋하지 않는다."
+    echo "- visual blocker 를 \`dev\` 에 직접 고치지 않는다. fix 는 항상 \`dev-staging\` 으로 들어간다."
+    echo ""
+    echo "<!-- minglit-mds-render-snapshot-diff"
+    echo "source_sha: ${SOURCE_SHA}"
+    echo "archive_branch: ${ARCHIVE_BRANCH}"
+    echo "snapshot_path: ${SNAPSHOT_PATH}"
+    echo "after_sha: ${AFTER_SHA}"
+    echo "run_id: ${GITHUB_RUN_ID}"
+    echo "-->"
+  } > "${BODY_FILE}"
+
+  if [ "${DRY_RUN}" = "true" ]; then
+    echo "## Dry run issue body: ${TITLE}"
+    cat "${BODY_FILE}"
+    continue
+  fi
+
+  EXISTING="$(gh issue list \
+    --repo "${GITHUB_REPOSITORY}" \
+    --search "\"${TITLE}\" in:title state:open" \
+    --json number \
+    --jq '.[0].number // empty')"
+
+  if [ -n "${EXISTING}" ]; then
+    gh issue comment "${EXISTING}" --repo "${GITHUB_REPOSITORY}" --body-file "${BODY_FILE}"
+    ISSUE_NUMBER="${EXISTING}"
+    echo "Updated existing issue #${ISSUE_NUMBER}: ${TITLE}"
+  else
+    ISSUE_URL="$(gh issue create \
+      --repo "${GITHUB_REPOSITORY}" \
+      --title "${TITLE}" \
+      --body-file "${BODY_FILE}" \
+      --label needs-arch \
+      --label automated \
+      --label P1-high)"
+    ISSUE_NUMBER="${ISSUE_URL##*/}"
+    echo "Created issue #${ISSUE_NUMBER}: ${TITLE}"
+  fi
+done

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -15,9 +15,9 @@
 | `pr-review-setup-` | PR 의 "리뷰 준비" 자동화 — auto-merge enable + 조건 충족 시 `needs-review` 라벨 부여 | `pr-review-setup` |
 | `deploy-` | 사용자·dev 환경에 코드·스키마·시드가 안 갔음 | `dev-deploy`, `main-deploy`, `deploy-vercel`, `deploy-supabase`, `deploy-dev-event-flow-cron`, `deploy-android-user`, `deploy-ios-user`, `deploy-dev-seed` |
 | `monitor-` | 운영·테스트 시스템 헬스 이상 / 스케줄 유지보수 | `monitor-dev-staging-health`, `monitor-dev-cuj`, `monitor-db-invariants`, `monitor-event-flow-distributed`, `monitor-event-flow-hourly`, `monitor-event-flow-daily`, `monitor-mds-render-coverage`, `monitor-patrol-e2e`, `monitor-allure`, `monitor-build-retention`, `monitor-security-advisor`, `monitor-doc-freshness` |
-| `sync-` | repo 에 자동 commit/push 가 실패함 (dev-staging push 또는 merge 기반) | `sync-graphify`, `sync-mds-mockups`, `sync-pr-branches`, `sync-test-coverage` |
+| `sync-` | repo 에 자동 commit/push 가 실패함 (dev-staging push 또는 merge 기반) | `sync-graphify`, `sync-mds-mockups`, `sync-mds-render-snapshot`, `sync-pr-branches`, `sync-test-coverage` |
 | `set-` | GitHub status/metadata 를 쓰는 수동·자동 API entrypoint 실패 | `set-dev-soak-status`, `set-rc-soak-status` |
-| `triage-` | 이슈 생성·슬래시 명령 (commit 없음) | `triage-mds-issue`, `triage-slash` |
+| `triage-` | 이슈 생성·슬래시 명령 (commit 없음) | `triage-mds-issue`, `triage-mds-render-snapshot-diff`, `triage-slash` |
 | `post-merge` | dev-staging push 직후 일반 PR flow follow-up 자동화의 단일 entry point | `post-merge` |
 | `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
 | `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy`, `shared-ios-deploy`, `shared-vercel-deploy`, `shared-set-commit-status`, `shared-soak-gate`, `shared-promo-tag`, `shared-pr-source-guard` |
@@ -35,6 +35,8 @@
 - `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 `shared-pr-source-guard` 로 직접 PR 을 차단한다. 정상 진입점은 `dev-staging` 이고, 예외는 branch별 approved hotfix 뿐이다.
 - `monitor-dev-staging-health` 는 required check 가 아니다. 6시간마다 `dev-staging` HEAD 에서 EF unit/integration 중심으로 nightly 전 회귀를 발견하고, 결과를 `dev-staging-health/*` commit status 로 남긴다.
 - `monitor-dev-cuj` 는 Flutter 모바일 동결(웹 MVP 피벗)로 disable 대상이다. 활성 시절에는 `dev` push 마다 user/partner CUJ 를 실행하고 `dev-soak/cuj-*` status 와 실패 이슈를 남겼다.
+- `sync-mds-render-snapshot` 은 `dev` push 마다 MDS emulator render PNG 를 `artifacts/mds-render/snapshots/dev/<sha>/` 에 commit/push 하고 `mds-render/snapshot` status 를 남긴다. PNG 변경이 있으면 `mds_render_snapshot_archived` repository dispatch 로 triage 를 깨운다. Source branch 에 PNG 를 커밋하지 않는다.
+- `triage-mds-render-snapshot-diff` 는 `mds_render_snapshot_archived` dispatch 의 artifact diff 를 감지해 AI visual review issue 를 만든다. 이 workflow 는 commit 하지 않는다.
 - `dev-staging-dev-cut-gate` 는 수동 candidate inspect 전용이며 per-merge mutation 을 하지 않는다. 날짜 기반 dev-staging version bump/tag 는 하루 1회 `dev-staging-dev-cut` 이 직접 수행한다.
 - `dev-staging-dev-cut` 은 release bot 으로 protected `dev-staging` 에 version bump commit 을 fast-forward push 하고 `vYY.MM.DD+YYMMDDNN-dev-staging` tag 를 만든 뒤, 해당 tag SHA 를 `dev` 로 promote 한다. `dev`/`rc`/`main` promotion 은 source-controlled version 변경 없이 처리한다.
 - `dev-rc-cut-gate` 는 cut 직전 evaluator 다. 내부에서 `shared-soak-gate` 를 호출해 legacy `dev-soak/*` health status 와 `deploy-dev-event-flow-cron` same-SHA run evidence 를 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다 (모바일 동결로 CUJ run requirement 는 제거, `dev-soak/cuj-*` failure 는 수동 block lever 로 유지).
@@ -78,4 +80,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — branch별 required check / auto-merge 흐름
 
 ---
-_Reviewed: 2026-06-04 07:16_
+_Reviewed: 2026-06-04 22:11_

--- a/.github/workflows/dev-rc-cut-gate.yml
+++ b/.github/workflows/dev-rc-cut-gate.yml
@@ -51,6 +51,11 @@ jobs:
         dev-soak/backend-simulator
         dev-soak/cuj-user
         dev-soak/cuj-partner
+        dev-soak/app-ai-review
+        mds-render/snapshot
+      required_success_contexts: |
+        mds-render/snapshot
+        dev-soak/app-ai-review
       success_contexts: |
         dev-soak/backend-simulator
       pass_context: dev-rc-cut-pass

--- a/.github/workflows/shared-soak-gate.yml
+++ b/.github/workflows/shared-soak-gate.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: ''
         description: 'Newline-separated commit status contexts to mark success when eligible.'
+      required_success_contexts:
+        type: string
+        required: false
+        default: ''
+        description: 'Newline-separated commit status contexts that must already be success.'
       pass_context:
         type: string
         required: true
@@ -98,6 +103,7 @@ jobs:
           INPUT_REQUIRED_RUNS_JSON: ${{ inputs.required_runs_json }}
           INPUT_FAILURE_CONTEXTS: ${{ inputs.failure_contexts }}
           INPUT_SUCCESS_CONTEXTS: ${{ inputs.success_contexts }}
+          INPUT_REQUIRED_SUCCESS_CONTEXTS: ${{ inputs.required_success_contexts }}
           INPUT_PASS_CONTEXT: ${{ inputs.pass_context }}
           INPUT_PASS_DESCRIPTION: ${{ inputs.pass_description }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
@@ -209,6 +215,14 @@ jobs:
               skip "${context} is failure on ${CANDIDATE_SHA}"
             fi
           done <<< "${INPUT_FAILURE_CONTEXTS}"
+
+          while IFS= read -r context; do
+            [ -z "${context}" ] && continue
+            state="$(jq -r --arg context "${context}" '.statuses[]? | select(.context == $context) | .state' <<< "${STATUS_JSON}" | head -n 1)"
+            if [ "${state}" != "success" ]; then
+              skip "${context} is ${state:-missing} on ${CANDIDATE_SHA}"
+            fi
+          done <<< "${INPUT_REQUIRED_SUCCESS_CONTEXTS}"
 
           TARGET_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           write_status() {

--- a/.github/workflows/sync-mds-render-snapshot.yml
+++ b/.github/workflows/sync-mds-render-snapshot.yml
@@ -246,6 +246,7 @@ jobs:
         run: bash .github/scripts/archive-mds-render-snapshot.sh
 
       - name: Mark snapshot success
+        id: mark-snapshot-success
         env:
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
           TARGET_SHA: ${{ needs.plan.outputs.target_sha }}
@@ -259,6 +260,60 @@ jobs:
             -f context=mds-render/snapshot \
             -f description="MDS snapshot archived (${PNG_COUNT} PNGs)" \
             -f target_url="${SNAPSHOT_URL}"
+
+      - name: Mark snapshot failure
+        if: failure() && steps.mark-snapshot-success.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          TARGET_SHA: ${{ needs.plan.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${TARGET_SHA}" \
+            --method POST \
+            -f state=failure \
+            -f context=mds-render/snapshot \
+            -f description="MDS render snapshot archive failed" \
+            -f target_url="${RUN_URL}"
+
+          title="[sync-mds-render-snapshot] archive failed for dev ${TARGET_SHA:0:8}"
+          body_file="$(mktemp)"
+          {
+            echo "Scheduler: sync-mds-render-snapshot"
+            echo ""
+            echo "## MDS render snapshot archive failure"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Source dev SHA | \`${TARGET_SHA}\` |"
+            echo "| Status context | \`mds-render/snapshot=failure\` |"
+            echo "| Workflow run | ${RUN_URL} |"
+            echo ""
+            echo "The render snapshot was not archived, so visual review evidence is unavailable for this dev SHA."
+            echo ""
+            echo "<!-- minglit-mds-render-snapshot-archive-failure"
+            echo "source_sha: ${TARGET_SHA}"
+            echo "run_id: ${GITHUB_RUN_ID}"
+            echo "-->"
+          } > "${body_file}"
+
+          existing="$(
+            gh issue list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --search "\"${title}\" in:title state:open" \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --repo "${GITHUB_REPOSITORY}" --body-file "${body_file}"
+          else
+            gh issue create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${title}" \
+              --body-file "${body_file}" \
+              --label automated \
+              --label P1-high
+          fi
 
       - name: Dispatch snapshot diff triage
         if: steps.archive.outputs.changed == 'true'

--- a/.github/workflows/sync-mds-render-snapshot.yml
+++ b/.github/workflows/sync-mds-render-snapshot.yml
@@ -1,0 +1,301 @@
+name: sync-mds-render-snapshot
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Optional dev commit SHA to render. Defaults to current dev HEAD.
+        required: false
+        type: string
+      dry_run:
+        description: Plan only; do not run emulator, push artifact branch, or write status.
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: sync-mds-render-snapshot-${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  statuses: write
+  issues: write
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      target_sha: ${{ steps.plan.outputs.target_sha }}
+      dry_run: ${{ steps.plan.outputs.dry_run }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Resolve target SHA
+        id: plan
+        env:
+          INPUT_TARGET_SHA: ${{ inputs.target_sha || '' }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run || false }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${INPUT_TARGET_SHA}" ]; then
+            TARGET_SHA="${INPUT_TARGET_SHA}"
+            git fetch origin dev --force
+            if ! git cat-file -e "${TARGET_SHA}^{commit}" 2>/dev/null; then
+              echo "::error::target_sha does not resolve to a commit: ${TARGET_SHA}"
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "${TARGET_SHA}" origin/dev; then
+              echo "::error::target_sha is not reachable from origin/dev: ${TARGET_SHA}"
+              exit 1
+            fi
+          else
+            TARGET_SHA="$(git rev-parse HEAD)"
+          fi
+
+          if [[ ! "${TARGET_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::target SHA must be a full 40-character commit SHA."
+            exit 1
+          fi
+
+          echo "target_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
+          echo "dry_run=${INPUT_DRY_RUN}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## sync-mds-render-snapshot plan"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| target_sha | \`${TARGET_SHA}\` |"
+            echo "| dry_run | ${INPUT_DRY_RUN} |"
+            echo "| artifact_branch | \`artifacts/mds-render\` |"
+            echo "| snapshot_path | \`snapshots/dev/${TARGET_SHA}/\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  render-capture:
+    needs: plan
+    if: needs.plan.outputs.dry_run != 'true'
+    name: render-capture-${{ matrix.app }}-shard-${{ matrix.shard_index }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [user, partner]
+        shard_index: [0, 1, 2, 3]
+
+    env:
+      APP_NAME: ${{ matrix.app }}
+      SHARD_INDEX: ${{ matrix.shard_index }}
+      SHARD_TOTAL: 4
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.target_sha }}
+          persist-credentials: false
+
+      - name: Create dev Flutter env file
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_DEV_URL }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+          ENVIRONMENT: development
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN_FLUTTER }}
+          STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_DEV_WEB_CLIENT_ID }}
+          KAKAO_LOCAL_REST_API_KEY: ${{ secrets.KAKAO_LOCAL_REST_API_KEY }}
+          KAKAO_MAP_JAVASCRIPT_KEY: ${{ secrets.KAKAO_MAP_JAVASCRIPT_KEY }}
+          JUSO_CONFIRM_KEY: ${{ secrets.JUSO_CONFIRM_KEY }}
+          IAMPORT_USER_CODE: ${{ secrets.IAMPORT_USER_CODE }}
+          MOBILE_REDIRECT_SCHEME: ${{ secrets.MOBILE_REDIRECT_SCHEME }}
+        run: bash .github/scripts/create-dev-flutter-env.sh
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.41.9'
+          cache: true
+
+      - name: Allow git access to Flutter SDK dir
+        run: |
+          FLUTTER_SDK="$(dirname "$(dirname "$(command -v flutter)")")"
+          git config --global --add safe.directory "$FLUTTER_SDK"
+
+      - name: Install dependencies
+        run: flutter pub get
+        working-directory: apps/app_${{ matrix.app }}
+
+      - name: Enable KVM acceleration
+        if: runner.environment == 'github-hosted'
+        run: |
+          sudo mkdir -p /etc/udev/rules.d
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules && sudo udevadm trigger --name-match=kvm
+
+      - name: Prepare empty render artifact directory
+        run: |
+          rm -rf docs/infra/mds-emulator-render
+          mkdir -p docs/infra/mds-emulator-render
+          touch docs/infra/mds-emulator-render/artifact-root.txt
+
+      - name: Run render shard on Android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          profile: pixel_6
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: true
+          script: bash .github/scripts/run-mds-render-shard.sh
+
+      - name: Upload render shard artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mds-render-snapshot-${{ matrix.app }}-shard-${{ matrix.shard_index }}
+          path: docs/infra/mds-emulator-render
+          if-no-files-found: warn
+          retention-days: 14
+
+  archive:
+    needs: [plan, render-capture]
+    if: always() && needs.plan.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      snapshot_url: ${{ steps.archive.outputs.snapshot_url }}
+      snapshot_path: ${{ steps.archive.outputs.snapshot_path }}
+      png_count: ${{ steps.archive.outputs.png_count }}
+      changed: ${{ steps.archive.outputs.changed }}
+      archive_commit: ${{ steps.archive.outputs.archive_commit }}
+      before_commit: ${{ steps.archive.outputs.before_commit }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.target_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Generate release bot token
+        id: release-bot
+        uses: ./.github/actions/release-bot-token
+        with:
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Mark snapshot pending
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          TARGET_SHA: ${{ needs.plan.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${TARGET_SHA}" \
+            --method POST \
+            -f state=pending \
+            -f context=mds-render/snapshot \
+            -f description="MDS render snapshot archiving" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+      - name: Check render shard result
+        if: needs.render-capture.result != 'success'
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          TARGET_SHA: ${{ needs.plan.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${TARGET_SHA}" \
+            --method POST \
+            -f state=failure \
+            -f context=mds-render/snapshot \
+            -f description="MDS render capture failed" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          exit 1
+
+      - name: Clean merged render artifact directory
+        run: |
+          rm -rf docs/infra/mds-emulator-render
+          mkdir -p docs/infra/mds-emulator-render
+
+      - name: Download render artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: mds-render-snapshot-*-shard-*
+          merge-multiple: true
+          path: docs/infra/mds-emulator-render
+
+      - name: Archive MDS render snapshot
+        id: archive
+        env:
+          TARGET_SHA: ${{ needs.plan.outputs.target_sha }}
+          RENDER_SOURCE_DIR: docs/infra/mds-emulator-render
+          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
+          ARCHIVE_BRANCH: artifacts/mds-render
+          SNAPSHOT_CHANNEL: dev
+        run: bash .github/scripts/archive-mds-render-snapshot.sh
+
+      - name: Mark snapshot success
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          TARGET_SHA: ${{ needs.plan.outputs.target_sha }}
+          SNAPSHOT_URL: ${{ steps.archive.outputs.snapshot_url }}
+          PNG_COUNT: ${{ steps.archive.outputs.png_count }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${TARGET_SHA}" \
+            --method POST \
+            -f state=success \
+            -f context=mds-render/snapshot \
+            -f description="MDS snapshot archived (${PNG_COUNT} PNGs)" \
+            -f target_url="${SNAPSHOT_URL}"
+
+      - name: Dispatch snapshot diff triage
+        if: steps.archive.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          TARGET_SHA: ${{ needs.plan.outputs.target_sha }}
+          BEFORE_SHA: ${{ steps.archive.outputs.before_commit }}
+          AFTER_SHA: ${{ steps.archive.outputs.archive_commit }}
+          SNAPSHOT_PATH: ${{ steps.archive.outputs.snapshot_path }}
+          SNAPSHOT_URL: ${{ steps.archive.outputs.snapshot_url }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg before_sha "${BEFORE_SHA}" \
+            --arg after_sha "${AFTER_SHA}" \
+            --arg source_sha "${TARGET_SHA}" \
+            --arg snapshot_path "${SNAPSHOT_PATH}" \
+            --arg snapshot_url "${SNAPSHOT_URL}" \
+            '{
+              event_type: "mds_render_snapshot_archived",
+              client_payload: {
+                before_sha: $before_sha,
+                after_sha: $after_sha,
+                source_sha: $source_sha,
+                snapshot_path: $snapshot_path,
+                snapshot_url: $snapshot_url
+              }
+            }' \
+            | gh api "repos/${GITHUB_REPOSITORY}/dispatches" \
+                --method POST \
+                --input -
+
+  dry-run:
+    needs: plan
+    if: needs.plan.outputs.dry_run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize dry run
+        run: |
+          echo "Dry run only. Skipped emulator render, artifact branch push, and mds-render/snapshot status write."

--- a/.github/workflows/triage-mds-render-snapshot-diff.yml
+++ b/.github/workflows/triage-mds-render-snapshot-diff.yml
@@ -1,0 +1,52 @@
+name: triage-mds-render-snapshot-diff
+
+on:
+  repository_dispatch:
+    types: [mds_render_snapshot_archived]
+  workflow_dispatch:
+    inputs:
+      before_sha:
+        description: Optional archive branch commit to diff from.
+        required: false
+        type: string
+      after_sha:
+        description: Optional archive branch commit to diff to. Defaults to current branch HEAD.
+        required: false
+        type: string
+      dry_run:
+        description: Print issue bodies only; do not create or update issues.
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: triage-mds-render-snapshot-diff-${{ github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - uses: actions/checkout@v6
+        with:
+          ref: artifacts/mds-render
+          fetch-depth: 0
+          path: archive
+
+      - name: Triage MDS render snapshot diff
+        working-directory: archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE_SHA: ${{ inputs.before_sha || github.event.client_payload.before_sha || '' }}
+          AFTER_SHA: ${{ inputs.after_sha || github.event.client_payload.after_sha || github.sha || '' }}
+          ARCHIVE_BRANCH: artifacts/mds-render
+          DRY_RUN: ${{ inputs.dry_run || false }}
+        run: bash ../.github/scripts/triage-mds-render-snapshot-diff.sh

--- a/.github/workflows/triage-mds-render-snapshot-diff.yml
+++ b/.github/workflows/triage-mds-render-snapshot-diff.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           BEFORE_SHA: ${{ inputs.before_sha || github.event.client_payload.before_sha || '' }}
-          AFTER_SHA: ${{ inputs.after_sha || github.event.client_payload.after_sha || github.sha || '' }}
+          AFTER_SHA: ${{ inputs.after_sha || github.event.client_payload.after_sha || '' }}
           ARCHIVE_BRANCH: artifacts/mds-render
           DRY_RUN: ${{ inputs.dry_run || false }}
         run: bash ../.github/scripts/triage-mds-render-snapshot-diff.sh

--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -15,6 +15,9 @@ flowchart LR
   npg --> dev[dev]
 
   dev --> dh[dev health / CUJ signals]
+  dev --> mds["MDS render snapshots"]
+  mds --> art["artifacts/mds-render"]
+  mds -. mds-render/snapshot .-> dh
   dh --> rg[dev-rc-cut-gate]
   monitor["monitor-event-flow-* batch"] -. dev-soak/backend-simulator .-> dev
   cuj["monitor-dev-cuj (frozen)"] -. "dev-soak/cuj-* (manual lever)" .-> dev
@@ -51,6 +54,7 @@ flowchart LR
 | dev-staging → dev cut | `dev-staging-dev-cut` + `dev-pr-gate` | daily cut 시점에 coherent snapshot 을 직접 bump/tag 하고 dev PR 로 promote |
 | dev → rc cut gate | `dev-rc-cut-gate` | dev health/CUJ status + dev cron install run 확인 후 `dev-rc-cut-pass` status 부여 |
 | dev deploy/validation | `dev-deploy` | dev 환경 deploy/validation orchestrator. 이벤트 플로우 시뮬레이터는 dev Supabase pg_cron 으로 별도 운영 |
+| dev visual evidence | `sync-mds-render-snapshot` | dev push SHA 기준 MDS PNG 를 `artifacts/mds-render` 에 저장하고 `mds-render/snapshot` status 제공 |
 | dev → rc cut | `dev-rc-cut` | latest `dev-rc-cut-pass` commit 에서 `rc/YYYY-Wxx` 생성 |
 | rc hotfix | dev-staging fix PR + `rc-pr-gate` | dev-staging 에 먼저 반영된 fix commit 을 active RC 로 cherry-pick/promote |
 | rc deploy/validation | `rc-deploy` | Supabase branching 기반 RC 검증 환경 구성 + pre-main validation |
@@ -107,6 +111,7 @@ flowchart LR
 - cut-gate Issue 는 사람이 진행 상태를 추적하기 위한 projection 이다. 생성/갱신/닫기는 `.github/actions/cut-issue` 와 `close-cut-issue-on-pr-merge` 가 담당하며, promotion 판정 SSOT 로 사용하지 않는다
 - 일반 작업 PR 은 dev-staging 에서 squash 로 정리한다. Branch promotion PR 은 source branch ancestry 보존을 위해 merge commit 을 사용하며, dev/rc/main 에 linear history 를 강제하지 않는다
 - Protected branch 직접 push 는 human 금지. dev-staging daily cut version bump, promotion branch/tag, RC cleanup 은 `minglit-release-bot` 전용 token + Ruleset bypass 로만 허용
+- MDS render PNG 는 source branch 에 커밋하지 않는다. dev push SHA 의 visual evidence 는 `artifacts/mds-render/snapshots/dev/<sha>/` 에 저장하고 `mds-render/snapshot` + `dev-soak/app-ai-review` status 로 소비한다
 - `deploy-dev-event-flow-cron` 은 `dev` push 에서만 `dev-event-flow-simulator` pg_cron 을 설치한다. `monitor-event-flow-*` 는 수동 smoke 이며, RC cron 은 RC project 준비 후 별도 설치한다
 - main 머지 = backend + mobile 모두 prod deploy. backend prod deploy 는 `main-deploy` 에서 한 번에 수행한다
 - 소스 파일 version bump 는 `dev-staging-dev-cut` 이 promote 할 dev-staging snapshot 에만 남긴다. release bot 이 protected `dev-staging` 에 직접 bump commit 을 fast-forward push 하고, 날짜 버전(`YY.MM.DD`) + snapshot build number(`YYMMDDNN`) tag 를 붙인다. `dev`/`rc`/`main` 은 branch state 를 바꾸지 않고 deploy workflow 가 metadata 를 build-time 에 주입한다
@@ -132,4 +137,4 @@ Promotion PR 제목은 workflow 이름과 source artifact 를 앞에 둔다. PR 
 RC cut 의 source-of-truth status 이름은 **`dev-rc-cut-pass`** 이다. `rc-eligible` 은 workflow/status 명칭으로 쓰지 않으며, 새 이름으로 바꾸려면 `dev-rc-cut-gate`, `dev-rc-cut`, `main-pr-gate`, 문서 전체를 같은 PR 에서 일괄 변경한다.
 
 ---
-_Reviewed: 2026-06-03 15:15_
+_Reviewed: 2026-06-04 22:11_

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -9,7 +9,9 @@
                               │
                               └─daily dev-staging-dev-cut merge-commit snapshot PR──▶ dev
                                                               │
-                                                              ├─▶ dev push health/deploy + daily dev-rc-cut-gate
+                                                              ├─▶ dev push health/deploy + MDS render snapshot + daily dev-rc-cut-gate
+                                                              │      │
+                                                              │      ├─ visual evidence: artifacts/mds-render/snapshots/dev/<sha>/
                                                               │      │
                                                               │      ├─ pass: status dev-rc-cut-pass
                                                               │      │         │
@@ -64,8 +66,23 @@ RC hotfix 는 dev-staging-first 가 기본이다. active RC 에만 먼저 들어
 | `dev` | 금지 | **OFF** | `dev-pr-gate` | merge commit for promotion |
 | `rc/YYYY-Wxx` | 금지 | **OFF** | `rc-pr-gate` | approved hotfix merge |
 | `main` | 금지 (release bot 예외) | **OFF** | `main-pr-gate` | merge commit for promotion |
+| `artifacts/mds-render` | workflow only | n/a | n/a | SHA-bound PNG archive, not a promotion branch |
 
 Global linear history 정책은 폐기한다. 일반 작업 PR 은 `dev-staging` 에서 squash 로 정리하고, branch promotion PR 은 source branch ancestry 를 보존하기 위해 merge commit 을 사용한다. Protected branch 직접 push 는 `minglit-release-bot` 의 dev-staging version bump, promotion branch/tag, RC cleanup 에만 Ruleset bypass 로 허용한다.
+
+## Artifact Branch
+
+`artifacts/mds-render` 는 source branch 가 아니라 Git-backed visual evidence archive 다.
+
+| 규칙 | 내용 |
+|------|------|
+| canonical path | `snapshots/dev/<dev-sha>/<screen>/state-*.png` |
+| writer | dev push 후 MDS render snapshot workflow |
+| consumer | `triage-mds-render-snapshot-diff`, AI visual review / human audit |
+| status | source dev SHA 의 `mds-render/snapshot` |
+| 금지 | `dev-staging`, `dev`, `rc/*`, `main` 에 PNG snapshot 커밋 |
+
+`triage-mds-render-snapshot-diff` 는 snapshot PNG diff 가 생기면 AI visual review issue 를 만든다. AI visual review 가 blocker 를 찾으면 `dev-soak/app-ai-review=failure` 를 쓰고, fix 는 일반 flow 처럼 `dev-staging` PR 로 들어간다.
 
 ## Promotion Tag 컨벤션
 
@@ -101,6 +118,11 @@ monitor-dev-cuj:  # disabled (web-mvp pivot — Flutter CUJ 동결)
   trigger: manual dispatch only
   branch: dev
   purpose: (legacy) user/partner CUJ health signal
+
+sync-mds-render-snapshot:
+  trigger: push to dev
+  branch: dev
+  purpose: MDS render PNG archive + mds-render/snapshot status
 ```
 
 ### main push → prod deploy chain
@@ -121,7 +143,7 @@ main-deploy (on push to main):
 
 상세: [specs/workflow-spec.md](./specs/workflow-spec.md).
 
-Mobile APK/AAB/IPA archive 는 GitHub Release asset 이 canonical 이다. Actions artifact 는 workflow 실패 분석용 테스트 리포트/스크린샷/로그 같은 단기 디버깅 산출물에만 사용한다.
+Mobile APK/AAB/IPA archive 는 GitHub Release asset 이 canonical 이다. Actions artifact 는 workflow 실패 분석용 테스트 리포트/스크린샷/로그 같은 단기 디버깅 산출물에만 사용한다. MDS render PNG 처럼 SHA-bound visual evidence 로 재조회해야 하는 산출물은 `artifacts/mds-render` branch 에 보존한다.
 
 ## Safety Nets 위치
 
@@ -142,4 +164,4 @@ Mobile APK/AAB/IPA archive 는 GitHub Release asset 이 canonical 이다. Action
 - [promotion-contract.md](./promotion-contract.md) — 승격 정책 + concrete marker/failure contract
 
 ---
-_Reviewed: 2026-05-24 10:24_
+_Reviewed: 2026-06-04 22:11_

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -1,14 +1,16 @@
 # Dev Pipeline
 
-`dev` 브랜치가 integration-health trunk 역할: dev-staging 의 daily snapshot 을 받고, 새 dev commit 마다 health/CUJ signal 을 기록한다. `dev-rc-cut-gate` 는 commit status 와 dev cron install signal 을 평가해 `dev-rc-cut-pass` 를 쓰고, RC 는 그 status 를 보고 cut 한다. 이벤트 플로우 시뮬레이터는 dev Supabase pg_cron 으로 계속 돌며, backend prod deploy 는 main 머지 후 `main-deploy` 에서 수행한다.
+`dev` 브랜치가 integration-health trunk 역할: dev-staging 의 daily snapshot 을 받고, 새 dev commit 마다 health/MDS visual signal 을 기록한다. Flutter CUJ 는 web-mvp pivot 으로 동결되어 수동 block lever 로만 남는다. `dev-rc-cut-gate` 는 commit status 와 dev cron install signal 을 평가해 `dev-rc-cut-pass` 를 쓰고, RC 는 그 status 를 보고 cut 한다. 이벤트 플로우 시뮬레이터는 dev Supabase pg_cron 으로 계속 돌며, backend prod deploy 는 main 머지 후 `main-deploy` 에서 수행한다.
 
 ## 주요 workflow
 
 1. **`dev-staging-dev-cut`** — daily cron, dev-staging tip 을 직접 bump/tag 한 뒤 그 snapshot 으로 PR 생성
 2. **`dev-pr-gate`** — snapshot PR 머지 전 검증 (defensive)
 3. **`monitor-dev-cuj`** (동결 — web-mvp pivot) — disable 됨. `dev-soak/cuj-*` 는 `set-dev-soak-status` 수동 블락 레버로만 유지
-4. **`dev-rc-cut-gate`** — cut 직전 evaluator. dev health status + cron install run 확인 후 `dev-rc-cut-pass` set
-5. **`dev-deploy` / cron install** — dev 환경 deploy/smoke 가 필요할 때 수행. 이벤트 플로우 시뮬레이터는 dev pg_cron 으로 별도 운영
+4. **`sync-mds-render-snapshot`** — dev push 마다 MDS emulator render PNG 를 `artifacts/mds-render` 에 SHA-bound 저장하고 `mds-render/snapshot` status 기록
+5. **AI visual review** — `artifacts/mds-render` 의 dev SHA snapshot 을 MDS spec 과 비교하고 `dev-soak/app-ai-review` 기록
+6. **`dev-rc-cut-gate`** — cut 직전 evaluator. dev health status + cron install run 확인 후 `dev-rc-cut-pass` set
+7. **`dev-deploy` / cron install** — dev 환경 deploy/smoke 가 필요할 때 수행. 이벤트 플로우 시뮬레이터는 dev pg_cron 으로 별도 운영
 
 ## `dev-staging-dev-cut`
 
@@ -54,6 +56,7 @@ GitHub Issue 는 source-of-truth 가 아니다. Gate 판정은 commit status con
 | `dev-soak/backend-simulator` | `event-flow-simulator` reporter 또는 `deploy-dev-event-flow-cron` 실패 path | `dev-rc-cut-gate` |
 | `dev-soak/cuj-user` | `set-dev-soak-status` (manual; `monitor-dev-cuj` 동결) | manual |
 | `dev-soak/cuj-partner` | `set-dev-soak-status` (manual; `monitor-dev-cuj` 동결) | manual |
+| `mds-render/snapshot` | `sync-mds-render-snapshot` | `sync-mds-render-snapshot` |
 | `dev-soak/real-device` | real-device/Test Lab workflow 또는 AI agent | `dev-rc-cut-gate` |
 | `dev-soak/app-ai-review` | AI agent | `dev-rc-cut-gate` |
 | `dev-rc-cut-pass` | 없음 | `dev-rc-cut-gate` |
@@ -68,9 +71,10 @@ GitHub Issue 는 source-of-truth 가 아니다. Gate 판정은 commit status con
 |------|------|
 | Event-flow distributed simulator | candidate SHA 에서 `deploy-dev-event-flow-cron` success >= 1 + `dev-soak/backend-simulator` failure 없음 |
 | CUJ (동결 — web-mvp pivot) | run 요구 제거. `dev-soak/cuj-user` / `dev-soak/cuj-partner` failure 없음만 확인 (수동 블락 레버) |
+| MDS render snapshot | candidate SHA 에서 `mds-render/snapshot=success` + `artifacts/mds-render/snapshots/dev/<sha>/` 저장 완료 |
 | Legacy hourly/daily simulator | 수동 smoke 전용. RC cut gate 조건에서 제외 |
 | Real device | candidate 기준 required real-device signal success >= 1 (workflow TBD) |
-| App AI review | AI agent 가 candidate 기준 app-soak pass signal 제공 (입력 방식 TBD) |
+| App AI review | AI agent 가 candidate 기준 `artifacts/mds-render` snapshot 을 비교하고 `dev-soak/app-ai-review` pass signal 제공 |
 | Failure status | `dev-soak/*` context 의 최신 state 가 `failure` 가 아니어야 함 |
 | Positive evidence | required run history 와 required signal success 가 모두 존재해야 함. 미존재는 pass 가 아니라 unknown |
 
@@ -91,6 +95,7 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 
 - Status 미부여 (`dev-rc-cut-pass` 없음 → dev-rc-cut 이 이 commit 안 골라잡음)
 - 실패를 발견한 monitor/AI agent 가 `dev-soak/*` failure status 를 즉시 작성
+- MDS render 저장 실패는 `mds-render/snapshot=failure`, visual blocker 는 `dev-soak/app-ai-review=failure`
 - `shared-notify` 가 release-blocker issue 를 생성/갱신하되, issue 상태는 gate 판정 source-of-truth 로 쓰지 않음
 - 자동 이슈 + `P1-high` 라벨 + 직전 `dev-rc-cut-pass` 이후 머지된 PR 작성자들 assignee (AI agent 포함)
 - AI agent 가 fix PR 을 dev-staging 으로 작성 → dev-staging-pr-gate → 다음 dev-staging-dev-cut → 다음 dev-rc-cut-gate 가 검증
@@ -128,16 +133,27 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 - release promotion 과 독립적으로 계속 돈다
 - RC 에서는 main 배포 전 pre-main validation signal 로 사용한다
 
+### `sync-mds-render-snapshot`
+
+- `push` to `dev` 의 promoted SHA 를 기준으로 MDS emulator render 를 실행한다.
+- PNG 는 source branch 에 커밋하지 않고 `artifacts/mds-render` branch 의 `snapshots/dev/<dev-sha>/` 에만 커밋한다.
+- 해당 dev SHA 에 `mds-render/snapshot` status 를 쓴다. `target_url` 은 artifact branch/path 또는 workflow summary 를 가리킨다.
+- PNG diff 가 있으면 `sync-mds-render-snapshot` 이 `mds_render_snapshot_archived` repository dispatch 를 보내고, `triage-mds-render-snapshot-diff` 가 review issue 를 만든다.
+- AI visual review agent 는 이 branch 를 fetch 해 MDS spec PNG 와 비교한다. 확정 blocker 는 finding 당 별도 fix issue 로 만들고 `dev-soak/app-ai-review=failure` 를 기록한다. blocker 가 없으면 `dev-soak/app-ai-review=success` 를 기록한다.
+- 발견된 visual blocker/fix 는 모두 `dev-staging` PR 로 처리한다. `dev` 에 PNG/fix commit 을 직접 만들지 않는다.
+
 ## Artifact / 보존
 
 - 실패한 monitor/soak workflow: 30일 (스크린샷, 로그, APK)
 - 성공한 `dev-rc-cut-gate` evaluator run: 7일
+- MDS render PNG: `artifacts/mds-render` branch 에 SHA-bound path 로 영구 보존. Actions artifact 는 디버깅 보조용
 
 ## 결정해야 할 것
 
 - dev-staging-dev-cut cron 시각
 - backoff 임계 (3회 차단이 적정한가)
 - real-device/app AI review status writer 구현 방식
+- `sync-mds-render-snapshot` branch push/retry 구현 방식
 - `shared-notify` 의 release signal metadata/log tail 확장
 - Supabase RC branch TTL / seed data 정책
 
@@ -150,4 +166,4 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 - [branch-flow.md](./branch-flow.md) — workflow chain 그림
 
 ---
-_Reviewed: 2026-05-24 10:24_
+_Reviewed: 2026-06-04 22:11_

--- a/docs/infra/branch-strategy/dev-soak-status-model.md
+++ b/docs/infra/branch-strategy/dev-soak-status-model.md
@@ -10,6 +10,7 @@
 |--------|------|-----------|
 | Commit status | dev health failure/pass marker. `dev-rc-cut-gate` 가 직접 판정에 사용 | yes |
 | Workflow run history | monitor 가 실제로 돌았는지 확인 | yes |
+| `artifacts/mds-render` branch | dev SHA 별 MDS render PNG 보관 위치. status `target_url`/AI review 입력으로 사용 | no (evidence archive) |
 | GitHub Issue | 로그, 담당, 원인, 후속 조치 기록 | no |
 | GitHub label | 사람이 보는 분류/필터 | no |
 
@@ -38,6 +39,8 @@ Workflow 와 AI agent 는 commit status context 를 직접 하드코딩하지 �
 | `set-rc-soak-status` | public API (`workflow_call` + `workflow_dispatch`) | `signal` 을 `rc-soak/*` context 로 매핑한 뒤 `shared-set-commit-status` 호출 |
 
 외부 consumer 는 `shared-set-commit-status` 를 직접 호출하지 않는다. 공통 writer 는 context 를 검증하지 않는 low-level primitive 이므로, 사람이 직접 쓰면 stage/signal naming 을 우회할 수 있다.
+
+`mds-render/snapshot` 은 `dev-soak/*` signal 이 아니라 render archive availability status 다. writer 는 `sync-mds-render-snapshot` 이며, `target_url` 은 `artifacts/mds-render/snapshots/dev/<sha>/` 또는 workflow summary 를 가리킨다.
 
 ### `set-dev-soak-status`
 
@@ -92,8 +95,9 @@ RC soak 는 dev soak 와 signal set 이 달라질 수 있으므로 별도 entry 
 | `dev-soak/backend-simulator` | `event-flow-simulator` reporter / `dev-rc-cut-gate` | event-flow simulator 실패 즉시 `failure` | `dev-rc-cut-gate` 가 cron install run 을 확인한 뒤 `success` | backend/event-flow health signal |
 | `dev-soak/cuj-user` | `set-dev-soak-status` (manual; `monitor-dev-cuj` 동결 — web-mvp pivot) | 수동 블락 시 `failure` | required evidence 아님 — gate 는 failure 부재만 확인 | manual block lever (legacy: user app CUJ signal) |
 | `dev-soak/cuj-partner` | `set-dev-soak-status` (manual; `monitor-dev-cuj` 동결 — web-mvp pivot) | 수동 블락 시 `failure` | required evidence 아님 — gate 는 failure 부재만 확인 | manual block lever (legacy: partner app CUJ signal) |
+| `mds-render/snapshot` | `sync-mds-render-snapshot` | MDS render 또는 artifact branch 저장 실패 즉시 `failure` | same-SHA PNG 가 `artifacts/mds-render/snapshots/dev/<sha>/` 에 저장되면 `success` | AI visual review 의 screenshot evidence availability |
 | `dev-soak/real-device` | `set-dev-soak-status` via real-device workflow / `dev-rc-cut-gate` | Firebase Test Lab 또는 실디바이스 smoke 실패 즉시 `failure` | `dev-rc-cut-gate` 가 required run/signal 을 확인한 뒤 `success` | 실제 디바이스 안정성 signal |
-| `dev-soak/app-ai-review` | `set-dev-soak-status` via AI agent / `dev-rc-cut-gate` | AI/human 앱 review 중 blocker 발견 즉시 `failure` | `dev-rc-cut-gate` 가 AI review pass signal 을 확인한 뒤 `success` | screenshot/UX/manual-ish app review signal |
+| `dev-soak/app-ai-review` | `set-dev-soak-status` via AI agent / `dev-rc-cut-gate` | confirmed visual blocker 발견 즉시 `failure` | AI review 가 blocker 없음 확인 또는 `dev-rc-cut-gate` 확인 뒤 `success` | `artifacts/mds-render` 기반 screenshot/UX/manual-ish app review signal |
 | `dev-rc-cut-pass` | `dev-rc-cut-gate` | 작성하지 않음 | 모든 required dev health 조건 통과 시 `success` | RC cut source marker |
 
 실패 status 는 발견 즉시 찍는다. `dev-rc-cut-gate` 는 required run history 와 failure context 부재를 확인한 뒤 필요한 `dev-soak/*` success confirmation 과 `dev-rc-cut-pass` 를 쓴다. (`monitor-dev-cuj` 의 CUJ status 자동 기록은 web-mvp pivot 으로 동결 — [web-mvp-pivot.md](../../architecture/web-mvp-pivot.md))
@@ -132,9 +136,10 @@ Issue label 은 분류용이다. Gate 판정에는 사용하지 않는다.
 |--------|-----------|
 | `deploy-dev-event-flow-cron` | candidate SHA 에서 `success` run >= 1 |
 | ~~`monitor-dev-cuj`~~ (동결) | web-mvp pivot 으로 required run 에서 제외. 웹 MVP smoke/CUJ 신호로 대체 예정 |
+| `sync-mds-render-snapshot` | candidate SHA 에서 `mds-render/snapshot=success` + `artifacts/mds-render/snapshots/dev/<sha>/` 존재 |
 | legacy `monitor-event-flow-hourly/daily` | 수동 smoke 전용. gate run requirement 에서 제외 |
 | real-device smoke | candidate 기준 required run/signal success >= 1 (workflow 이름 TBD) |
-| app AI review | AI agent 가 candidate 기준 pass signal 제공 (workflow/status 입력 방식 TBD) |
+| app AI review | AI agent 가 candidate 의 MDS render snapshot 을 비교하고, blocker 없음은 success, confirmed blocker 는 failure 로 status 제공 |
 
 예시 조회:
 
@@ -195,9 +200,11 @@ blocks_rc_cut: true
    - `dev-soak/backend-simulator`
    - `dev-soak/cuj-user`
    - `dev-soak/cuj-partner`
+   - `mds-render/snapshot` (app AI review 가 required 인 경우)
    - `dev-soak/real-device`
    - `dev-soak/app-ai-review`
-4. 모두 통과하면 각 required `dev-soak/*` status 를 `success` 로 찍고 `dev-rc-cut-pass` 를 `success` 로 찍는다
+4. required MDS snapshot/run evidence 가 있으면 AI review 는 해당 snapshot 을 소비한다
+5. 모두 통과하면 각 required `dev-soak/*` status 를 `success` 로 찍고 `dev-rc-cut-pass` 를 `success` 로 찍는다
 
 실패 또는 미충족 시 `dev-rc-cut-pass` 는 쓰지 않는다.
 
@@ -208,10 +215,11 @@ Commit status 를 직접 관리하는 actor 는 GitHub App token 을 사용한�
 | Actor | 필요 권한 |
 |-------|-----------|
 | `shared-notify` / monitor workflows | Commit statuses: read/write, Issues: read/write |
+| `sync-mds-render-snapshot` | Contents: read/write on `artifacts/mds-render`, Commit statuses: read/write, Issues: read/write |
 | AI agent status writer | Commit statuses: read/write, Issues: read/write |
 | `dev-rc-cut-gate` | Commit statuses: read/write, Actions: read, Contents: read |
 
 Human 은 로컬에서 release bot token 을 사용하지 않는다. AI agent 가 app soak failure/pass 를 기록할 때도 같은 status context naming 을 따라야 한다.
 
 ---
-_Reviewed: 2026-05-24 13:05_
+_Reviewed: 2026-06-04 22:11_

--- a/docs/infra/branch-strategy/error-detection.md
+++ b/docs/infra/branch-strategy/error-detection.md
@@ -9,8 +9,8 @@
 | 개발자 로컬 | LSP, analyze, unit | 컴파일/타입/단위 | 초~분 |
 | dev-staging PR gate | `dev-staging-pr-gate` (unit, lint, pgTAP, EF, migration, `expand-migrate-contract`, `flag-registration`, gitleaks) | PR 회귀, 보안, migration 충돌, flag 미등록, contract 위반 | < 10분 |
 | dev-staging-dev-cut PR | `dev-pr-gate` (defensive) | 환경 차이 회귀 | < 10분 |
-| dev health | `deploy-dev-event-flow-cron`, real-device workflow, AI app review status writer via `set-dev-soak-status` (`monitor-dev-cuj` 동결 — web-mvp pivot) | backend simulator, 외부 의존, 디바이스, UX/blocker | 즉시~분 |
-| RC cut 직전 | `dev-rc-cut-gate` evaluator | required dev health evidence 미충족, `dev-soak/*` failure status, monitor 미실행 | 분 |
+| dev health | `deploy-dev-event-flow-cron`, `sync-mds-render-snapshot`, real-device workflow, AI app review status writer via `set-dev-soak-status` (`monitor-dev-cuj` 동결 — web-mvp pivot) | backend simulator, visual regression, 외부 의존, 디바이스, UX/blocker | 즉시~분 |
+| RC cut 직전 | `dev-rc-cut-gate` evaluator | required dev health evidence 미충족, `mds-render/snapshot`/`dev-soak/*` failure status, monitor 미실행 | 분 |
 | Backend/Web deploy validation | post-deploy smoke, Sentry release marker | deploy infra 회귀 | 분 |
 | rc soak (5일) | rc 의 nightly 재실행 + 내부 dogfooding | 누적 회귀, real-data 이슈 | 일 단위 |
 | main 머지 후 (auto-deploy) | smoke + Sentry/Crashlytics 알람 임계 | prod 회귀 | 분 |
@@ -55,6 +55,7 @@
 | Detection 신호 | 누가 받음 | 어디서 | Action |
 |---------------|----------|--------|--------|
 | pr-gate 실패 (어느 단계든) | PR 작성자 | GitHub PR | 본인 fix → re-push → auto-merge 재대기 |
+| `mds-render/snapshot` failure status | release manager / AI agent | commit status + GitHub issue | render infra 또는 app render 문제 확인. fix 는 dev-staging PR 로 처리 |
 | `dev-soak/*` failure status | 직전 dev-rc-cut-pass 이후 머지된 PR 작성자들 + AI agent | commit status + GitHub issue + Slack `#nightly` | AI agent fix PR via dev-staging — dev keeps moving ([dev-pipeline.md](./dev-pipeline.md)) |
 | `dev-rc-cut-gate` evaluator 미충족 | release manager / AI agent | GitHub Actions run summary | RC cut 보류. failure status 또는 monitor run history 부족 원인 확인 |
 | Backend/web deploy validation 실패 | on-call | Slack `#release` | retry → P0 이슈, 해당 promotion/deploy 진행 차단 |
@@ -89,4 +90,4 @@
 - [../firebase/BLUEDOC.md](../firebase/BLUEDOC.md), [../statsig/BLUEDOC.md](../statsig/BLUEDOC.md)
 
 ---
-_Reviewed: 2026-05-19 09:47_
+_Reviewed: 2026-06-04 22:11_

--- a/docs/infra/branch-strategy/promotion-contract.md
+++ b/docs/infra/branch-strategy/promotion-contract.md
@@ -13,6 +13,8 @@
 
 승격 PR 은 source ancestry 보존을 위해 merge commit 을 사용한다. 일반 작업 PR 은 `dev-staging` 에서 squash merge 한다. `dev`, `rc/*`, `main` 직접 PR 은 promotion 또는 승인된 hotfix 만 허용한다.
 
+MDS render PNG 는 source branch 에 커밋하지 않는다. 영구 보존이 필요한 visual evidence 는 전용 branch `artifacts/mds-render` 에 SHA-bound path 로 저장하고, 해당 source SHA 의 commit status 가 그 위치를 가리킨다.
+
 ## Promotion Edges
 
 | Edge | Entry workflow | Source | Target | Merge / mutation |
@@ -30,11 +32,13 @@
 |--------|------|--------|----------|---------|
 | `vYY.MM.DD+YYMMDDNN-dev-staging` | git tag | `dev-staging-dev-cut` | dev promotion, deploy metadata | coherent dev-staging snapshot |
 | `dev-staging-health/*` | commit status | `monitor-dev-staging-health` | human/AI triage only | early regression signal, not a promotion gate |
+| `artifacts/mds-render` | git branch | `sync-mds-render-snapshot` | AI visual review, human audit, `triage-mds-render-snapshot-diff` | source branch 밖의 MDS render PNG archive |
+| `mds-render/snapshot` | commit status | `sync-mds-render-snapshot` | AI visual review, `dev-rc-cut-gate` when visual review is required | dev SHA 의 render snapshot 저장/조회 가능 여부 |
 | `dev-soak/backend-simulator` | commit status | `deploy-dev-event-flow-cron`, simulator reporter, `dev-rc-cut-gate` | `dev-rc-cut-gate` | legacy-named dev health signal |
 | `dev-soak/cuj-user` | commit status | `set-dev-soak-status` (manual; `monitor-dev-cuj` 동결) | `dev-rc-cut-gate` | manual block lever — failure 만 소비, success 는 required evidence 아님 |
 | `dev-soak/cuj-partner` | commit status | `set-dev-soak-status` (manual; `monitor-dev-cuj` 동결) | `dev-rc-cut-gate` | manual block lever — failure 만 소비, success 는 required evidence 아님 |
 | `dev-soak/real-device` | commit status | real-device workflow / AI agent | `dev-rc-cut-gate` | device smoke signal |
-| `dev-soak/app-ai-review` | commit status | AI agent / human-assisted review | `dev-rc-cut-gate` | app UX/blocker review signal |
+| `dev-soak/app-ai-review` | commit status | AI agent / human-assisted review | `dev-rc-cut-gate` | confirmed visual blocker/pass signal, normally consuming `artifacts/mds-render` snapshots |
 | `dev-rc-cut-pass` | commit status | `dev-rc-cut-gate` | `dev-rc-cut`, `main-pr-gate` | RC cut source marker |
 | `promo/rc-YYYY-Wxx` | git tag | `dev-rc-cut` | release audit/deploy metadata | RC branch creation marker |
 | `rc-soak/*` | commit status | RC monitor/dogfooding workflows | `rc-main-cut-gate` | RC soak/pre-main signal |
@@ -52,7 +56,7 @@ Release gate 는 true evidence 기반이다. 실패 이슈가 없다는 사실�
 | Gate | Required success evidence | Blocking evidence |
 |------|---------------------------|-------------------|
 | `dev-pr-gate` | reusable `pr-gate` success + source guard success | source guard failure, PR gate failure |
-| `dev-rc-cut-gate` | same-SHA `deploy-dev-event-flow-cron` success, no required `dev-soak/*` failure status (Flutter CUJ run 요구는 web-mvp pivot 으로 제거) | any required `dev-soak/*=failure`, missing required success evidence, infra failure |
+| `dev-rc-cut-gate` | same-SHA `deploy-dev-event-flow-cron` success, required real-device/app AI review evidence, no required `dev-soak/*` failure status (Flutter CUJ run 요구는 web-mvp pivot 으로 제거) | any required `dev-soak/*=failure`, `mds-render/snapshot=failure` when visual review is required, missing required success evidence, infra failure |
 | `rc-pr-gate` | reusable `pr-gate` success + source guard success | RC-only unapproved source, PR gate failure |
 | `rc-main-cut-gate` | RC age >= 5 days since last RC commit, required `rc-soak/*` success, pre-main validation success, dev-staging-first hotfix lineage | `rc-soak/*=failure`, hotfix lineage violation, missing evidence, age not met |
 | `main-pr-gate` | reusable `pr-gate` success, RC lineage contains `dev-rc-cut-pass=success`, RC HEAD has `rc-main-cut-pass=success` and PR label | missing lineage marker, missing RC marker, PR gate failure |
@@ -65,6 +69,8 @@ Release gate 는 true evidence 기반이다. 실패 이슈가 없다는 사실�
 | `monitor-dev-staging-health` fails | set `dev-staging-health/*=failure`, create/update issue | AI fix PR to `dev-staging` | does not directly block promotion |
 | `dev-pr-gate` fails on promotion PR | promotion PR stays open/failed | fix in `dev-staging`, rerun or regenerate cut | dev does not advance |
 | `dev-soak/cuj-*=failure` set manually (`set-dev-soak-status`; `monitor-dev-cuj` 는 동결) | create/update issue | fix PR to `dev-staging`, next `dev-staging-dev-cut` creates new dev commit | `dev-rc-cut-gate` must not write `dev-rc-cut-pass` |
+| `sync-mds-render-snapshot` fails on dev push | set `mds-render/snapshot=failure`, create/update infra issue | fix workflow/render infra or app render issue via `dev-staging` | visual review cannot pass; `dev-rc-cut-gate` blocks if app AI review is required |
+| AI visual review finds blocker | set `dev-soak/app-ai-review=failure`, create one fix issue per confirmed finding | AI fix PR to `dev-staging`, next `dev-staging-dev-cut` creates new dev commit | `dev-rc-cut-gate` must not write `dev-rc-cut-pass` |
 | `deploy-dev-event-flow-cron` or simulator fails | set `dev-soak/backend-simulator=failure`, create/update issue | AI fix PR to `dev-staging` | `dev-rc-cut-gate` blocks RC eligibility |
 | `dev-rc-cut-gate` missing evidence | no pass marker; cut issue stays waiting | required monitor/status writer reruns or fix PR lands | `dev-rc-cut` skips this commit |
 | `dev-rc-cut` cannot find pass commit | skip and alert if prolonged | run/fix `dev-rc-cut-gate` evidence | no RC branch cut |
@@ -87,6 +93,34 @@ No automatic revert is part of the normal contract. Broken `dev` keeps moving th
 |----------|---------|--------|
 | `monitor-dev-cuj` (disabled) | ~~`push` to `dev`~~, manual dispatch | `dev-soak/cuj-user`, `dev-soak/cuj-partner`, CI issue with failed CUJ file list |
 
+## MDS Render Snapshot Contract
+
+MDS render snapshots are dev health evidence, not source code. The promoted `dev` SHA is the canonical visual candidate.
+
+| Item | Contract |
+|------|----------|
+| Source | latest promoted `dev` commit SHA |
+| Storage branch | `artifacts/mds-render` |
+| Storage path | `snapshots/dev/<dev-sha>/<screen>/state-*.png` |
+| Status | `mds-render/snapshot` on the same `dev` SHA |
+| Consumer | AI visual review / human audit |
+| Fix path | fix PR to `dev-staging`; never commit PNG or fixes directly to `dev` |
+
+Workflow:
+
+1. `dev-staging-dev-cut` promotes a source snapshot to `dev`.
+2. `push` to `dev` triggers the MDS render snapshot writer.
+3. The writer renders emulator PNGs for the promoted `dev` SHA and commits them only to `artifacts/mds-render`.
+4. The writer sets `mds-render/snapshot=success` with a target URL/path to `snapshots/dev/<dev-sha>/`; on failure it sets `failure` and files an issue.
+5. If the artifact commit changed PNGs, the writer dispatches `mds_render_snapshot_archived`; `triage-mds-render-snapshot-diff` runs from the default branch and files a visual review issue when PNG diffs are present.
+6. The AI visual review agent fetches `artifacts/mds-render`, compares `snapshots/dev/<dev-sha>/` against MDS spec assets, and triages findings.
+7. The review issue is not the fix tracker. Each confirmed visual blocker gets a separate fix issue with enough screen/state/snapshot/spec detail for an AI worker to fix it.
+8. If at least one blocker is confirmed, the agent writes `dev-soak/app-ai-review=failure` on the source dev SHA, using the review or representative finding issue as `target_url`.
+9. If no blocker is found, the agent writes `dev-soak/app-ai-review=success` on the same SHA and closes the review issue with evidence.
+10. Visual blockers are fixed through normal `dev-staging` PR flow and reach `dev` in the next promotion.
+
+`artifacts/mds-render` is not a promotion source and is not merged into `dev`, `rc`, or `main`. It is an archive branch and does not carry source workflow files; dispatch from `sync-mds-render-snapshot` is the trigger contract for triage. `latest` pointers may exist for convenience, but gate logic must use SHA-bound paths and commit statuses.
+
 ## Query Examples
 
 ```bash
@@ -97,7 +131,7 @@ git tag -l 'promo/main-*'
 
 ```bash
 gh api repos/<owner>/<repo>/commits/<sha>/status \
-  --jq '.statuses[] | select(.context == "dev-rc-cut-pass" or (.context | startswith("dev-soak/")))'
+  --jq '.statuses[] | select(.context == "dev-rc-cut-pass" or .context == "mds-render/snapshot" or (.context | startswith("dev-soak/")))'
 ```
 
 ```bash
@@ -105,4 +139,4 @@ gh workflow list --all --limit 200 | grep -E 'dev-rc-cut|rc-main-cut|monitor-dev
 ```
 
 ---
-_Reviewed: 2026-06-03 15:15_
+_Reviewed: 2026-06-04 22:11_

--- a/docs/infra/branch-strategy/specs/execution-plan.md
+++ b/docs/infra/branch-strategy/specs/execution-plan.md
@@ -12,7 +12,7 @@
 | **PR / Review** | `pr-gate`, `pr-review-setup`, `doc-freshness` | spec 의 pr-gate-core 의 base — 추출·일반화 대상 |
 | **Post-merge** | `post-merge` (dev-staging push orchestrator), `sync-pr-branches`, `triage-mds-issue` | 일반 PR flow follow-up 자동화. dev 는 promotion-only 이므로 deploy/health workflow 만 push 에 직접 붙인다 |
 | **Reusable** | `shared-android-deploy`, `shared-cuj-integration`, `shared-notify` | spec 의 reusable 패턴 — 추가 reusable extract 시 참고 |
-| **Monitor** | `monitor-allure`, `monitor-cuj-coverage`, `monitor-db-invariants`, `monitor-deno-coverage`, `monitor-event-flow-*`, `monitor-mds-render-coverage`, `monitor-patrol-e2e` | 본 release pipeline 과 orthogonal — 유지 |
+| **Monitor** | `monitor-allure`, `monitor-cuj-coverage`, `monitor-db-invariants`, `monitor-deno-coverage`, `monitor-event-flow-*`, `monitor-mds-render-coverage`, `monitor-patrol-e2e` | 본 release pipeline 과 orthogonal — 유지. 단, `sync-mds-render-snapshot` 은 dev push health evidence 이므로 dev pipeline 에 속함 |
 | **Triage** | `triage-mds-issue`, `triage-slash` | 동상 — 유지 |
 
 > `post-merge.yml` 은 `dev-staging` push 직후 일반 PR flow follow-up 을 묶는 orchestrator 다. dev push 는 promotion 결과의 deploy/health signal 에만 사용한다.
@@ -25,7 +25,7 @@
 | `version-bump` (reusable) | legacy/building block for source-controlled version file changes. Active daily cut uses direct `scripts/bump-version.sh` inside `dev-staging-dev-cut` | **refactor** |
 | `shared-set-commit-status` | commit status write 공통 reusable | **신규** |
 | `set-dev-soak-status`, `set-rc-soak-status` | stage별 status write API (`workflow_call` + `workflow_dispatch`). `dev-soak/*` 는 dev health legacy prefix | **신규** |
-| dev health monitor/status model | 기존 `monitor-event-flow-*`, `monitor-dev-cuj`, real-device workflow, AI agent signal 을 `dev-soak/*` commit status 로 통합 | **신규 (조합)** |
+| dev health monitor/status model | 기존 `monitor-event-flow-*`, `monitor-dev-cuj`, MDS render snapshot, real-device workflow, AI agent signal 을 `mds-render/snapshot` + `dev-soak/*` commit status 로 통합 | **신규 (조합)** |
 | `auto-issue` (reusable) | (없음) | **신규** |
 | `cherry-pick-pr` (reusable) | (없음) | **신규** |
 | `dev-staging-pr-gate` | `pr-gate` 를 dev-staging base 로 재사용 (stage=dev-staging) | **신규 (얇은 wrapper)** |
@@ -112,6 +112,7 @@
 | 4a | `shared-set-commit-status`, `set-dev-soak-status`, `set-rc-soak-status` 구현 | Phase 2 |
 | 4b | `shared-notify` 가 실패 시 `set-dev-soak-status` 호출 + issue title/body/log tail 개선 | 4a |
 | 4c | `dev-rc-cut-gate` 를 dev health evaluator 로 변경 (run history + `dev-soak/*` status 확인) | 4a, 4b |
+| 4d | `sync-mds-render-snapshot` 추가 (`push: dev` → `artifacts/mds-render/snapshots/dev/<sha>/` + `mds-render/snapshot` + `mds_render_snapshot_archived` dispatch) | 4c |
 | 4d | `main-pr-gate` 에 RC lineage / `rc-main-cut-pass` / contract 재검증 추가 | Phase 2 |
 | 4e | `cherry-pick-pr` reusable, `rc-hotfix-apply` | Phase 2 |
 
@@ -238,6 +239,7 @@ Phase 1 (skeletal) → Phase 2 (CI/PR flow) → Phase 3 (branch CD)
 
 - `auto-issue` 의 P0/P1/P2 라벨 컨벤션 표준 (현재 minglit 의 `P0-critical` 등 따름)
 - real-device/app AI review 의 `set-dev-soak-status` pass/failure 입력 방식
+- `sync-mds-render-snapshot` 의 `artifacts/mds-render` branch write 권한/재시도 방식
 - 4d 의 main protection 적용을 *warn-only* → *enforced* 전환 일자
 - Vercel native build 전환 시점 + Vercel-GitHub 연결 설정 (Vercel-side 작업)
 - Secret 마이그레이션 timing (user 와 함께 — Phase 2/3 와 별도)
@@ -250,4 +252,4 @@ Phase 1 (skeletal) → Phase 2 (CI/PR flow) → Phase 3 (branch CD)
 - 기존 [`.github/workflows/BLUEDOC.md`](../../../../.github/workflows/BLUEDOC.md) — 현재 workflow 의 인벤토리 진입점
 
 ---
-_Reviewed: 2026-05-24 13:05_
+_Reviewed: 2026-06-04 22:11_

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -67,7 +67,7 @@ GitHub commit status 를 쓰는 low-level reusable workflow. Stage/signal mappin
 | Trigger | `workflow_call` |
 | Inputs | `sha`, `context`, `state`: failure\|success\|pending, `target_url`, `description` |
 | Outputs | GitHub commit status |
-| Called by | `set-dev-soak-status`, `set-rc-soak-status`, cut-gate evaluators |
+| Called by | `set-dev-soak-status`, `set-rc-soak-status`, `sync-mds-render-snapshot`, cut-gate evaluators |
 
 외부 workflow/AI agent 는 직접 호출하지 않는다. Public API 는 stage별 `set-*-soak-status` entry workflow 다.
 
@@ -199,7 +199,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Trigger | `schedule` (cut 직전, TBD) + `workflow_dispatch` |
 | Inputs | optional `candidate_sha` (default: latest `origin/dev` HEAD) |
 | Outputs | commit status `dev-rc-cut-pass` (success only) + `dev-soak/*` success confirmations + cut issue `gate/dev-rc` |
-| Steps | calls `shared-soak-gate` with candidate=`origin/dev`, min_soak_hours=0, required runs=`deploy-dev-event-flow-cron>=1` on matching SHA (`monitor-dev-cuj` run 요구는 web-mvp pivot 으로 제거), failure contexts=`dev-soak/backend-simulator` + `dev-soak/cuj-*` (수동 블락 레버), success contexts=required `dev-soak/*` (cuj-* 제외), pass context=`dev-rc-cut-pass`; then upserts cut issue as `status/waiting` or `status/ready` |
+| Steps | calls `shared-soak-gate` with candidate=`origin/dev`, min_soak_hours=0, required runs=`deploy-dev-event-flow-cron>=1` and required visual evidence on matching SHA (`monitor-dev-cuj` run 요구는 web-mvp pivot 으로 제거), failure contexts=`dev-soak/backend-simulator` + `dev-soak/cuj-*` (수동 블락 레버) + required visual contexts, success contexts=required `dev-soak/*` (cuj-* 제외), pass context=`dev-rc-cut-pass`; then upserts cut issue as `status/waiting` or `status/ready` |
 | Failure path | 조건 미충족 또는 required success evidence 누락이면 `dev-rc-cut-pass` 를 쓰지 않는다. 실패를 발견한 monitor/AI agent 가 이미 `dev-soak/*` failure 를 쓴다 |
 
 > **No auto-revert** — snapshot 모델: 실패 = no `dev-rc-cut-pass`, dev keeps moving, 새 fix 가 자연스럽게 다음 dev-staging-dev-cut 후 새 candidate 로 검증됨.
@@ -233,6 +233,26 @@ Cross-branch cherry-pick PR 자동 생성.
 | Branch/env | latest dev commit. User/partner app CUJ 를 각각 실행 |
 | Outputs | `set-dev-soak-status(signal=cuj-user|cuj-partner,state=success|failure)`, issue/alert with failed CUJ files |
 | Note | CUJ runner 는 첫 실패에서 중단하지 않고 모든 CUJ file 을 실행한 뒤 실패 목록을 aggregate 한다 |
+
+#### `sync-mds-render-snapshot`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `push` to `dev` + `workflow_dispatch` |
+| Branch/env | latest promoted dev commit |
+| Outputs | `artifacts/mds-render` branch commit under `snapshots/dev/<dev-sha>/`, commit status `mds-render/snapshot`, repository dispatch on PNG changes, issue/alert on failure |
+| Steps | (1) resolve dev SHA (2) run MDS emulator render capture (3) commit PNG only to `artifacts/mds-render` using SHA-bound path (4) set `mds-render/snapshot=success` with target URL/path, or `failure` if render/archive write fails (5) dispatch `mds_render_snapshot_archived` when the artifact commit changed PNGs |
+| Note | source branches never receive PNG snapshot commits. `triage-mds-render-snapshot-diff` creates review issues from dispatched artifact branch diffs |
+
+#### `triage-mds-render-snapshot-diff`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `repository_dispatch: mds_render_snapshot_archived` from `sync-mds-render-snapshot` + `workflow_dispatch` |
+| Branch/env | artifact branch checkout for diff, default branch checkout for workflow/script source |
+| Outputs | GitHub issue with `needs-arch`, `automated`, `P1-high` labels |
+| Steps | (1) diff previous artifact commit vs pushed commit (2) group changed `state-*.png` by source dev SHA (3) create/update visual review issue with snapshot path, compare URL, changed screens, and agent contract |
+| Note | no commit/status mutation. AI agent consumes the issue, creates one fix issue per confirmed visual blocker, and writes `dev-soak/app-ai-review=failure` when at least one blocker is confirmed or `success` when review passes |
 
 ### rc
 
@@ -381,6 +401,8 @@ Promotion/deploy entry workflows support `workflow_dispatch` dry-run where mutat
 | Workflow | Dry-run behavior |
 |----------|------------------|
 | `dev-staging-dev-cut` | computes/reuses dev-staging snapshot tag, computes cut branch, skips version bump/tag/branch push/PR/auto-merge |
+| `sync-mds-render-snapshot` | resolves target SHA and planned artifact path, skips emulator render, artifact branch push, and `mds-render/snapshot` status write |
+| `triage-mds-render-snapshot-diff` | computes diff and issue body, skips issue creation/update |
 | `dev-rc-cut-gate` | evaluates dev health run/status inputs, skips `dev-soak/*` and `dev-rc-cut-pass` status writes |
 | `dev-rc-cut` | selects source SHA/RC week, skips RC branch push/promo tag |
 | `rc-main-cut-gate` | selects RC branch and evaluates soak, skips `rc-main-cut-pass` status write |
@@ -395,6 +417,7 @@ Use dry-run before connecting new deploy backends or changing branch rulesets. D
 - `pr-gate-core` 의 stage 별 `extra_steps` 명세
 - `set-dev-soak-status` / `set-rc-soak-status` 의 signal set 확정
 - real-device / app AI review 가 어떤 workflow 또는 agent 에서 pass/failure status 를 쓸지 확정
+- `sync-mds-render-snapshot` 의 artifact branch push/retry 방식
 - `dev-deploy` 가 실제로 맡을 dev deploy/smoke 범위
 - `rc-deploy` 의 Supabase branch seed data 와 event-flow simulation contract
 - CUJ chaos 시나리오 정의 (현재 미정의)
@@ -415,4 +438,4 @@ Use dry-run before connecting new deploy backends or changing branch rulesets. D
 - `execution-plan.md` (예정) — 기존 workflow refactor + 구현 순서
 
 ---
-_Reviewed: 2026-05-24 16:45_
+_Reviewed: 2026-06-04 22:11_

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -104,7 +104,7 @@ Soak window, workflow run history, commit status failure context 를 평가하�
 | 항목 | 값 |
 |------|----|
 | Trigger | `workflow_call` |
-| Inputs | `candidate_ref`, `candidate_sha`, `min_soak_hours`, `required_runs_json`, `failure_contexts`, `success_contexts`, `pass_context`, `pass_description` |
+| Inputs | `candidate_ref`, `candidate_sha`, `min_soak_hours`, `required_runs_json`, `failure_contexts`, `required_success_contexts`, `success_contexts`, `pass_context`, `pass_description` |
 | Outputs | `skipped`, `reason`, `candidate_sha` |
 | Called by | `dev-rc-cut-gate`, `rc-main-cut-gate` |
 
@@ -199,7 +199,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Trigger | `schedule` (cut 직전, TBD) + `workflow_dispatch` |
 | Inputs | optional `candidate_sha` (default: latest `origin/dev` HEAD) |
 | Outputs | commit status `dev-rc-cut-pass` (success only) + `dev-soak/*` success confirmations + cut issue `gate/dev-rc` |
-| Steps | calls `shared-soak-gate` with candidate=`origin/dev`, min_soak_hours=0, required runs=`deploy-dev-event-flow-cron>=1` and required visual evidence on matching SHA (`monitor-dev-cuj` run 요구는 web-mvp pivot 으로 제거), failure contexts=`dev-soak/backend-simulator` + `dev-soak/cuj-*` (수동 블락 레버) + required visual contexts, success contexts=required `dev-soak/*` (cuj-* 제외), pass context=`dev-rc-cut-pass`; then upserts cut issue as `status/waiting` or `status/ready` |
+| Steps | calls `shared-soak-gate` with candidate=`origin/dev`, min_soak_hours=0, required runs=`deploy-dev-event-flow-cron>=1` and required visual evidence on matching SHA (`monitor-dev-cuj` run 요구는 web-mvp pivot 으로 제거), failure contexts=`dev-soak/backend-simulator` + `dev-soak/cuj-*` (수동 블락 레버) + `dev-soak/app-ai-review` + `mds-render/snapshot`, required success contexts=`mds-render/snapshot` + `dev-soak/app-ai-review`, success contexts=`dev-soak/backend-simulator` only, pass context=`dev-rc-cut-pass`; then upserts cut issue as `status/waiting` or `status/ready` |
 | Failure path | 조건 미충족 또는 required success evidence 누락이면 `dev-rc-cut-pass` 를 쓰지 않는다. 실패를 발견한 monitor/AI agent 가 이미 `dev-soak/*` failure 를 쓴다 |
 
 > **No auto-revert** — snapshot 모델: 실패 = no `dev-rc-cut-pass`, dev keeps moving, 새 fix 가 자연스럽게 다음 dev-staging-dev-cut 후 새 candidate 로 검증됨.

--- a/docs/infra/branch-strategy/test-strategy.md
+++ b/docs/infra/branch-strategy/test-strategy.md
@@ -1,6 +1,6 @@
 # Test Strategy
 
-4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = branch별 `*-pr-gate`, dev push health = event-flow/CUJ/real-device/app AI review, RC 후보 판정 = `dev-rc-cut-gate`, RC 5일 soak = `rc-main-cut-gate`, 프로덕션 검증 = `deploy-android-*, deploy-ios-*` smoke + flag staged.
+4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = branch별 `*-pr-gate`, dev push health = event-flow/MDS render/real-device/app AI review (Flutter CUJ 는 web-mvp pivot 으로 동결), RC 후보 판정 = `dev-rc-cut-gate`, RC 5일 soak = `rc-main-cut-gate`, 프로덕션 검증 = `deploy-android-*, deploy-ios-*` smoke + flag staged.
 
 ## 단계별 게이트
 
@@ -9,7 +9,7 @@
 | dev-staging 머지 전 | `dev-staging-pr-gate` (unit · lint · analyze · pgTAP · EF test · migration check · `expand-migrate-contract` · `flag-registration` · gitleaks) | < 10분 | auto-merge 보류 |
 | dev-staging 머지 후 지속 검증 | `monitor-dev-staging-health` (EF unit/integration 중심) | 6시간마다 | 실패 즉시 issue/notify + `dev-staging-health/*` status |
 | dev 머지 전 | `dev-pr-gate` (dev-staging-pr-gate 와 동일 — defensive) | < 10분 | dev-staging-dev-cut PR drop |
-| dev 머지 후 health | `deploy-dev-event-flow-cron` + real-device/app AI review status writer (`monitor-dev-cuj` 는 동결 — web-mvp pivot) | push/monitor cadence | 실패 즉시 `dev-soak/*` failure status + release-blocker issue |
+| dev 머지 후 health | `deploy-dev-event-flow-cron` + MDS render snapshot + real-device/app AI review status writer (`monitor-dev-cuj` 는 동결 — web-mvp pivot) | push/monitor cadence | 실패 즉시 `mds-render/snapshot` 또는 `dev-soak/*` failure status + release-blocker issue |
 | RC cut 직전 | `dev-rc-cut-gate` evaluator (dev run history + `dev-soak/*` status 확인) | 분 | `dev-rc-cut-pass` 미부여 |
 | rc 머지 전 (hotfix) | dev-staging-first fix cherry-pick PR + `rc-pr-gate` (pr-gate + mobile smoke) | < 15분 | hotfix PR drop |
 | main 머지 전 (rc → main) | `main-pr-gate` (pr-gate + `expand-migrate-contract` 재검증 + RC HEAD 의 `dev-rc-cut-pass` 확인 + `rc-main-cut-pass` marker 확인) | 분 | promotion PR 보류 |
@@ -58,8 +58,9 @@ dev 에 들어간 latest HEAD 만 RC candidate 로 평가한다. 새 dev commit 
 | backend simulator | `deploy-dev-event-flow-cron` + pg_cron `dev-event-flow-simulator` | `dev-soak/backend-simulator` failure 즉시 | `dev-rc-cut-gate` 가 cron install + 1회 simulator tick run + failure status 확인 |
 | user CUJ (동결) | `set-dev-soak-status` manual lever | `dev-soak/cuj-user` 수동 failure 시 | required success evidence 아님 |
 | partner CUJ (동결) | `set-dev-soak-status` manual lever | `dev-soak/cuj-partner` 수동 failure 시 | required success evidence 아님 |
+| MDS render snapshot | `sync-mds-render-snapshot` | `mds-render/snapshot` failure 즉시 | same-SHA snapshot 이 `artifacts/mds-render/snapshots/dev/<sha>/` 에 저장되면 success |
 | real device | Test Lab/실디바이스 workflow | `dev-soak/real-device` failure 즉시 | `dev-rc-cut-gate` 가 required signal 확인 후 success |
-| app AI review | AI agent | `dev-soak/app-ai-review` failure 즉시 | `dev-rc-cut-gate` 가 pass signal 확인 후 success |
+| app AI review | AI agent | `dev-soak/app-ai-review` failure 즉시 | AI agent 가 MDS render snapshot 비교 후 pass signal 제공 |
 
 ### dev-rc-cut-gate — Evaluator
 
@@ -68,6 +69,7 @@ cut 직전 schedule/manual 로 실행한다. 통과 시 commit 에 GitHub status
 - candidate SHA 에서 `deploy-dev-event-flow-cron` success >= 1
 - `dev-soak/backend-simulator` failure status 없음
 - `dev-soak/cuj-user`, `dev-soak/cuj-partner` failure status 없음 (`monitor-dev-cuj` run 요구는 동결로 제거)
+- required visual review 사용 시 `mds-render/snapshot=success` + `dev-soak/app-ai-review` failure status 없음
 - legacy hourly/daily 는 수동 smoke 로만 실행
 - candidate 의 최신 `dev-soak/*` status 가 failure 가 아님
 - real-device/app AI review required signal 충족
@@ -106,6 +108,8 @@ RC 의 hotfix 만 받음. 기본은 dev-staging 에 먼저 머지된 fix commit/
 | 결정론적, < 10분 | `dev-staging-pr-gate` | PR 사이클 안 막음 |
 | flaky 또는 느림 (10분+) | dev health monitor / real-device workflow | PR 머지 게이트의 신뢰도 보호 |
 | CUJ (동결 — web-mvp pivot) | ~~`monitor-dev-cuj` on dev push~~ | Flutter CUJ 동결. 웹 MVP smoke/CUJ 로 대체 예정 |
+| MDS visual snapshot | `sync-mds-render-snapshot` on dev push + `artifacts/mds-render` archive | source branch 를 오염시키지 않고 SHA-bound visual evidence 보존 |
+| AI visual review | dev health monitor after MDS snapshot | MDS spec 대비 blocker 를 자동/반자동 검출하고 fix 는 dev-staging 으로 회수 |
 | 10분+ 이지만 nightly 전에 잡아야 하는 EF 회귀 | `monitor-dev-staging-health` | dev-staging 머지는 빠르게 유지하고 최대 6시간 내 발견 |
 | 외부 의존성 (실 결제 등) | dev health + flag canary | 비용·side effect 통제 |
 | 부하/성능 | scheduled monitor or staged rollout 메트릭 | 매일 무거움 |
@@ -119,8 +123,9 @@ RC 의 hotfix 만 받음. 기본은 dev-staging 에 먼저 머지된 fix commit/
 - 부하 테스트 도구 (k6 / Artillery / 자체)
 - mobile smoke 5개 핵심 경로 정의 + `dev-soak/real-device` status writer
 - AI app soak pass/fail status writer 구현
+- `sync-mds-render-snapshot` 구현과 AI visual review 비교 기준
 - 카나리 cohort 정의 (내부 직원 group)
 - `expand-migrate-contract` 구현 디테일 (Option C: DB schema only)
 
 ---
-_Reviewed: 2026-05-19 09:47_
+_Reviewed: 2026-06-04 22:11_


### PR DESCRIPTION
## Summary
- add `sync-mds-render-snapshot` to render MDS emulator PNGs from dev SHAs and archive them on `artifacts/mds-render`
- add `triage-mds-render-snapshot-diff` to file AI review issues when archived snapshot PNGs change
- document the branch/status contract for MDS visual evidence and `dev-soak/app-ai-review`

No linked issue: workflow/promotion contract update requested during release process design.

## Validation
- `bash -n .github/scripts/archive-mds-render-snapshot.sh .github/scripts/triage-mds-render-snapshot-diff.sh`
- `python3` YAML parse for new workflows
- `git diff --check origin/dev-staging..HEAD`
