### PR TITLE
test(mds): add notification settings render states

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/_mocks/notifiers.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_mocks/notifiers.dart
@@ -136,6 +136,41 @@ class LoadedNotificationSettingsNotifier
   );
 }
 
+/// 알림 설정 로드 완료 (service OFF, marketing OFF).
+class AllOffNotificationSettingsNotifier
+    extends NotificationSettingsController {
+  @override
+  FutureOr<UserSettings?> build() async => UserSettings(
+    userId: 'mock-user-1',
+    updatedAt: DateTime.utc(2026, 5, 17),
+    serviceNotification: false,
+  );
+}
+
+/// 알림 설정 로드 완료 (service ON, marketing ON).
+class AllOnNotificationSettingsNotifier extends NotificationSettingsController {
+  @override
+  FutureOr<UserSettings?> build() async => UserSettings(
+    userId: 'mock-user-1',
+    updatedAt: DateTime.utc(2026, 5, 17),
+    marketingConsent: true,
+  );
+}
+
+/// 알림 설정 로딩 유지.
+class LoadingNotificationSettingsNotifier
+    extends NotificationSettingsController {
+  @override
+  FutureOr<UserSettings?> build() => Completer<UserSettings?>().future;
+}
+
+/// 알림 설정 오류 상태.
+class ErrorNotificationSettingsNotifier extends NotificationSettingsController {
+  @override
+  FutureOr<UserSettings?> build() async =>
+      throw Exception('notification settings render error');
+}
+
 /// 필터 (location, eligibility) 비활성화.
 class NoFiltersNotifier extends ActiveFilters {
   @override

--- a/apps/app_user/integration_test/mds-emulator-render/notification_settings_screen/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/notification_settings_screen/builder.dart
@@ -1,4 +1,5 @@
-// NotificationSettingsScreenBuilder — notification_settings_screen 전용 fluent API.
+// NotificationSettingsScreenBuilder
+// notification_settings_screen 전용 fluent API.
 
 import 'package:minglit_kit/minglit_kit.dart';
 
@@ -10,16 +11,67 @@ class NotificationSettingsScreenBuilder
   NotificationSettingsScreenBuilder()
     : super(
         page: const NotificationSettingsScreen(),
-        base: [
-          notificationSettingsControllerProvider.overrideWith(
-            LoadedNotificationSettingsNotifier.new,
-          ),
-        ],
       );
+
+  /// 서비스 ON / 마케팅 OFF (MDS state_1).
+  NotificationSettingsScreenBuilder mixed() {
+    addOverride(
+      notificationSettingsControllerProvider.overrideWith(
+        LoadedNotificationSettingsNotifier.new,
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 서비스 OFF / 마케팅 OFF (MDS state_2).
+  NotificationSettingsScreenBuilder allOff() {
+    addOverride(
+      notificationSettingsControllerProvider.overrideWith(
+        AllOffNotificationSettingsNotifier.new,
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 서비스 ON / 마케팅 ON (MDS state_3).
+  NotificationSettingsScreenBuilder allOn() {
+    addOverride(
+      notificationSettingsControllerProvider.overrideWith(
+        AllOnNotificationSettingsNotifier.new,
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 설정 정보를 가져오는 중 (MDS state_4).
+  NotificationSettingsScreenBuilder loading() {
+    addOverride(
+      notificationSettingsControllerProvider.overrideWith(
+        LoadingNotificationSettingsNotifier.new,
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 설정 정보 로드/저장 오류 (MDS state_5).
+  NotificationSettingsScreenBuilder error() {
+    addOverride(
+      notificationSettingsControllerProvider.overrideWith(
+        ErrorNotificationSettingsNotifier.new,
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
 
   /// 다크 모드 토글.
   NotificationSettingsScreenBuilder dark() {
     useDarkTheme();
+    // ignore: avoid_returning_this, fluent builder chain style
     return this;
   }
 }

--- a/apps/app_user/integration_test/mds-emulator-render/notification_settings_screen/notification_settings_screen_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/notification_settings_screen/notification_settings_screen_test.dart
@@ -13,8 +13,18 @@ final catalog = MdsCatalog<NotificationSettingsScreenBuilder>(
   mdsSpec: 'apps/mds/docs/public/specs/notification_settings_screen/',
   builder: NotificationSettingsScreenBuilder.new,
   states: [
-    MdsState('state-loaded', (b) => b, mdsIndex: 1),
-    MdsState('state-dark', (b) => b.dark()),
+    MdsState('state-mixed', (b) => b.mixed(), mdsIndex: 1),
+    MdsState('state-all-off', (b) => b.allOff(), mdsIndex: 2),
+    MdsState('state-all-on', (b) => b.allOn(), mdsIndex: 3),
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 4,
+      infiniteAnimation: true,
+    ),
+    MdsState('state-error', (b) => b.error(), mdsIndex: 5),
+    // state_6 permission-denied is documented as a future implementation state.
+    MdsState('state-dark', (b) => b.mixed().dark()),
   ],
 );
 

--- a/apps/app_user/integration_test/mds-emulator-render/signup_consent_page/signup_consent_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/signup_consent_page/signup_consent_page_test.dart
@@ -20,6 +20,7 @@ final catalog = MdsCatalog<SignupConsentPageBuilder>(
     MdsState(
       'state-loading',
       (b) => b.loading(),
+      mdsIndex: 6,
       infiniteAnimation: true,
     ),
     // State 1 — Default: 체크박스 없음, CTA 비활성


### PR DESCRIPTION
Scheduler: swe-codex-gpt55-medium-1

## Summary
- add deterministic MDS render catalog states for `notification_settings_screen`: mixed, all-off, all-on, loading, and error
- wire `signup_consent_page` loading-on-entry to MDS `state_6`
- leave `notification_settings_screen` permission-denied and signup submitting/error states out because the current implementation/spec notes mark them as future or interaction/snackbar-driven states

## Issue
Refs #3078 - partial coverage improvement; the issue should remain open for remaining incomplete screen states.

## Validation
- `dart format apps/app_user/integration_test/mds-emulator-render/_mocks/notifiers.dart apps/app_user/integration_test/mds-emulator-render/notification_settings_screen/builder.dart apps/app_user/integration_test/mds-emulator-render/notification_settings_screen/notification_settings_screen_test.dart apps/app_user/integration_test/mds-emulator-render/signup_consent_page/signup_consent_page_test.dart`
- `git diff --check`
- `flutter analyze integration_test/mds-emulator-render/_mocks/notifiers.dart integration_test/mds-emulator-render/notification_settings_screen/builder.dart integration_test/mds-emulator-render/notification_settings_screen/notification_settings_screen_test.dart integration_test/mds-emulator-render/signup_consent_page/signup_consent_page_test.dart`

## Residual Risk
- Full `flutter analyze` still exits non-zero on existing repo-wide info findings unrelated to this change.
- `flutter test -d linux integration_test/mds-emulator-render/notification_settings_screen/notification_settings_screen_test.dart` could not run locally because Linux desktop test execution requires CMake in this environment.
- Actual PNG capture remains covered by the monitor/emulator render workflow.
