### PR TITLE
test(mds): stabilize render shard states

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/_engine/runner.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_engine/runner.dart
@@ -4,6 +4,7 @@
 //   <screen>__<state>
 // driver 의 onScreenshot 콜백이 이 name 을 split 해서 출력 경로 결정.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -24,6 +25,10 @@ class MdsRenderEngine {
 
     for (final state in catalog.states) {
       testWidgets(state.name, (tester) async {
+        addTearDown(() {
+          debugDefaultTargetPlatformOverride = null;
+        });
+
         final builder = state.setup(catalog.builder());
         await tester.pumpWidget(builder.build());
         // Fix #2590: repeat() 애니메이션은 pumpAndSettle이 timeout — 고정 pump 사용.

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_login_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_login_page/builder.dart
@@ -34,9 +34,7 @@ class _LoadingAuthController extends AuthController {
 
 class _ErrorAuthController extends AuthController {
   @override
-  Future<void> build() async {
-    throw Exception('render: forced auth error');
-  }
+  FutureOr<void> build() {}
 }
 
 class PartnerLoginPageBuilder extends MdsScreenBuilder<PartnerLoginPage> {

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_login_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_login_page/builder.dart
@@ -37,17 +37,50 @@ class _ErrorAuthController extends AuthController {
   FutureOr<void> build() {}
 }
 
+class _AuthErrorDialogSeed extends StatefulWidget {
+  const _AuthErrorDialogSeed({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_AuthErrorDialogSeed> createState() => _AuthErrorDialogSeedState();
+}
+
+class _AuthErrorDialogSeedState extends State<_AuthErrorDialogSeed> {
+  bool _shown = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_shown) return;
+    _shown = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      handleMinglitError(
+        context,
+        Exception('render: forced auth error'),
+        StackTrace.current,
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
 class PartnerLoginPageBuilder extends MdsScreenBuilder<PartnerLoginPage> {
   PartnerLoginPageBuilder() : super(page: const PartnerLoginPage());
 
   bool _isDevEnv = false;
   TargetPlatform _platform = TargetPlatform.iOS;
   AuthController Function() _controllerFactory = _IdleAuthController.new;
+  bool _seedAuthErrorDialog = false;
 
   /// iOS/macOS/Web 대응 상태: Apple 버튼 포함 baseline.
   PartnerLoginPageBuilder iosDefault() {
     _platform = TargetPlatform.iOS;
     _controllerFactory = _IdleAuthController.new;
+    _seedAuthErrorDialog = false;
     // ignore: avoid_returning_this, fluent builder — callers chain methods
     return this;
   }
@@ -56,6 +89,7 @@ class PartnerLoginPageBuilder extends MdsScreenBuilder<PartnerLoginPage> {
   PartnerLoginPageBuilder androidDefault() {
     _platform = TargetPlatform.android;
     _controllerFactory = _IdleAuthController.new;
+    _seedAuthErrorDialog = false;
     // ignore: avoid_returning_this, fluent builder — callers chain methods
     return this;
   }
@@ -64,6 +98,7 @@ class PartnerLoginPageBuilder extends MdsScreenBuilder<PartnerLoginPage> {
   PartnerLoginPageBuilder loading() {
     _platform = TargetPlatform.iOS;
     _controllerFactory = _LoadingAuthController.new;
+    _seedAuthErrorDialog = false;
     // ignore: avoid_returning_this, fluent builder — callers chain methods
     return this;
   }
@@ -72,6 +107,7 @@ class PartnerLoginPageBuilder extends MdsScreenBuilder<PartnerLoginPage> {
   PartnerLoginPageBuilder error() {
     _platform = TargetPlatform.iOS;
     _controllerFactory = _ErrorAuthController.new;
+    _seedAuthErrorDialog = true;
     // ignore: avoid_returning_this, fluent builder — callers chain methods
     return this;
   }
@@ -90,6 +126,8 @@ class PartnerLoginPageBuilder extends MdsScreenBuilder<PartnerLoginPage> {
 
     final controllerFactory = _controllerFactory;
     final isDevEnv = _isDevEnv;
+    final seedAuthErrorDialog = _seedAuthErrorDialog;
+    final page = PartnerLoginPage(isDevEnvOverride: isDevEnv);
 
     return ProviderScope(
       overrides: [
@@ -101,7 +139,7 @@ class PartnerLoginPageBuilder extends MdsScreenBuilder<PartnerLoginPage> {
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
         theme: MinglitTheme.materialTheme,
-        home: PartnerLoginPage(isDevEnvOverride: isDevEnv),
+        home: seedAuthErrorDialog ? _AuthErrorDialogSeed(child: page) : page,
       ),
     );
   }

--- a/apps/app_user/integration_test/mds-emulator-render/identity_verification_screen/identity_verification_screen_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/identity_verification_screen/identity_verification_screen_test.dart
@@ -19,7 +19,12 @@ final catalog = MdsCatalog<IdentityVerificationScreenBuilder>(
       mdsIndex: 1,
       infiniteAnimation: true,
     ),
-    MdsState('state-consent-sheet', (b) => b.withConsentSheet(), mdsIndex: 2),
+    MdsState(
+      'state-consent-sheet',
+      (b) => b.withConsentSheet(),
+      mdsIndex: 2,
+      infiniteAnimation: true,
+    ),
     // MDS state_3(WebView) and state_4(Success) are external/transient
     // Iamport surfaces, so this catalog captures only app-owned states.
     MdsState('state-error-retry', (b) => b.errorRetry(), mdsIndex: 5),

--- a/apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/ticket_qr_screen_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/ticket_qr_screen_test.dart
@@ -20,9 +20,19 @@ final catalog = MdsCatalog<TicketQRScreenBuilder>(
   mdsSpec: 'apps/mds/docs/public/specs/ticket_qr_screen/',
   builder: TicketQRScreenBuilder.new,
   states: [
-    MdsState('state-with-token', (b) => b, mdsIndex: 1),
-    MdsState('state-not-found', (b) => b.notFound(), mdsIndex: 5),
-    MdsState('state-dark', (b) => b.dark()),
+    MdsState(
+      'state-with-token',
+      (b) => b,
+      mdsIndex: 1,
+      infiniteAnimation: true,
+    ),
+    MdsState(
+      'state-not-found',
+      (b) => b.notFound(),
+      mdsIndex: 5,
+      infiniteAnimation: true,
+    ),
+    MdsState('state-dark', (b) => b.dark(), infiniteAnimation: true),
   ],
 );
 


### PR DESCRIPTION
Scheduler: swe-codex-gpt55-medium-1

## Summary
- Mark the known non-settling MDS render states in `identity_verification_screen` and `ticket_qr_screen` as fixed-pump captures.
- Reset `debugDefaultTargetPlatformOverride` after each partner MDS render test so platform-specific partner login states do not trip Flutter test invariants.
- Stop the partner login render-only auth error controller from throwing during provider build, which was failing the shard before later screens could render.

Refs #3078 - partial: this PR addresses the render-capture malfunction observed in the latest monitor run. It does not claim full MDS render state coverage; remaining incomplete screen state catalog additions should continue under #3078 after this stabilizes the shards.

## Verification
- `dart format apps/app_user/integration_test/mds-emulator-render/identity_verification_screen/identity_verification_screen_test.dart apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/ticket_qr_screen_test.dart apps/app_partner/integration_test/mds-emulator-render/_engine/runner.dart apps/app_partner/integration_test/mds-emulator-render/partner_login_page/builder.dart`
- `git diff --check`
- `flutter analyze integration_test/mds-emulator-render/identity_verification_screen/identity_verification_screen_test.dart integration_test/mds-emulator-render/ticket_qr_screen/ticket_qr_screen_test.dart` in `apps/app_user`
- `flutter analyze integration_test/mds-emulator-render/_engine/runner.dart integration_test/mds-emulator-render/partner_login_page/partner_login_page_test.dart` in `apps/app_partner`
- `APP_NAME=user SHARD_INDEX=1 SHARD_TOTAL=4 MDS_RENDER_DRY_RUN=1 bash .github/scripts/run-mds-render-shard.sh`
- `APP_NAME=user SHARD_INDEX=3 SHARD_TOTAL=4 MDS_RENDER_DRY_RUN=1 bash .github/scripts/run-mds-render-shard.sh`
- `APP_NAME=partner SHARD_INDEX=3 SHARD_TOTAL=4 MDS_RENDER_DRY_RUN=1 bash .github/scripts/run-mds-render-shard.sh`

## Residual Risk
- Full `flutter drive` render capture requires an Android emulator and was not run locally in this worktree.
- The partner login auth-error capture is now non-throwing to keep the render catalog deterministic; it may still need a richer fixture if visual parity for that specific error state becomes required.