### PR TITLE
fix(event-flow): send idempotency key for apply-event

### DIFF
--- a/supabase/functions/event-flow-simulator/BLUEDOC.md
+++ b/supabase/functions/event-flow-simulator/BLUEDOC.md
@@ -46,4 +46,4 @@ curl -X POST "https://<project>.supabase.co/functions/v1/event-flow-simulator" \
 - 단위 테스트: `cd supabase/functions && deno test event-flow-simulator/`
 
 ---
-_Reviewed: 2026-06-05 10:15_
+_Reviewed: 2026-06-06 07:33_

--- a/supabase/functions/event-flow-simulator/core/auth.ts
+++ b/supabase/functions/event-flow-simulator/core/auth.ts
@@ -45,6 +45,7 @@ export async function callEdgeFunction(
   functionName: string,
   payload: unknown,
   userToken: string,
+  extraHeaders: Record<string, string> = {},
 ): Promise<{ status: number; data: unknown }> {
   const url = `${supabaseUrl}/functions/v1/${functionName}`;
   const res = await fetch(url, {
@@ -52,6 +53,7 @@ export async function callEdgeFunction(
     headers: {
       "Content-Type": "application/json",
       "Authorization": `Bearer ${userToken}`,
+      ...extraHeaders,
     },
     body: JSON.stringify(payload),
   });

--- a/supabase/functions/event-flow-simulator/core/transport.ts
+++ b/supabase/functions/event-flow-simulator/core/transport.ts
@@ -10,13 +10,19 @@ export interface EFTransportConfig {
   supabaseUrl: string;
   /** actorId → JWT 토큰. cascade 실행 전 모든 actor 의 토큰을 미리 채움 */
   tokenByActor: Map<ActorId, string>;
+  /** Current simulator run id, used to avoid idempotency-key reuse across runs. */
+  runId?: string;
 }
+
+const IDEMPOTENCY_REQUIRED_FUNCTIONS = new Set(["apply-event"]);
 
 /**
  * 실 EF 호출 transport. action.ef 가 정의돼 있으면 callEdgeFunction 으로 POST.
  * action.ef 가 undefined 인 경우 (현재: block 액션) supabase client 로 direct DB write.
  */
 export class EFTransport implements Transport {
+  private idempotencySequence = 0;
+
   constructor(private cfg: EFTransportConfig) {}
 
   async execute(action: Action) {
@@ -55,16 +61,30 @@ export class EFTransport implements Transport {
     if (!action.ef) {
       return { ok: false, status: 0, error: `action ${action.type} has no ef` };
     }
+    const extraHeaders = this.headersForAction(action);
     const res = await callEdgeFunction(
       this.cfg.supabaseUrl,
       action.ef,
       action.payload,
       token,
+      extraHeaders,
     );
     return {
       ok: res.status >= 200 && res.status < 300,
       status: res.status,
       data: res.data,
+    };
+  }
+
+  private headersForAction(action: Action): Record<string, string> {
+    if (!action.ef || !IDEMPOTENCY_REQUIRED_FUNCTIONS.has(action.ef)) {
+      return {};
+    }
+    const runId = this.cfg.runId ?? "unknown-run";
+    const sequence = this.idempotencySequence++;
+    return {
+      "Idempotency-Key":
+        `event-flow-simulator:${runId}:${sequence}:${action.type}`,
     };
   }
 }

--- a/supabase/functions/event-flow-simulator/core/transport_test.ts
+++ b/supabase/functions/event-flow-simulator/core/transport_test.ts
@@ -1,0 +1,76 @@
+import { assertEquals } from "@std/assert";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  createFetchMock,
+  withMockedFetch,
+} from "../../_test_utils/mock_http.ts";
+import { EFTransport } from "./transport.ts";
+
+Deno.test("EFTransport adds Idempotency-Key for apply-event calls", async () => {
+  let idempotencyKey: string | null = null;
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req) => req.url.endsWith("/functions/v1/apply-event"),
+      handler: (req) => {
+        assertEquals(req.headers.get("Authorization"), "Bearer test-token");
+        idempotencyKey = req.headers.get("Idempotency-Key");
+        return Response.json({ success: true });
+      },
+    },
+  ]);
+
+  await withMockedFetch(fetchMock, async () => {
+    const transport = new EFTransport({
+      supabase: {} as SupabaseClient,
+      supabaseUrl: "https://example.supabase.co",
+      tokenByActor: new Map([["user-1", "test-token"]]),
+      runId: "run-1",
+    });
+
+    const result = await transport.execute({
+      type: "user_apply",
+      actorId: "user-1",
+      ef: "apply-event",
+      payload: { event_id: "event-1", ticket_id: "ticket-1" },
+    });
+
+    assertEquals(result.ok, true);
+    assertEquals(result.status, 200);
+  });
+
+  assertEquals(
+    idempotencyKey,
+    "event-flow-simulator:run-1:0:user_apply",
+  );
+});
+
+Deno.test("EFTransport omits Idempotency-Key for functions without that contract", async () => {
+  let idempotencyKey: string | null = "unexpected";
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req) => req.url.endsWith("/functions/v1/event-checkin"),
+      handler: (req) => {
+        idempotencyKey = req.headers.get("Idempotency-Key");
+        return Response.json({ success: true });
+      },
+    },
+  ]);
+
+  await withMockedFetch(fetchMock, async () => {
+    const transport = new EFTransport({
+      supabase: {} as SupabaseClient,
+      supabaseUrl: "https://example.supabase.co",
+      tokenByActor: new Map([["user-1", "test-token"]]),
+      runId: "run-1",
+    });
+
+    await transport.execute({
+      type: "user_checkin",
+      actorId: "user-1",
+      ef: "event-checkin",
+      payload: { event_id: "event-1" },
+    });
+  });
+
+  assertEquals(idempotencyKey, null);
+});

--- a/supabase/functions/event-flow-simulator/index.ts
+++ b/supabase/functions/event-flow-simulator/index.ts
@@ -195,7 +195,12 @@ export const handler = async (
     }
 
     // 3. cascade 실행
-    const transport = new EFTransport({ supabase, supabaseUrl, tokenByActor });
+    const transport = new EFTransport({
+      supabase,
+      supabaseUrl,
+      tokenByActor,
+      runId,
+    });
     const cascade = await runCascade({
       actors,
       initialSnapshot,


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## What changed
- Adds optional extra headers to the event-flow simulator EF caller.
- Passes the simulator run id into `EFTransport`.
- Sends a per-run/per-action `Idempotency-Key` for `apply-event`, whose auth manifest requires idempotency.
- Adds transport unit coverage for idempotency-required and non-idempotency EF calls.

## Why
Fixes #3115. The representative cascade trace showed every `user_apply` / `apply-event` call returning HTTP 400. `apply-event` has `idempotency.required=true`, while the simulator transport previously sent only JSON/Auth headers, so calls could be rejected before the handler reached dev data.

## Verification
- `cd supabase/functions && npx -y deno@2 test event-flow-simulator/core/transport_test.ts`
- `cd supabase/functions && npx -y deno@2 test --allow-env event-flow-simulator/` (56 passed / 0 failed)

## Residual risk
- The idempotency-required EF set currently includes `apply-event`, matching the current manifest. If another simulator action targets a future idempotency-required EF, that EF must be added to the set.

리뷰 트리거는 현재 head SHA의 review check 부재로 자동 처리된다