### PR TITLE
pivot(mds): mark 70 mobile specs + add web_user/web_partner spec infra (Phase 1c)

### DIFF
--- a/apps/mds/docs/BLUEDOC.md
+++ b/apps/mds/docs/BLUEDOC.md
@@ -8,7 +8,7 @@ Minglit Design System 의 **시각 SSOT + 문서 사이트**. 화면 spec, 컴�
 |---|---|
 | [`src/app/`](./src/app/) | Next.js route pages (`/`, `/tokens`, `/components`, `/screens`, `/icons`, `/flows`) |
 | [`src/lib/components.ts`](./src/lib/components.ts) | MDS 컴포넌트 manifest SSOT |
-| [`src/lib/screen-definitions.ts`](./src/lib/screen-definitions.ts) | `/screens` surface별 screen registry (`app_user`, `app_partner`, `web_admin`) |
+| [`src/lib/screen-definitions.ts`](./src/lib/screen-definitions.ts) | `/screens` surface별 screen registry (`app_user`, `app_partner`, `web_admin`, `web_user`, `web_partner` — 웹 surface 는 정적 목록) |
 | [`src/components/specs/`](./src/components/specs/) | 컴포넌트별 inline visual playground |
 | [`public/specs/BLUEDOC.md`](./public/specs/BLUEDOC.md) | 화면 spec source HTML + generated MD/PNG |
 | [`reports/BLUEDOC.md`](./reports/BLUEDOC.md) | MDS 정합성 audit report + weekly FRESH_DOC job |
@@ -22,7 +22,7 @@ Minglit Design System 의 **시각 SSOT + 문서 사이트**. 화면 spec, 컴�
 - **런타임 검증은 mock app 중심** — emulator render catalog 가 실제 Flutter 화면 캡처를 담당한다.
 - **토큰 SSOT 는 `shared/packages/mds/tokens/`** — docs 는 generated CSS 를 `public/tokens.css` 로 sync 한다.
 - **아이콘 SSOT 는 `shared/packages/mds/icons/`** — docs 의 React icon copy/data 는 sync script 로 갱신한다.
-- **화면 spec source 는 `public/specs/<screen>/index.html`** — screen 변경은 여기만 직접 수정한다.
+- **화면 spec source 는 `public/specs/<screen>/index.html`** — screen 변경은 여기만 직접 수정한다. 웹 화면 spec 은 `_template_web.html` + `web_foundation_responsive` 기반으로 신규 작성한다.
 - **`index.md` / `state_*.png` / `blueprint*.png` 는 자동 산출물** — `render-spec-mockups.js` / `sync-mds-mockups.yml` 이 HTML 에서 재생성한다.
 
 ## 자주 쓰는 명령

--- a/apps/mds/docs/public/specs/BLUEDOC.md
+++ b/apps/mds/docs/public/specs/BLUEDOC.md
@@ -20,7 +20,8 @@ MDS 화면 spec 의 **source HTML + 자동 산출물 디렉터리**. Flutter 화
 ## 핵심 컨벤션
 
 - **직접 수정은 `<screen>/index.html` 만** — `index.md`, `state_*.png`, `blueprint*.png` 는 자동 산출물이다.
-- **새 spec / 큰 개편은 `_template.html` 구조를 따른다** — Header → Overview → History → Layout → States → Global Behavior → Reference.
+- **모든 spec `<head>` 에 `<meta name="feature-status">`** — 기존 모바일 spec 은 web-mvp pivot(2026-06-06) 분류 `behavior-reference`(웹 spec 의 behavior 원천) / `on-hold` / `deprecated` 3종, 신규 웹 spec 은 lifecycle `planned` / `in-progress` / `shipped` 3종. deprecated spec 은 `<body>` 최상단에 `.spec-status-banner` 가시 배너를 함께 둔다.
+- **새 spec / 큰 개편은 `_template.html` 구조를 따른다** — Header → Overview → History → Layout → States → Global Behavior → Reference. 웹 화면 spec (`web_user`/`web_partner` surface) 은 [`_template_web.html`](./_template_web.html) + [`web_foundation_responsive/`](./web_foundation_responsive/index.html) breakpoint 규칙을 따른다.
 - **States 는 template mini-table 형식** — `table.ref.state-mini` + `thead` + mockup `rowspan=6` + 조건/사용자 액션/에지케이스/컴포넌트/토큰/노트 6행.
 - **경로는 `<screen>/index.html`** — legacy `<screen>.html` flat path 를 새로 만들지 않는다.
 - **코드와 다르면 먼저 source of truth 를 판정** — 구현이 live 이고 spec 이 stale 이면 HTML spec 을 갱신하고 History row 에 issue/PR 맥락을 남긴다.

--- a/apps/mds/docs/public/specs/BLUEDOC.md
+++ b/apps/mds/docs/public/specs/BLUEDOC.md
@@ -20,7 +20,7 @@ MDS 화면 spec 의 **source HTML + 자동 산출물 디렉터리**. Flutter 화
 ## 핵심 컨벤션
 
 - **직접 수정은 `<screen>/index.html` 만** — `index.md`, `state_*.png`, `blueprint*.png` 는 자동 산출물이다.
-- **모든 spec `<head>` 에 `<meta name="feature-status">`** — 기존 모바일 spec 은 web-mvp pivot(2026-06-06) 분류 `behavior-reference`(웹 spec 의 behavior 원천) / `on-hold` / `deprecated` 3종, 신규 웹 spec 은 lifecycle `planned` / `in-progress` / `shipped` 3종. deprecated spec 은 `<body>` 최상단에 `.spec-status-banner` 가시 배너를 함께 둔다.
+- **모든 spec `<head>` 에 `<meta name="feature-status">`** — 동결된 모바일 spec 은 web-mvp pivot(2026-06-06) 분류 `behavior-reference`(웹 spec 의 behavior 원천) / `on-hold` / `deprecated` 3종, 웹 surface spec (web_admin/web_user/web_partner) 은 lifecycle `planned` / `in-progress` / `shipped` 3종. deprecated spec 은 `<body>` 최상단에 `.spec-status-banner` 가시 배너를 함께 둔다.
 - **새 spec / 큰 개편은 `_template.html` 구조를 따른다** — Header → Overview → History → Layout → States → Global Behavior → Reference. 웹 화면 spec (`web_user`/`web_partner` surface) 은 [`_template_web.html`](./_template_web.html) + [`web_foundation_responsive/`](./web_foundation_responsive/index.html) breakpoint 규칙을 따른다.
 - **States 는 template mini-table 형식** — `table.ref.state-mini` + `thead` + mockup `rowspan=6` + 조건/사용자 액션/에지케이스/컴포넌트/토큰/노트 6행.
 - **경로는 `<screen>/index.html`** — legacy `<screen>.html` flat path 를 새로 만들지 않는다.

--- a/apps/mds/docs/public/specs/_spec.css
+++ b/apps/mds/docs/public/specs/_spec.css
@@ -55,6 +55,21 @@ body {
 }
 
 /* ============================================================
+   Status banner — visible flag for deprecated specs (web-mvp pivot).
+   Paired with <meta name="feature-status"> in each spec's <head>.
+   ============================================================ */
+.spec-status-banner {
+  margin: 0 0 16px;
+  padding: 10px 14px;
+  border: 1px solid var(--color-error);
+  border-radius: 8px;
+  background: rgba(239, 68, 68, 0.12); /* --color-error @ 12% */
+  color: var(--color-error);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+/* ============================================================
    Toolbar — spec mode + dark mode toggles (top-right, always visible)
    Two independent checkboxes:
      #spec-toggle    → adds .spec-mode to body (annotations / callouts on)

--- a/apps/mds/docs/public/specs/_template_web.html
+++ b/apps/mds/docs/public/specs/_template_web.html
@@ -1,0 +1,884 @@
+<!DOCTYPE html>
+<!--
+  WEB screen spec template — copy this file as `apps/mds/docs/public/specs/{snake_case_screen}/index.html`.
+
+  Use this template for web surfaces only (web_user · web_partner · web_admin).
+  Mobile Flutter app screens keep using /specs/_template.html.
+
+  Filename = snake_case of the screen name. e.g.
+    WebUserEventDetail   → web_user_event_detail/index.html
+    WebPartnerDashboard  → web_partner_dashboard/index.html
+
+  Differences vs the mobile template (_template.html):
+    · <meta> placeholders in <head> — feature-status / features / surface
+    · Layout perspective → "Responsive Layout" with per-breakpoint variants
+    · Token references are CSS variable / Tailwind oriented (token NAMES stay MDS)
+    · Overview gains a "Behavior Source" row → mobile spec this screen inherits from
+
+  Full authoring guide (status lifecycle, spec types, additive diff syntax,
+  motion tokens, etc.) → /specs/_authoring.html
+  Breakpoint / container / grid / pointer rules SSOT → /specs/web_foundation_responsive/
+-->
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<!-- ── Web spec metadata (machine-readable) ─────────────────────
+     · feature-status — feature lifecycle: planned | in-progress | shipped
+     · features       — docs/features/ slug(s), comma-separated (예: event/event-detail)
+     · surface        — exactly one of: web_user | web_partner (admin specs use web_admin) -->
+<meta name="feature-status" content="[planned|in-progress|shipped]">
+<meta name="features" content="[domain/feature-slug]">
+<meta name="surface" content="[web_user|web_partner]">
+<title>Spec — [SCREEN NAME] ([web_user|web_partner] · [/path])</title>
+<link rel="stylesheet" href="/specs/_spec.css">
+<style>
+/* ============================================================
+   Screen-specific atoms only.
+   Keep this block minimal — most styles come from _spec.css.
+
+   Viewport sizing per breakpoint variant:
+     · default .viewport = 375×812 (mobile) — _spec.css 기본값.
+     · desktop variant mockup은 inline style 또는 아래처럼 모디파이어로
+       폭을 키운다 (스크린샷 캡처가 variant별로 분리되도록):
+         .viewport--desktop { width: 1280px; height: 720px; }
+       (실제 px 는 화면 컨테이너 폭에 맞춰 조정 — web_foundation_responsive 참조)
+   ============================================================ */
+
+/* TODO: layout + custom widgets unique to this screen.
+   Common pattern:
+     .{screen}__container   — outermost grid/flex
+     .{screen}__header      — top region
+     .{screen}__body        — main content
+     .{screen}__cta         — CTA region
+*/
+</style>
+</head>
+<body>
+
+<!-- ============================================================
+     Toolbar — universal toggles (do NOT modify)
+     ============================================================ -->
+<div class="toolbar">
+  <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>
+  <label><input type="checkbox" id="dark-toggle"> Dark mode (viewports flip dark)</label>
+</div>
+
+<div class="page">
+
+<!-- ============================================================
+     📍 HEADER — compact metadata
+     ============================================================ -->
+<header>
+  <!-- TEMPLATE-ONLY banner — delete this <p> block when copying to a real spec. -->
+  <p style="font-size: 12px; color: var(--color-text-secondary); margin-bottom: 8px;">
+    📋 This is the WEB spec template. Authoring guide →
+    <a href="/specs/_authoring.html" style="color: var(--color-primary); font-weight: 600;">/specs/_authoring.html</a> ·
+    Responsive foundation →
+    <a href="/specs/web_foundation_responsive/" style="color: var(--color-primary); font-weight: 600;">/specs/web_foundation_responsive/</a>
+  </p>
+  <!-- short, user-facing screen name (not the component/class name) -->
+  <h1>[Screen Title]</h1>
+  <!-- 모든 메타 (Status · Surface · Category · Path · Purpose 등) → Overview 테이블.
+       Component · file path → Reference > Implementation source. -->
+</header>
+
+<!-- ============================================================
+     🎯 PURPOSE & CONTEXT — why this screen exists
+     ============================================================ -->
+<section class="doc">
+  <h2>Overview</h2>
+  <table class="ref">
+    <tbody>
+      <tr>
+        <th style="width: 160px;">Status</th>
+        <td>
+          <strong>[🚧 디자인중 | ✅ 디자인완료]</strong>
+          <em style="color: var(--color-text-secondary);">— 라이프사이클 phase (구현 추적은 History row로)</em>
+        </td>
+      </tr>
+      <tr>
+        <th>Surface</th>
+        <td><code>web_user</code> · 또는 <code>web_partner</code> — head의 <code>&lt;meta name="surface"&gt;</code>와 일치해야 함</td>
+      </tr>
+      <tr>
+        <th>Category</th>
+        <td>[feature 그룹 — auth · home · event · partner · payment · my · ticket 등]</td>
+      </tr>
+      <tr>
+        <th>Route / Surface</th>
+        <td><code>[/path/:param]</code> · Next.js route (landing_user / landing_partner 확장) · 또는 sub-component (route 없음 — parent screen의 일부)</td>
+      </tr>
+      <tr>
+        <th>Behavior Source</th>
+        <td>
+          <!-- 이 웹 화면이 동작(상태 전이 · 비즈니스 규칙 · 에지케이스)을 상속하는 기존 모바일 spec.
+               레이아웃은 웹에서 새로 정의하지만, behavior 는 이 spec 을 SSOT 로 따른다.
+               상속하지 않는 신규 화면이면 "— (web-native, no mobile counterpart)". -->
+          <a href="/specs/[mobile_screen]/index.html"><code>/specs/[mobile_screen]/index.html</code></a>
+          — [무엇을 상속하는가: states · 전이 규칙 · 에지케이스 / 웹에서 달라지는 점 1줄]
+        </td>
+      </tr>
+      <tr>
+        <th>Hierarchy</th>
+        <td>
+          <strong>Parent</strong>: <em>— (top-level screen)</em> · 또는 <a href="/specs/[parent]/index.html"><code>[ParentScreen]</code></a> (sub-component인 경우)<br>
+          <strong>Children</strong>: <em>—</em> · 또는 별도 spec으로 분리된 sub-component들의 링크
+        </td>
+      </tr>
+      <tr>
+        <th>Purpose</th>
+        <td>
+          [<strong>1-2 sentences</strong>: 이 화면이 무엇을 위한 화면인가. 사용자가 이 화면에서 무엇을 달성하는가.
+          첫 문장은 짧은 tagline 형태로.]
+        </td>
+      </tr>
+      <tr>
+        <th>User journey</th>
+        <td>
+          <strong>Entry points</strong>: [어디서 이 화면으로 오는가 — URL 직접 진입 · 검색/SNS 유입 · 내부 링크 등 웹 진입 경로 포함.]<br>
+          <strong>Exit points</strong>: [어디로 가는가 — 성공 / 취소 / 에러 분기 포함.]
+        </td>
+      </tr>
+      <tr>
+        <th>Background</th>
+        <td>
+          [디자인 결정의 배경. 왜 이 흐름인가. 모바일 spec 대비 웹에서 달라진 결정과 이유.]
+        </td>
+      </tr>
+      <tr>
+        <th>Frequency</th>
+        <td>[얼마나 자주 보는가 — 매일 / 1회만 / 특정 트리거 시 등.]</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     🕐 HISTORY — spec change log (right after Overview)
+     ============================================================ -->
+<section class="doc">
+  <h2>History</h2>
+  <p class="intro">
+    이 spec의 주요 변경 이력. 최신 항목 위에 추가 (최신 → 오래된 순).
+    의미 있는 디자인/동작 변경만 — 소소한 typo는 생략. 구현 PR 머지 시에도 row 추가
+    ("Implemented in PR #123 (date)" 형태).
+  </p>
+  <p class="intro" style="font-size: 12px; color: var(--color-text-secondary);">
+    아래는 이 <strong>웹 템플릿 자체</strong>의 이력 — 실제 spec 작성 시 본인 화면의 history로 교체.
+  </p>
+  <table class="ref">
+    <thead>
+      <tr>
+        <th style="width: 110px;">Date</th>
+        <th style="width: 80px;">Version</th>
+        <th style="width: 120px;">Author</th>
+        <th>Changes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>2026-06-06</td>
+        <td>1.0</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>Web template published</strong> — forked from <code>_template.html</code> v1.4 for the web MVP pivot.
+          Changes vs mobile template: head <code>&lt;meta&gt;</code> placeholders (feature-status · features · surface) ·
+          Layout → <strong>Responsive Layout</strong> (Mobile &lt;768 / Desktop ≥1280 variants, States 테이블은 공유) ·
+          token references reframed as CSS variables / Tailwind (token 이름은 MDS 체계 유지) ·
+          Overview에 <strong>Behavior Source</strong> 행 신설 (모바일 spec 상속 경로).
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     Anchor nav — keep as-is, 4 perspectives
+     ============================================================ -->
+<nav class="perspective-nav">
+  <a href="#layout"><span class="glyph">🧱</span> Responsive Layout</a>
+  <a href="#states"><span class="glyph">🎨</span> States</a>
+  <a href="#global-behavior"><span class="glyph">🔄</span> Global Behavior</a>
+  <a href="#reference"><span class="glyph">📖</span> Reference</a>
+</nav>
+
+<!-- ============================================================
+     🧱 PERSPECTIVE 1 · RESPONSIVE LAYOUT — structural blueprint per breakpoint
+     ============================================================ -->
+<div class="perspective" id="layout">
+  <div class="perspective__header">
+    <span class="glyph">🧱</span>
+    <h2>Responsive Layout</h2>
+    <span class="lede">
+      화면 구조 — 영역, 정렬, 간격 규칙. 색·타이포 무시.
+      <strong>breakpoint variant 별</strong> top-level blueprint + internal-composition region당 Sub-anatomy (① ② ③ ...).
+    </span>
+  </div>
+
+  <section class="doc">
+    <h2>Breakpoint variants</h2>
+    <p class="intro">
+      Breakpoint · 컨테이너 · 그리드 정의의 SSOT는
+      <a href="/specs/web_foundation_responsive/"><code>web_foundation_responsive</code></a>.
+      이 spec에는 <strong>이 화면이 breakpoint별로 어떻게 달라지는지만</strong> 기술한다.
+    </p>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 160px;">Variant</th>
+          <th style="width: 180px;">Breakpoint</th>
+          <th>이 화면에서의 차이</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- 룰: 레이아웃이 실제로 달라지는 variant만 blueprint를 추가로 그린다.
+             · Mobile (<768px) — 모든 web spec의 기본 variant. 항상 작성.
+             · Desktop (≥1280px) — Mobile과 구조가 다를 때만 variant 섹션 추가.
+             · Tablet (768–1279px) — 별도 blueprint 없음. 어느 variant를 따르는지만 명시
+               (기본: web_user는 Mobile 레이아웃 유지, web_partner는 Desktop 레이아웃 축소).
+             States 테이블(아래 perspective)은 breakpoint와 무관하게 공유 — variant별로 복제하지 않음. -->
+        <tr><td><strong>Mobile</strong> (기본)</td><td><code>&lt; 768px</code></td><td>[단일 컬럼 등 — 항상 작성]</td></tr>
+        <tr><td><strong>Desktop</strong></td><td><code>≥ 1280px</code></td><td>[2-컬럼 / 사이드 패널 등 — 차이가 있을 때만 variant 섹션 작성. 동일하면 "Mobile과 동일 (max-width 컨테이너 중앙 정렬)"]</td></tr>
+        <tr><td>Tablet</td><td><code>768–1279px</code></td><td>[별도 blueprint 없음 — 어느 variant 기준으로 fluid 하게 따라가는지 1줄]</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Blueprint &amp; tree — Mobile (&lt;768px)</h2>
+    <p class="intro">
+      [1-2 sentences explaining the high-level structure. e.g. "Sticky header + scrollable body + fixed bottom CTA."]
+    </p>
+
+    <div class="layout-grid">
+      <!-- ────── Wireframe blueprint ──────
+        Use absolute-positioned .blueprint__region divs to outline
+        each layout region. Number them ①②③... so the tree and the
+        spacing/alignment table can cross-reference.
+      -->
+      <div class="blueprint">
+        <!-- Whole frame outline (always include) -->
+        <div class="blueprint__region" style="top:0; left:0; right:0; bottom:0; border-style:solid; border-color: rgba(var(--spec-blueprint-rgb), 0.18);"></div>
+
+        <!-- ⚠️ TODO: 아래 height/top/bottom 픽셀 값은 EXAMPLE — 실제 화면 비례에
+             맞춰 반드시 변경. 대충 56/80 고정 사용 금지. -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:0; left:0; right:0; height:56px;">
+          <span class="blueprint__region-label">① [Region name] · h=[?px]</span>
+        </div>
+        <div class="blueprint__region" style="top:56px; left:0; right:0; bottom:80px;">
+          <span class="blueprint__region-label">② [Region name]</span>
+        </div>
+        <div class="blueprint__region blueprint__region--shaded" style="bottom:0; left:0; right:0; height:80px;">
+          <span class="blueprint__region-label">③ [Region name] · h=[?px]</span>
+        </div>
+
+        <!-- Optional alignment markers -->
+        <div class="blueprint__align-marker" style="top:8px; right:8px;">[align: ...]</div>
+      </div>
+
+      <!-- ────── Tree outline ──────
+        Use <b> for elements/components, <code> for token references, <em> for
+        named region groupings. Mirror the numbered regions with ← ① markers.
+        토큰 표기 통일: <code>spacing-medium (16px)</code> 형태 (이름 + 괄호 픽셀).
+        구현 관점 주석: CSS variable `var(--spacing-medium)` 또는 Tailwind arbitrary
+        value `p-[var(--spacing-medium)]` — Flutter MinglitSpacing 아님.
+      -->
+      <div class="layout-tree"><b>&lt;main&gt;</b> (page container — <code>web_foundation_responsive</code> 컨테이너 규칙)
+├─ <em>[header region]</em>                       ← ①
+│  ├─ <b>[Component]</b>
+│  └─ Gap: <code>spacing-medium (16px)</code>
+│
+├─ <em>[scrollable body]</em>                     ← ②
+│  └─ [child components]
+│
+└─ <em>[bottom region]</em>                       ← ③
+   └─ [child components]</div>
+    </div>
+  </section>
+
+  <!-- ────── Desktop variant — 차이가 있는 화면만 이 섹션 유지 ──────
+       Mobile과 구조가 동일하면 (컨테이너 max-width 중앙 정렬뿐이면) 이 섹션 전체 삭제
+       + 위 Breakpoint variants 표에 "Mobile과 동일" 명시. -->
+  <section class="doc">
+    <h2>Blueprint &amp; tree — Desktop (≥1280px) <small style="font-size:12px;font-weight:400;color:var(--color-text-secondary);">— 차이가 있을 때만</small></h2>
+    <p class="intro">
+      [Mobile 대비 무엇이 달라지는가 — 예: body가 2-컬럼 그리드로, CTA가 우측 패널로 이동.]
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint" style="height: 300px;">
+        <!-- 데스크톱 비례 wireframe — 가로로 넓은 프레임 가정 -->
+        <div class="blueprint__region" style="top:0; left:0; right:0; bottom:0; border-style:solid; border-color: rgba(var(--spec-blueprint-rgb), 0.18);"></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:0; left:0; right:0; height:48px;">
+          <span class="blueprint__region-label">① [Region name] · h=[?px]</span>
+        </div>
+        <div class="blueprint__region" style="top:48px; left:0; width:60%; bottom:0;">
+          <span class="blueprint__region-label">② [main column]</span>
+        </div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:48px; right:0; width:40%; bottom:0;">
+          <span class="blueprint__region-label">③ [side panel]</span>
+        </div>
+      </div>
+      <div class="layout-tree"><b>&lt;main&gt;</b> (max-width 컨테이너 — <code>web_foundation_responsive</code> 참조)
+├─ <em>[header region]</em>                       ← ①
+└─ <b>grid</b> (2-col: [main / side], gap: <code>spacing-? (?px)</code>)
+   ├─ <em>[main column]</em>                      ← ②
+   └─ <em>[side panel]</em>                       ← ③</div>
+    </div>
+  </section>
+
+  <section class="doc">
+    <h2>Spacing &amp; alignment rules</h2>
+    <p class="intro">
+      variant별로 값이 다르면 Mobile / Desktop 컬럼에 각각 기입. 동일하면 Desktop 칸에 "동일".
+    </p>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 50px;">#</th>
+          <th style="width: 170px;">Region</th>
+          <th style="width: 170px;">Alignment</th>
+          <th>Spacing — Mobile</th>
+          <th>Spacing — Desktop</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- TODO: one row per numbered region. Cite real mds tokens.
+             구현은 CSS variable: var(--spacing-screen-edge) 등. -->
+        <tr><td>—</td><td>Outer page padding</td><td>—</td><td><code>spacing-screen-edge (16px)</code></td><td>[컨테이너 gutter — foundation 참조]</td></tr>
+        <tr><td>①</td><td>[region]</td><td>[justify / align]</td><td><code>spacing-? (?px)</code></td><td>동일</td></tr>
+        <tr><td>②</td><td>[region]</td><td>[align]</td><td><code>...</code></td><td><code>...</code></td></tr>
+        <tr><td>③</td><td>[region]</td><td>[align]</td><td><code>...</code></td><td><code>...</code></td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Sub-anatomies — required per region</h2>
+    <p class="intro">
+      <strong>Top-level blueprint은 화면 골조만 보여줌</strong>. 각 numbered region이 internal
+      composition을 가지면 그 region마다 별도 Sub-anatomy 섹션을 <strong>반드시 작성</strong>.
+      <strong>구조는 평면 PARALLEL</strong> — Sub-anatomy ①, ②, ③ ... 같은 level 나열, 깊이 금지.
+      breakpoint 간 internal composition이 다르면 해당 Sub-anatomy 안에 variant를 함께 기술
+      (별도 Sub-anatomy로 분리하지 않음).
+    </p>
+    <table class="ref">
+      <thead>
+        <tr><th style="width: 200px;">Region 형태</th><th>Sub-anatomy 작성</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>자식 element 2개 이상 + 정렬/간격 규칙 있음</td><td><strong>REQUIRED</strong> — blueprint + tree + spacing 표 모두 작성</td></tr>
+        <tr><td>자식 1개 (atom — 예: 버튼 단독)</td><td>생략 가능 — <code>/components/{name}.html</code> 참조로 위임</td></tr>
+        <tr><td>list / grid (반복 element)</td><td>REQUIRED — 1 item의 internal composition + 반복 패턴 (gap, breakpoint별 column 수)</td></tr>
+        <tr><td>scrollable body 내부에 여러 sections</td><td>REQUIRED — 각 section을 별도 Sub-anatomy로 분리</td></tr>
+      </tbody>
+    </table>
+    <p class="intro" style="margin-top: 12px;">
+      <strong>Numbering</strong> — top-level blueprint은 <code>①②③</code>, sub-anatomy 내부는 <code>㉠㉡㉢</code>.
+    </p>
+  </section>
+
+  <section class="doc">
+    <h2>Sub-anatomy ① — [Region name]</h2>
+    <p class="intro">
+      [이 region의 internal composition 1-2 sentences. breakpoint별 차이가 있으면 명시.]
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint" style="height: 200px;">
+        <!-- ⚠️ height: 200px도 EXAMPLE — sub-region 비례에 맞춰 변경 -->
+        <div class="blueprint__region blueprint__region--full"></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:16px;left:16px;width:100px;height:24px;">
+          <span class="blueprint__region-label">㉠ [child]</span>
+        </div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:48px;left:16px;right:16px;height:32px;">
+          <span class="blueprint__region-label">㉡ [child]</span>
+        </div>
+      </div>
+
+      <div class="layout-tree"><b>[Parent element for this region]</b>
+└─ padding: <code>spacing-? (?px)</code> — <code>var(--spacing-?)</code>
+   └─ <b>flex column / grid</b>(align: ...)
+      ├─ <em>[child name]</em>                                ← ㉠
+      │  └─ <b>[Component]</b>(<code>tokens</code>)
+      ├─ Gap: <code>spacing-? (?px)</code>
+      │
+      └─ <em>[child name]</em>                                ← ㉡
+         └─ <b>[Component]</b>(<code>tokens</code>)</div>
+    </div>
+
+    <table class="ref" style="margin-top: 16px;">
+      <thead>
+        <tr>
+          <th style="width: 60px;">#</th>
+          <th style="width: 180px;">Region</th>
+          <th style="width: 220px;">Alignment</th>
+          <th>Spacing / tokens</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>㉠</td><td>[child]</td><td>[align]</td><td><code>spacing-? (?px)</code></td></tr>
+        <tr><td>㉡</td><td>[child]</td><td>[align]</td><td><code>spacing-? (?px)</code></td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- TODO: Sub-anatomy ② ③ ... internal composition을 가진 모든 numbered region당
+       1 섹션씩 평면 추가. 단순 atom region은 생략 가능 (/components/ 참조). -->
+
+</div>
+
+<!-- ============================================================
+     🎨 PERSPECTIVE 2 · STATES — visual states + per-state spec
+     ============================================================ -->
+<div class="perspective" id="states">
+  <div class="perspective__header">
+    <span class="glyph">🎨</span>
+    <h2>States</h2>
+    <span class="lede">
+      각 state의 시각 mockup + state-specific 사양 — 6 aspect rows (조건 · 사용자 액션 ·
+      에지케이스 · 컴포넌트 · 토큰 · 노트). <strong>States는 breakpoint와 무관하게 공유</strong> —
+      variant별로 복제하지 않음. mockup은 surface의 기본 breakpoint로
+      (web_user → Mobile 375px · web_partner → Desktop).
+    </span>
+  </div>
+
+  <section class="doc">
+    <h2>States gallery</h2>
+    <p class="intro">
+      각 state는 <strong>독립된 미니 테이블</strong> — header(state name + tag) → 좌측 mockup(rowspan=6) +
+      우측 6 aspect rows (조건 / 사용자 액션 / 에지케이스 / 컴포넌트 / 토큰 / 노트).
+      cross-cutting 동작은 아래 Global Behavior 섹션에.
+    </p>
+
+    <p class="intro" style="background: var(--color-surface); padding: 12px; border-left: 3px solid var(--color-primary); border-radius: 4px;">
+      <strong>📋 Aspect 행 작성 룰</strong><br>
+      · <strong>조건</strong> — 데이터 로드 상태 / URL param / 로그인·권한 상태 기준을 디자인 언어로 명시 (예: "이벤트 데이터 로드 완료", "비로그인 방문")<br>
+      · <strong>사용자 액션</strong> — 이 state에서 가능한 모든 클릭/탭/입력/호버 (액션 N개면 N행으로 반복). disabled/무반응이면 "클릭 무반응" 한 행<br>
+      · <strong>에지케이스</strong> — 이 state 한정 변형. 없으면 "—". (cross-cutting edge는 Global Behavior로)<br>
+      · <strong>컴포넌트</strong> — 첫 state는 <strong>풀 리스트</strong>. 2번째 state부터 <strong>변경분만</strong>:
+        <code>+ X</code> (추가) · <code>− X</code> (제거) · <code>↔ X → Y</code> (교체) · <code>동일</code> (변경 없음) · <code>—</code> (해당 없음)<br>
+      · <strong>토큰</strong> — 컴포넌트와 동일 룰. 토큰 이름은 MDS 체계 (<code>color-primary</code> · <code>spacing-medium</code> 등) —
+        구현은 CSS variable <code>var(--color-primary)</code> / Tailwind <code>text-[var(--color-primary)]</code> 형태로 소비<br>
+      · <strong>노트</strong> — free-form designer/dev memo. 없으면 "—"<br>
+      <br>
+      <strong>State 종류 식별</strong> — Default/Empty/Loading/Error는 default placeholder. 화면별로 실제
+      데이터 상태 · URL param · 사용자 상태 기준으로 enumerate. Behavior Source 모바일 spec의
+      state enumeration 을 출발점으로 삼되, 웹 전용 state(예: 비로그인 public view)를 추가.
+    </p>
+
+    <!-- ════════════════════════════════════════════════════════════
+         State summary matrix — 선택적 (state 5개 이상일 때 권장)
+         ════════════════════════════════════════════════════════════ -->
+    <h3 style="margin-top: 24px;">State summary <small style="font-size:12px;font-weight:400;color:var(--color-text-secondary);">— state 5개 이상일 때 권장</small></h3>
+    <p class="intro">
+      모든 state를 한 row씩 한눈에 비교. 자세한 사양은 아래 각 state mini-table 참조.
+    </p>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 180px;">State</th>
+          <th style="width: 100px;">Tag</th>
+          <th style="width: 220px;">조건 (요약)</th>
+          <th>Key visual differentiator</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- TODO: 각 state 1행씩. -->
+        <tr><td><strong>Default</strong></td><td>primary</td><td>[데이터 로드 완료]</td><td>모든 컴포넌트 풀 렌더 — 인터랙션 가능</td></tr>
+        <tr><td><strong>Empty</strong></td><td>no data</td><td>[데이터 0건]</td><td>풀-페이지 empty state 단독 표시</td></tr>
+        <tr><td><strong>Loading</strong></td><td>async</td><td>[fetch 중]</td><td>Skeleton으로 컴포넌트 자리 표시</td></tr>
+        <tr><td><strong>Error</strong></td><td>network/server</td><td>[로드 실패]</td><td>에러 메시지 + 다시 시도 CTA</td></tr>
+      </tbody>
+    </table>
+
+    <div class="visual-gallery" style="background: var(--color-surface); padding: 16px; border-radius: var(--radius-card); display: flex; flex-direction: column; gap: 16px;">
+
+      <!-- ─── Default (annotated, primary case) ──────────── -->
+      <table class="ref state-mini">
+        <thead>
+          <tr><th colspan="3">
+            <strong>Default</strong> <span class="tag">primary</span>
+          </th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td rowspan="6" class="state-mini__mock">
+              <div class="viewport">
+                <!-- TODO: real screen content (real logo / icons / Korean copy)
+                     web_user → 기본 375px viewport (mobile-web-first)
+                     web_partner → .viewport--desktop 등으로 데스크톱 폭 mockup -->
+                [SCREEN CONTENT]
+
+                <!-- ════════════════════════════════════════════════════════
+                     Spec-mode overlays — 첫 state(Default) mockup에서만 사용.
+                     · annotation: 토큰 라벨 (spacing-medium 등)
+                     · callout (ⓐⓑⓒ): 컴포넌트 위치 — 첫 state "컴포넌트" 행 순서와 1:1
+                     · type-spec: 타이포 inline (size/weight/line-height) -->
+                <span class="annotation" style="top:8px;left:8px;">spacing-? — [where]</span>
+                <span class="callout" style="top:?px;right:?px;">ⓐ</span>
+                <span class="callout" style="top:?px;right:?px;">ⓑ</span>
+                <span class="type-spec" style="top:?px;left:?px;">14 / 400 / 1.45</span>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>[이 상태가 보이는 일반적 상황 — 데이터 상태, 사용자 상태, URL param 등]</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">사용자 액션</td>
+            <td>"[액션]" 클릭 → [즉각 피드백 + 상태 전이 + 도착지 URL]</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">에지케이스</td>
+            <td><strong>[edge case]</strong> — [user-visible behavior]</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td><code>[Button]</code> · <code>[Chip]</code> · <code>[EventCard]</code> · <code>[+ 이 화면이 사용하는 모든 컴포넌트 — MDS 컴포넌트 spec 이름 기준]</code></td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td><code>color-primary</code> · <code>spacing-medium</code> · <code>radius-card</code> · typography <code>bodyMedium</code> · <code>[+ 사용 토큰 전부 — CSS로는 var(--color-primary) 등]</code></td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">노트</td>
+            <td>📝 [free-form designer/dev memo — 결정 근거, TODO, 의문점 등]</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- ─── Empty ─────────────────────────────────────── -->
+      <table class="ref state-mini">
+        <thead>
+          <tr><th colspan="3">
+            <strong>Empty</strong> <span class="tag tag--mute">no data</span>
+          </th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td rowspan="6" class="state-mini__mock">
+              <div class="viewport">
+                [EMPTY STATE — full-page empty state]
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>[데이터가 0건일 때]</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">사용자 액션</td>
+            <td>"[CTA 버튼]" 클릭 → [빈 상태에서 권장되는 다음 액션 결과]</td>
+          </tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>—</td></tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>+ <code>[EmptyState]</code> (fullPage variant)</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td>동일 (Default 참조) — Empty 전용 추가 토큰 없음</td>
+          </tr>
+          <tr><td class="state-mini__aspect">노트</td><td>—</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── Loading ───────────────────────────────────── -->
+      <table class="ref state-mini">
+        <thead>
+          <tr><th colspan="3">
+            <strong>Loading</strong> <span class="tag tag--mute">async</span>
+          </th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td rowspan="6" class="state-mini__mock">
+              <div class="viewport">
+                [LOADING — skeleton placeholder]
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>[데이터 fetch 중 — SSR 화면이면 클라이언트 전환/액션 시에만 해당하는지 명시]</td>
+          </tr>
+          <tr><td class="state-mini__aspect">사용자 액션</td><td>클릭 무반응</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>—</td></tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>↔ <code>[Default content component]</code> → <code>[Skeleton]</code></td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td>동일 (skeleton shimmer는 컴포넌트 자체에 캡슐화 — 추가 토큰 없음)</td>
+          </tr>
+          <tr><td class="state-mini__aspect">노트</td><td>—</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── Error ─────────────────────────────────────── -->
+      <table class="ref state-mini">
+        <thead>
+          <tr><th colspan="3">
+            <strong>Error</strong> <span class="tag tag--mute">network/server</span>
+          </th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td rowspan="6" class="state-mini__mock">
+              <div class="viewport">
+                [ERROR STATE — full-page error with retry]
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>[로드 실패]</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">사용자 액션</td>
+            <td>"다시 시도" 클릭 → 재요청 → loading 재진입</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">에지케이스</td>
+            <td>네트워크 vs 서버 에러 구분 필요 시 sub-state로 분리 · 404/403 은 별도 페이지인지 명시</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>+ <code>[ErrorState]</code>(fullPage), <code>[TextButton]</code> ("다시 시도")</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td>+ <code>color-error</code> · <code>color-errorContainer</code></td>
+          </tr>
+          <tr><td class="state-mini__aspect">노트</td><td>—</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── Add more states as needed ──────────────────── -->
+      <!-- Common web variants: 비로그인 public view · form-filled · validation-error ·
+           wizard-stepN · modal-open · 404/403 등.
+           각 state는 자체 mini-table — mockup(rowspan=N) + N rows. -->
+
+    </div>
+  </section>
+</div>
+
+<!-- ============================================================
+     🔄 PERSPECTIVE 3 · GLOBAL BEHAVIOR — cross-cutting only
+     ============================================================ -->
+<div class="perspective" id="global-behavior">
+  <div class="perspective__header">
+    <span class="glyph">🔄</span>
+    <h2>Global Behavior</h2>
+    <span class="lede">
+      화면 전반에 걸친 cross-cutting 동작만 — motion timing, async lifecycle,
+      screen-wide edge cases. state-specific 동작은 States section의 각 mini-table에.
+      모바일 spec에서 상속한 behavior 는 Behavior Source 기준 — 여기엔 웹에서 달라지는 점만 추가.
+    </span>
+  </div>
+
+  <section class="doc">
+    <h2>Cross-cutting interactions</h2>
+    <p class="intro">
+      <strong>판단 기준</strong> — 이 액션이 모든 state(또는 다수 state)에서 동일하게 가능하면 cross-cutting.
+      특정 state에서만 가능하면 그 state의 mini-table로.
+    </p>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 220px;">사용자 액션</th>
+          <th>화면에 보이는 결과</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- TODO: 모든/다수 state에 적용되는 패턴만. 웹에서 흔한 예:
+             · 브라우저 back / forward (history 동작 — 모달/시트가 history entry인지)
+             · URL 직접 진입 / 새로고침 (state 복원 — 어떤 state로 착지하는가)
+             · 비로그인 접근 (redirect? public view?)
+             · hover (포인터 디바이스) vs touch — web_foundation_responsive 의 포인터 규칙 따름
+             · 브라우저 탭 비활성 → 복귀 (데이터 stale 처리) -->
+        <tr>
+          <td>브라우저 back</td>
+          <td>[이전 페이지로 — 모달/시트 열림 상태의 history 처리 명시]</td>
+        </tr>
+        <tr>
+          <td>새로고침 / URL 직접 진입</td>
+          <td>[URL만으로 state 복원 — 어떤 state로 착지하는가]</td>
+        </tr>
+        <tr>
+          <td>비로그인 접근</td>
+          <td>[로그인 redirect · 또는 public read-only view]</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Motion &amp; timing</h2>
+    <p class="intro">
+      <strong>임시값 사용 금지</strong> — duration은 MDS motion 토큰에서 선택.
+      토큰 이름은 모바일과 동일 체계 (<code>micro</code>/<code>fast</code>/<code>medium</code>/<code>slow</code>) —
+      웹 구현은 CSS <code>transition-duration</code> / Tailwind <code>duration-[N]</code> 로 같은 ms 값을 소비
+      (예: <code>fast (200ms)</code> → <code>transition: ... 200ms</code> 또는 <code>duration-200</code>).
+      <code>prefers-reduced-motion</code> 대응은 Global edge cases 에 명시.
+    </p>
+    <table class="ref" style="margin-bottom: 16px;">
+      <thead>
+        <tr><th style="width: 200px;">Token</th><th style="width: 80px;">Value</th><th>Use case</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>motion-micro</code></td><td>100ms</td><td>즉각 피드백 — chip toggle, button press, like 토글</td></tr>
+        <tr><td><code>motion-fast</code></td><td>200ms</td><td>간단 transition — fade, color change, hover</td></tr>
+        <tr><td><code>motion-medium</code></td><td>350ms</td><td>data crossfade, modal/sheet 진입</td></tr>
+        <tr><td><code>motion-slow</code></td><td>500ms</td><td>긴 page transition · 강조 모션</td></tr>
+        <tr><td><em>(unscoped)</em> attention loop</td><td>1.4–1.8s</td><td>blink / pulse / halo (token 미정의 — 직접 ms 명시)</td></tr>
+      </tbody>
+    </table>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 220px;">Transition</th>
+          <th style="width: 140px;">Duration (token)</th>
+          <th>Curve / notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- TODO: list each transition the user perceives. Reference token name + ms. -->
+        <tr>
+          <td>화면 진입 (loading → data)</td>
+          <td><code>medium</code> (350ms)</td>
+          <td>fade / crossfade — CSS transition or framer-motion</td>
+        </tr>
+        <tr>
+          <td>[주요 state 전이]</td>
+          <td><code>?</code> (?ms)</td>
+          <td>[curve + 사용자 인지 포인트]</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Global edge cases</h2>
+    <p class="intro">
+      화면 전반에 영향을 주는 edge case만. <strong>모든 항목 의무 아님</strong> — 적용되는 것만 작성.
+      다크 모드는 모든 spec에 작성 권장.
+    </p>
+    <ul class="notes">
+      <!-- TODO: 적용되는 항목만 남기고 나머지 삭제. -->
+      <li><strong>네트워크 끊김</strong> — [어떻게 나타나는가 — error state 진입 등] <em>(데이터 fetch 화면일 때)</em></li>
+      <li><strong>다크 모드</strong> — [우측 상단 Dark 토글로 확인 — 어떤 토큰이 어떻게 변하는가]</li>
+      <li><strong>접근성</strong> — [keyboard navigation / focus ring / screen reader / 큰 글씨 — 영향받는 요소. 웹은 키보드 포커스 순서 필수 검토]</li>
+      <li><strong>reduced motion</strong> — [<code>prefers-reduced-motion</code> 시 어떤 모션이 비활성화되는가]</li>
+      <li><strong>SEO / 공유</strong> — [public 페이지면 title/og 메타 + 공유 프리뷰 — 해당 시]</li>
+      <li><strong>브라우저 호환</strong> — [특이 의존이 있을 때만 — 기본은 evergreen 브라우저 가정]</li>
+    </ul>
+  </section>
+</div>
+
+<!-- ============================================================
+     📖 PERSPECTIVE 4 · REFERENCE — related screens only
+     ============================================================ -->
+<div class="perspective" id="reference">
+  <div class="perspective__header">
+    <span class="glyph">📖</span>
+    <h2>Reference</h2>
+    <span class="lede">
+      Implementation source + 인접 화면 link만. <strong>Components / Tokens는 States section의 각 mini-table</strong>에
+      분산됨 — 여기에서 중복 명세하지 않음.
+    </span>
+  </div>
+
+  <section class="doc">
+    <h2>Implementation source</h2>
+    <p class="intro">
+      이 spec과 매칭되는 실제 web source 위치. <code>designing</code> status면 미존재 항목은 <code>TBD</code>.
+    </p>
+    <table class="ref">
+      <thead>
+        <tr><th style="width: 200px;">항목</th><th>Path / Reference</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Page / Component</strong></td>
+          <td><code>[PageComponentName]</code></td>
+        </tr>
+        <tr>
+          <td><strong>File path</strong></td>
+          <td><a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/landing_user/src/app/[route]/page.tsx"><code>apps/landing_user/src/app/[route]/page.tsx</code></a> · web_partner는 <code>apps/landing_partner/...</code></td>
+        </tr>
+        <tr>
+          <td><strong>Data source</strong></td>
+          <td><code>[Supabase query / RPC / API route]</code> · <a href="..."><code>[file]</code></a></td>
+        </tr>
+        <tr>
+          <td><strong>Route</strong></td>
+          <td><code>[/path/:param]</code> · Next.js app router</td>
+        </tr>
+        <tr>
+          <td><strong>Behavior Source</strong></td>
+          <td><a href="/specs/[mobile_screen]/index.html"><code>/specs/[mobile_screen]/index.html</code></a> — Overview의 Behavior Source 행과 동일 경로</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="intro" style="margin-top: 12px; margin-bottom: 0;">
+      ※ 적용 안 되는 항목은 row 삭제. 항목별 미존재 시 <code>TBD</code>.
+    </p>
+  </section>
+
+  <section class="doc">
+    <h2>Related screens</h2>
+    <table class="ref">
+      <thead><tr><th style="width: 240px;">Spec</th><th>Relation</th></tr></thead>
+      <tbody>
+        <!-- TODO: neighbor screens — entry sources, exit targets,
+             sibling steps in a wizard, parent/child screens, 그리고
+             behavior source 모바일 spec. -->
+        <tr>
+          <td><a href="/specs/[neighbor]/index.html"><code>[NeighborScreen]</code></a></td>
+          <td>[관계 — 어떤 흐름으로 연결되는가]</td>
+        </tr>
+        <tr>
+          <td><a href="/specs/web_foundation_responsive/"><code>WebFoundationResponsive</code></a></td>
+          <td>breakpoint · 컨테이너 · 그리드 · 포인터 규칙 SSOT</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+</div>
+
+<!-- ============================================================
+     ✅ AUTHORING CHECKLIST — spec 작성 완료 전 self-check
+     ============================================================ -->
+<section class="doc" style="border: 2px solid var(--color-primary); border-radius: var(--radius-card); padding: 16px 24px; margin-top: 32px;">
+  <h2 style="color: var(--color-primary);">✅ Authoring checklist (web)</h2>
+  <p class="intro">
+    spec 작성 완료 전 항목별 self-check. 모든 ✓를 채울 수 있어야 published-ready.
+  </p>
+  <ul class="notes" style="line-height: 1.9;">
+    <li><strong>Head meta</strong> — <code>feature-status</code> · <code>features</code> · <code>surface</code> 3개 meta 채움. surface는 Overview의 Surface 행과 일치</li>
+    <li><strong>Header</strong> — Title (h1)만</li>
+    <li><strong>Overview</strong> — Status · Surface · Category · Route · <strong>Behavior Source</strong> · Hierarchy · Purpose · Entry/Exit · Background · Frequency 모두 채움 (해당 없으면 "—")</li>
+    <li><strong>Behavior Source</strong> — 상속하는 모바일 spec 경로 + 무엇을 상속하고 무엇이 달라지는지 1줄. web-native 화면이면 명시적으로 "—"</li>
+    <li><strong>History</strong> — Initial row + 의미 있는 변경 row (최신 → 오래된 순)</li>
+    <li><strong>Responsive Layout — variants</strong> — Mobile (&lt;768) blueprint 필수. Desktop (≥1280)은 구조가 다를 때만 별도 blueprint, 동일하면 표에 "Mobile과 동일" 명시. Tablet은 따라가는 variant 1줄</li>
+    <li><strong>Layout — Sub-anatomy</strong> — internal composition을 가진 모든 region마다 1 섹션 (평면 나열). breakpoint별 차이는 같은 Sub-anatomy 안에 기술</li>
+    <li><strong>States — breakpoint 공유</strong> — States 테이블은 variant별로 복제하지 않음. mockup은 surface 기본 breakpoint로</li>
+    <li><strong>States — 종류 enumerate</strong> — placeholder 그대로 쓰지 않고 실제 데이터/사용자/URL 상태 기준 enumerate. Behavior Source 의 state 목록과 대조</li>
+    <li><strong>States — mini-table 6 rows</strong> — 모든 state가 (조건 / 사용자 액션 / 에지케이스 / 컴포넌트 / 토큰 / 노트) 6행 채움</li>
+    <li><strong>States — 첫 state 풀 리스트, 2번째+ additive diff</strong> — <code>+ X</code> / <code>− X</code> / <code>↔ X → Y</code> / <code>동일</code> / <code>—</code> 5종 prefix만</li>
+    <li><strong>Global Behavior — 웹 cross-cutting</strong> — 브라우저 back / 새로고침·URL 진입 / 비로그인 접근 검토됨</li>
+    <li><strong>Global Behavior — Motion</strong> — 모든 duration이 motion token 이름 + ms로 표기. 임시값 금지. reduced-motion 검토</li>
+    <li><strong>토큰 표기 통일</strong> — 토큰 이름은 MDS 체계 (<code>spacing-medium (16px)</code> 형태). 구현 참조는 CSS variable / Tailwind 관점 (<code>var(--spacing-medium)</code>)</li>
+    <li><strong>Reference</strong> — Page/Component · File path · Data source · Route · Behavior Source 채움. 미존재 항목 <code>TBD</code></li>
+    <li><strong>Screen registry</strong> — <code>src/lib/screen-definitions.ts</code> 의 해당 surface 배열 (WEB_USER_SCREENS / WEB_PARTNER_SCREENS) 에 등록</li>
+  </ul>
+</section>
+
+</div>
+
+<script>
+  document.getElementById('spec-toggle').addEventListener('change', (e) => {
+    document.body.classList.toggle('spec-mode', e.target.checked);
+  });
+  document.getElementById('dark-toggle').addEventListener('change', (e) => {
+    document.body.classList.toggle('dark-mode', e.target.checked);
+  });
+</script>
+
+</body>
+</html>

--- a/apps/mds/docs/public/specs/account_management_page/index.html
+++ b/apps/mds/docs/public/specs/account_management_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — AccountManagementPage (kit-shared · AccountManagementRoute / PartnerAccountManagementRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/admin_console_dashboard/index.html
+++ b/apps/mds/docs/public/specs/admin_console_dashboard/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="features" content="admin/admin-dashboard">
-<meta name="feature-status" content="behavior-reference">
+<meta name="feature-status" content="in-progress">
 <title>Spec — AdminConsoleDashboard (web_admin · /admin)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/admin_console_dashboard/index.html
+++ b/apps/mds/docs/public/specs/admin_console_dashboard/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="features" content="admin/admin-dashboard">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — AdminConsoleDashboard (web_admin · /admin)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/auth_callback_page/index.html
+++ b/apps/mds/docs/public/specs/auth_callback_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — AuthCallbackPage (app_user · AuthCallbackRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/bank_account_page/index.html
+++ b/apps/mds/docs/public/specs/bank_account_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — BankAccountPage (app_partner · BankAccountRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/blocked_partners_page/index.html
+++ b/apps/mds/docs/public/specs/blocked_partners_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="on-hold">
 <title>Spec — BlockedPartnersPage (app_user · BlockedPartnersRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/checkin_placeholder_page/index.html
+++ b/apps/mds/docs/public/specs/checkin_placeholder_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — CheckinTabRoute (app_partner · route resolver)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -199,6 +200,7 @@ body.dark-mode .viewport {
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/create_verification_page/index.html
+++ b/apps/mds/docs/public/specs/create_verification_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — CreateVerificationPage (app_partner · CreateVerificationRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -257,6 +258,7 @@ body.dark-mode .viewport {
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/deletion_complete_page/index.html
+++ b/apps/mds/docs/public/specs/deletion_complete_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — DeletionCompletePage (app_user · DeletionCompleteRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/deletion_info_page/index.html
+++ b/apps/mds/docs/public/specs/deletion_info_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — DeletionInfoPage (app_user · DeletionInfoRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/deletion_reason_page/index.html
+++ b/apps/mds/docs/public/specs/deletion_reason_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — DeletionReasonPage (app_user · DeletionReasonRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/deletion_verify_page/index.html
+++ b/apps/mds/docs/public/specs/deletion_verify_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — DeletionVerifyPage (app_user · DeletionVerifyRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_application_detail_page/index.html
+++ b/apps/mds/docs/public/specs/event_application_detail_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventApplicationDetailPage (app_partner · EventApplicationDetailRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_application_list_page/index.html
+++ b/apps/mds/docs/public/specs/event_application_list_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventApplicationListPage (app_partner · EventApplicationListRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_application_manage_page/index.html
+++ b/apps/mds/docs/public/specs/event_application_manage_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventApplicationManagePage (app_partner · ApplicationListRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_application_review_carousel_page/index.html
+++ b/apps/mds/docs/public/specs/event_application_review_carousel_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventApplicationReviewCarouselPage (app_partner · EventApplicationReviewCarouselRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_application_review_confirm_page/index.html
+++ b/apps/mds/docs/public/specs/event_application_review_confirm_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventApplicationReviewConfirmPage (app_partner · EventApplicationReviewConfirmRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_application_review_page/index.html
+++ b/apps/mds/docs/public/specs/event_application_review_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventApplicationReviewPage (app_user · EventApplicationReviewRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_application_wizard_page/index.html
+++ b/apps/mds/docs/public/specs/event_application_wizard_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventApplicationWizardPage v2 (app_user · EventApplicationRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_bottom_ticket_bar/index.html
+++ b/apps/mds/docs/public/specs/event_bottom_ticket_bar/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventBottomTicketBar (app_user · event_detail bottom CTA)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_card/index.html
+++ b/apps/mds/docs/public/specs/event_card/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventCard (app_user · embedded in HomePage feed)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_check_in_screen/index.html
+++ b/apps/mds/docs/public/specs/event_check_in_screen/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — EventCheckInScreen (app_user · EventCheckInRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -273,6 +274,7 @@
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/event_checked_in_screen/index.html
+++ b/apps/mds/docs/public/specs/event_checked_in_screen/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — EventCheckedInScreen (app_user · EventCheckedInRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -192,6 +193,7 @@
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/event_create_page/index.html
+++ b/apps/mds/docs/public/specs/event_create_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventCreatePage (app_partner · EventCreateRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_detail_page/index.html
+++ b/apps/mds/docs/public/specs/event_detail_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventDetailPage (app_user · EventDetailRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_edit_page/index.html
+++ b/apps/mds/docs/public/specs/event_edit_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventEditPage (app_partner · EventEditRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_matching_results_screen/index.html
+++ b/apps/mds/docs/public/specs/event_matching_results_screen/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — EventMatchingResultsScreen (app_user · MatchResultsContent)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -259,6 +260,7 @@ body.dark-mode .match-card {
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/event_matching_screen/index.html
+++ b/apps/mds/docs/public/specs/event_matching_screen/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — EventMatchingScreen (app_user · EventMatchingRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -460,6 +461,7 @@ body.dark-mode .matching-dialog { background: var(--color-dark-surface); }
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/event_now_bar/index.html
+++ b/apps/mds/docs/public/specs/event_now_bar/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — EventNowBar (app_user · embedded in HomePage)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -118,6 +119,7 @@
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/event_ongoing_banner/index.html
+++ b/apps/mds/docs/public/specs/event_ongoing_banner/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventOngoingBanner (app_user · embedded in MyTicketsPage)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/event_results_screen/index.html
+++ b/apps/mds/docs/public/specs/event_results_screen/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — EventResultsScreen (app_user · EventResultsRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -166,6 +167,7 @@
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/event_review_screen/index.html
+++ b/apps/mds/docs/public/specs/event_review_screen/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventReviewScreen (app_user · EventReviewRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/home_page/index.html
+++ b/apps/mds/docs/public/specs/home_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — HomePage (app_user · HomeRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/identity_verification_screen/index.html
+++ b/apps/mds/docs/public/specs/identity_verification_screen/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — IdentityVerificationScreen (kit-shared · CertificationRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/location_guide_page/index.html
+++ b/apps/mds/docs/public/specs/location_guide_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="on-hold">
 <title>Spec — LocationGuidePage (app_partner · LocationGuideRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/login_page/index.html
+++ b/apps/mds/docs/public/specs/login_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — LoginPage (app_user · LoginRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/more_page/index.html
+++ b/apps/mds/docs/public/specs/more_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="on-hold">
 <title>Spec — MorePage (app_partner / MoreRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/my_page/index.html
+++ b/apps/mds/docs/public/specs/my_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — MyPage (app_user / MyPageRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/my_tickets_page/index.html
+++ b/apps/mds/docs/public/specs/my_tickets_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — MyTicketsPage (app_user · MyTicketsRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/notification_list_screen/index.html
+++ b/apps/mds/docs/public/specs/notification_list_screen/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="on-hold">
 <title>Spec — NotificationListScreen (kit-shared · NotificationCenterRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/notification_settings_screen/index.html
+++ b/apps/mds/docs/public/specs/notification_settings_screen/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="on-hold">
 <title>Spec — NotificationSettingsScreen (kit-shared · NotificationSettingsRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/ongoing_event_list_page/index.html
+++ b/apps/mds/docs/public/specs/ongoing_event_list_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — OngoingEventListPage (app_partner · participant check-in dashboard)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -524,6 +525,7 @@ body.dark-mode .viewport {
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/partner_application_detail_page/index.html
+++ b/apps/mds/docs/public/specs/partner_application_detail_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — PartnerApplicationDetailPage (app_partner · PartnerApplicationDetailRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -220,6 +221,7 @@ body.dark-mode .viewport {
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/partner_apply_page/index.html
+++ b/apps/mds/docs/public/specs/partner_apply_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — PartnerApplyPage (app_partner · PartnerApplyRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -311,6 +312,7 @@ body.dark-mode .viewport {
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/partner_apply_status_page/index.html
+++ b/apps/mds/docs/public/specs/partner_apply_status_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — PartnerApplyStatusPage (app_partner · PartnerApplyStatusRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -172,6 +173,7 @@ body.dark-mode .viewport {
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/partner_detail_page/index.html
+++ b/apps/mds/docs/public/specs/partner_detail_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — PartnerDetailPage (app_user · PartnerDetailRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/partner_event_detail_page/index.html
+++ b/apps/mds/docs/public/specs/partner_event_detail_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — EventDetailPage (app_partner · EventDetailRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/partner_events_page/index.html
+++ b/apps/mds/docs/public/specs/partner_events_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — PartnerEventsPage (app_user · PartnerEventsRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/partner_guide/index.html
+++ b/apps/mds/docs/public/specs/partner_guide/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="on-hold">
 <title>Spec — PartnerGuide (도움말)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/partner_home_page/index.html
+++ b/apps/mds/docs/public/specs/partner_home_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — PartnerHomePage (app_partner · HomeRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/partner_login_page/index.html
+++ b/apps/mds/docs/public/specs/partner_login_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — PartnerLoginPage (app_partner · LoginRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/partner_member_list_page/index.html
+++ b/apps/mds/docs/public/specs/partner_member_list_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="on-hold">
 <title>Spec — PartnerMemberListPage (app_partner · MemberListRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/partner_member_permission_page/index.html
+++ b/apps/mds/docs/public/specs/partner_member_permission_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="on-hold">
 <title>Spec — PartnerMemberPermissionPage (app_partner · MemberPermissionRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/partner_welcome_page/index.html
+++ b/apps/mds/docs/public/specs/partner_welcome_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — PartnerWelcomePage (app_partner · PartnerWelcomeRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -203,6 +204,7 @@ body.dark-mode .viewport {
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/party_create_wizard_page/index.html
+++ b/apps/mds/docs/public/specs/party_create_wizard_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — PartyCreateWizardPage (app_partner · PartyCreateWizardRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/party_detail_page/index.html
+++ b/apps/mds/docs/public/specs/party_detail_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — PartyDetailPage (app_partner · PartyDetailRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/party_list_page/index.html
+++ b/apps/mds/docs/public/specs/party_list_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — PartyListPage (app_partner · PartyListRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/privacy_page/index.html
+++ b/apps/mds/docs/public/specs/privacy_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — PrivacyPage (app_user / PrivacyRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/purchase_history_detail_page/index.html
+++ b/apps/mds/docs/public/specs/purchase_history_detail_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — PurchaseHistoryDetailPage (app_user · PurchaseHistoryDetailRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/purchase_history_page/index.html
+++ b/apps/mds/docs/public/specs/purchase_history_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — PurchaseHistoryPage (app_user · PurchaseHistoryRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/recurrence_management_screen/index.html
+++ b/apps/mds/docs/public/specs/recurrence_management_screen/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — RecurrenceManagementScreen (app_partner · RecurrenceManagementRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/search_page/index.html
+++ b/apps/mds/docs/public/specs/search_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — SearchPage (app_user · SearchRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/settlement_detail_page/index.html
+++ b/apps/mds/docs/public/specs/settlement_detail_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — SettlementDetailPage (app_partner · SettlementDetailRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/settlement_page/index.html
+++ b/apps/mds/docs/public/specs/settlement_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — SettlementPage (app_partner · SettlementRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/signup_consent_page/index.html
+++ b/apps/mds/docs/public/specs/signup_consent_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — SignupConsentPage (app_user · SignupConsentRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/tag_event_list_page/index.html
+++ b/apps/mds/docs/public/specs/tag_event_list_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — TagEventListPage (app_user · TagEventListRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -183,6 +184,7 @@ body.dark-mode .tel-appbar__title { color: var(--color-dark-text-primary); }
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/ticket_create_page/index.html
+++ b/apps/mds/docs/public/specs/ticket_create_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — TicketCreatePage (app_partner · TicketCreateRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/ticket_edit_page/index.html
+++ b/apps/mds/docs/public/specs/ticket_edit_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — TicketEditPage (app_partner · TicketEditRoute / PartyTicketEditRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/ticket_qr_screen/index.html
+++ b/apps/mds/docs/public/specs/ticket_qr_screen/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — TicketQRScreen (app_user · TicketQRRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -182,6 +183,7 @@ body.dark-mode .tqr-bp-placeholder__tag { background: var(--color-dark-backgroun
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/ticket_selection_sheet/index.html
+++ b/apps/mds/docs/public/specs/ticket_selection_sheet/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="behavior-reference">
 <title>Spec — TicketSelectionSheet (app_user · event purchase sheet)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>

--- a/apps/mds/docs/public/specs/verification_manage_page/index.html
+++ b/apps/mds/docs/public/specs/verification_manage_page/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="feature-status" content="deprecated">
 <title>Spec — VerificationManagePage (app_partner · VerificationManageRoute)</title>
 <link rel="stylesheet" href="/specs/_spec.css">
 <style>
@@ -275,6 +276,7 @@ body.dark-mode .viewport {
 </style>
 </head>
 <body>
+<p class="spec-status-banner">⛔ Deprecated (web-mvp pivot, 2026-06-06) — 신규 작업 금지. 배경: docs/architecture/web-mvp-pivot.md</p>
 
 <div class="toolbar">
   <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>

--- a/apps/mds/docs/public/specs/web_foundation_responsive/index.html
+++ b/apps/mds/docs/public/specs/web_foundation_responsive/index.html
@@ -1,0 +1,655 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="feature-status" content="in-progress">
+<meta name="features" content="web/foundation-responsive">
+<meta name="surface" content="web_shared">
+<title>Spec — WebFoundationResponsive (web shared · foundation)</title>
+<link rel="stylesheet" href="/specs/_spec.css">
+<style>
+/* Foundation spec — breakpoint/container/grid/pointer SSOT for all web surfaces.
+   Not a routed screen: no real mockup content, viewports illustrate container behavior. */
+:root {
+  --spec-blueprint-rgb: 34, 102, 204;
+}
+.page { max-width: 1120px; }
+.wfr-canvas {
+  position: absolute;
+  inset: 0;
+  background: #f5f7fa;
+  display: flex;
+  justify-content: center;
+}
+.wfr-container {
+  background: rgba(34, 102, 204, 0.08);
+  border-left: 1px dashed rgba(34, 102, 204, 0.5);
+  border-right: 1px dashed rgba(34, 102, 204, 0.5);
+  display: grid;
+  grid-auto-rows: min-content;
+  gap: 8px;
+  padding: 12px;
+  align-content: start;
+  flex: 1;
+}
+.wfr-container--capped { max-width: 82%; flex: 1; }
+.wfr-cell {
+  height: 56px;
+  background: rgba(34, 102, 204, 0.18);
+  border-radius: 6px;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  color: #2a4a78;
+  font-weight: 700;
+}
+.wfr-grid-2 { grid-template-columns: repeat(2, 1fr); }
+.wfr-grid-12 { grid-template-columns: repeat(12, 1fr); }
+.wfr-label {
+  position: absolute;
+  top: 6px;
+  left: 8px;
+  font-size: 10px;
+  font-weight: 800;
+  color: #2a4a78;
+  letter-spacing: 0.04em;
+}
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>
+  <label><input type="checkbox" id="dark-toggle"> Dark mode (viewports flip dark)</label>
+</div>
+
+<div class="page">
+
+<header>
+  <h1>Web Responsive Foundation</h1>
+</header>
+
+<section class="doc">
+  <h2>Overview</h2>
+  <table class="ref">
+    <tbody>
+      <tr><th style="width: 160px;">Status</th><td><strong>🚧 디자인중</strong> — web MVP pivot 의 responsive 기반 규칙</td></tr>
+      <tr><th>Surface</th><td><code>web_shared</code> — <code>web_user</code> · <code>web_partner</code> · <code>web_admin</code> 모든 웹 surface 가 공유</td></tr>
+      <tr><th>Category</th><td>foundation · layout</td></tr>
+      <tr><th>Route / Surface</th><td>— (foundation spec — 라우트 없음)</td></tr>
+      <tr>
+        <th>Behavior Source</th>
+        <td>— (web-native foundation, no mobile counterpart)</td>
+      </tr>
+      <tr>
+        <th>Hierarchy</th>
+        <td>
+          <strong>Parent</strong>: <em>— (top-level foundation)</em><br>
+          <strong>Children</strong>: 모든 web screen spec — <a href="/specs/_template_web.html"><code>_template_web.html</code></a> 로 작성되는 spec 이 이 문서의 breakpoint/컨테이너/그리드/포인터 규칙을 참조한다.
+        </td>
+      </tr>
+      <tr>
+        <th>Purpose</th>
+        <td>
+          웹 surface 공통 responsive 규칙의 SSOT. breakpoint 경계 · 컨테이너 폭 · 그리드 ·
+          터치/포인터 규칙을 한 곳에 정의해, 각 screen spec 은 "이 화면이 breakpoint 별로
+          어떻게 달라지는지"만 기술하게 한다.
+        </td>
+      </tr>
+      <tr>
+        <th>User journey</th>
+        <td>
+          <strong>Entry points</strong>: web screen spec 작성/리뷰 시 참조.<br>
+          <strong>Exit points</strong>: 각 화면의 Responsive Layout 섹션.
+        </td>
+      </tr>
+      <tr>
+        <th>Background</th>
+        <td>
+          웹 MVP 피벗 — 유저웹/파트너웹은 landing_user/landing_partner 확장으로 구현.
+          기존 70개 모바일 spec 은 behavior source 로 유지하고, 웹 화면 spec 은 신규 작성.
+          <strong>유저웹은 모바일웹 우선</strong> (SNS/검색 유입 = 모바일 브라우저 다수),
+          <strong>파트너웹·admin 은 데스크톱 우선</strong> (운영/관리 작업 환경) 원칙을 여기서 고정한다.
+        </td>
+      </tr>
+      <tr><th>Frequency</th><td>모든 web spec 작성 시 1회 이상 참조되는 공통 기반.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="doc">
+  <h2>History</h2>
+  <table class="ref">
+    <thead>
+      <tr>
+        <th style="width: 110px;">Date</th>
+        <th style="width: 80px;">Version</th>
+        <th style="width: 120px;">Author</th>
+        <th>Changes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>2026-06-06</td>
+        <td>1.0</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>Initial foundation published</strong> — breakpoint 3단 (mobile &lt;768 / tablet 768–1279 / desktop ≥1280),
+          컨테이너 폭, 그리드 규칙, 터치/포인터 규칙, surface 별 우선순위 원칙
+          (유저웹 = 모바일웹 우선 · 파트너웹/admin = 데스크톱 우선) 정의.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<nav class="perspective-nav">
+  <a href="#layout"><span class="glyph">🧱</span> Responsive Layout</a>
+  <a href="#states"><span class="glyph">🎨</span> States</a>
+  <a href="#global-behavior"><span class="glyph">🔄</span> Global Behavior</a>
+  <a href="#reference"><span class="glyph">📖</span> Reference</a>
+</nav>
+
+<!-- ============================================================
+     🧱 PERSPECTIVE 1 · RESPONSIVE LAYOUT — breakpoint / container / grid SSOT
+     ============================================================ -->
+<div class="perspective" id="layout">
+  <div class="perspective__header">
+    <span class="glyph">🧱</span>
+    <h2>Responsive Layout</h2>
+    <span class="lede">
+      breakpoint 경계 · 컨테이너 폭 · 그리드 규칙의 정의. 모든 web screen spec 이 이 값을 인용한다.
+    </span>
+  </div>
+
+  <section class="doc">
+    <h2>Breakpoints</h2>
+    <p class="intro">
+      3단 breakpoint. 경계값은 CSS media query / Tailwind 기준으로 min-width 판정
+      (<code>md: 768px</code> · <code>xl: 1280px</code> 와 정렬). screen spec 의 variant 는
+      <strong>Mobile / Desktop 2종만</strong> 작성하고, Tablet 은 어느 variant 를 따르는지 1줄로 명시한다.
+    </p>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 140px;">Tier</th>
+          <th style="width: 180px;">Range</th>
+          <th style="width: 220px;">Media query / Tailwind</th>
+          <th>Spec variant 규칙</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Mobile</strong></td>
+          <td><code>&lt; 768px</code></td>
+          <td>기본 (no prefix) — mobile-first</td>
+          <td>모든 web spec 의 <strong>기본 variant</strong>. 항상 blueprint 작성.</td>
+        </tr>
+        <tr>
+          <td><strong>Tablet</strong></td>
+          <td><code>768 – 1279px</code></td>
+          <td><code>@media (min-width: 768px)</code> · <code>md:</code></td>
+          <td>별도 blueprint 없음 — 기본: web_user 는 Mobile 레이아웃 유지(컨테이너만 fluid), web_partner/web_admin 은 Desktop 레이아웃 축소. 화면별 예외만 spec 에 1줄.</td>
+        </tr>
+        <tr>
+          <td><strong>Desktop</strong></td>
+          <td><code>≥ 1280px</code></td>
+          <td><code>@media (min-width: 1280px)</code> · <code>xl:</code></td>
+          <td>Mobile 과 구조가 다른 화면만 variant blueprint 추가. States 테이블은 공유.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Container widths</h2>
+    <p class="intro">
+      페이지 콘텐츠의 최대 폭과 좌우 gutter. 컨테이너는 항상 중앙 정렬, gutter 는 컨테이너 바깥 패딩.
+      토큰 이름은 MDS 체계 — 구현은 CSS variable / Tailwind arbitrary value 로 소비.
+    </p>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 140px;">Tier</th>
+          <th style="width: 200px;">Content max-width</th>
+          <th style="width: 200px;">Gutter (좌우 패딩)</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Mobile</strong></td>
+          <td>fluid (100%)</td>
+          <td><code>spacing-screen-edge (16px)</code> — <code>var(--spacing-screen-edge)</code></td>
+          <td>모바일 앱과 동일 edge 패딩 감각 유지.</td>
+        </tr>
+        <tr>
+          <td><strong>Tablet</strong></td>
+          <td>fluid (100%) · 단일 컬럼 콘텐츠는 <code>720px</code> 캡 권장</td>
+          <td><code>24px</code></td>
+          <td>긴 글줄 방지 — 읽기 콘텐츠는 폭 캡.</td>
+        </tr>
+        <tr>
+          <td><strong>Desktop</strong></td>
+          <td><code>1200px</code> 캡 (admin console 등 풀-와이드 도구 화면은 <code>1440px</code>까지 허용)</td>
+          <td><code>32px</code></td>
+          <td>중앙 정렬. 캡 초과 영역은 배경(surface)으로 채움.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="layout-grid" style="margin-top: 16px;">
+      <div class="blueprint">
+        <!-- Mobile container: fluid + 16px gutter -->
+        <div class="blueprint__region" style="top:0; left:0; right:0; bottom:0; border-style:solid; border-color: rgba(var(--spec-blueprint-rgb), 0.18);"></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:0; left:16px; right:16px; bottom:0;">
+          <span class="blueprint__region-label">① content — fluid · gutter 16px</span>
+        </div>
+        <div class="blueprint__align-marker" style="top:8px; right:24px;">gutter: spacing-screen-edge (16px)</div>
+      </div>
+      <div class="layout-tree"><b>Mobile (&lt;768px)</b>
+<b>&lt;body&gt;</b>
+└─ <b>&lt;main&gt;</b> — width: 100%
+   └─ padding-inline: <code>spacing-screen-edge (16px)</code>
+      └─ <em>content</em>                          ← ①
+
+<b>Desktop (≥1280px)</b>
+<b>&lt;body&gt;</b>
+└─ <b>&lt;main&gt;</b> — max-width: <code>1200px</code> · margin-inline: auto
+   └─ padding-inline: <code>32px</code>
+      └─ <em>content</em> (12-col grid)</div>
+    </div>
+  </section>
+
+  <section class="doc">
+    <h2>Grid rules</h2>
+    <p class="intro">
+      카드 목록 등 반복 콘텐츠의 컬럼 규칙. 고정 컬럼 수 — 컨테이너 폭 안에서 1fr 균등 분할.
+    </p>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 140px;">Tier</th>
+          <th style="width: 160px;">Columns</th>
+          <th style="width: 160px;">Gap</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td><strong>Mobile</strong></td><td>1 col (카드 목록) · 최대 2 col (compact 아이템)</td><td><code>spacing-medium (16px)</code></td><td>세로 스크롤 단일 흐름 우선.</td></tr>
+        <tr><td><strong>Tablet</strong></td><td>2 col</td><td><code>spacing-medium (16px)</code></td><td>카드 목록 기본 2열.</td></tr>
+        <tr><td><strong>Desktop</strong></td><td>12-col 레이아웃 그리드 · 카드 목록은 3–4 col</td><td><code>24px</code></td><td>main/side 분할 등 페이지 구조는 12-col 기준으로 명세 (예: 8/4 분할).</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Touch / pointer rules</h2>
+    <p class="intro">
+      입력 수단은 breakpoint 가 아니라 capability 로 판정 — <code>@media (hover: hover) and (pointer: fine)</code>.
+      좁은 창의 데스크톱, 터치 노트북이 있으므로 "좁으면 터치"라고 가정하지 않는다.
+    </p>
+    <table class="ref">
+      <thead>
+        <tr><th style="width: 240px;">Rule</th><th>정의</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>최소 터치 타깃</strong></td>
+          <td>44×44px — 터치 가능 모든 인터랙티브 요소. 시각 크기가 작아도 hit area 는 44px 확보.</td>
+        </tr>
+        <tr>
+          <td><strong>Hover 의존 금지</strong></td>
+          <td>hover 로만 노출되는 정보/액션 금지 — hover 는 보조 강조(<code>hover: hover</code> 디바이스에서만), 모든 액션은 클릭/탭으로 도달 가능해야 함.</td>
+        </tr>
+        <tr>
+          <td><strong>포인터 피드백</strong></td>
+          <td>fine pointer: hover 상태 (<code>motion-fast (200ms)</code> transition) + <code>cursor: pointer</code>. coarse pointer: press 상태로 즉각 피드백 (<code>motion-micro (100ms)</code>).</td>
+        </tr>
+        <tr>
+          <td><strong>스와이프 제스처</strong></td>
+          <td>모바일웹에서도 스와이프는 보조 수단 — 동일 기능의 버튼 대안 필수 (캐러셀 화살표 등).</td>
+        </tr>
+        <tr>
+          <td><strong>키보드</strong></td>
+          <td>모든 인터랙티브 요소 tab 도달 가능 + visible focus ring. 데스크톱 우선 surface (web_partner/web_admin) 는 필수 검토.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Surface priority principles</h2>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 160px;">Surface</th>
+          <th style="width: 200px;">우선 breakpoint</th>
+          <th>원칙</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>web_user</code></td>
+          <td><strong>Mobile (모바일웹 우선)</strong></td>
+          <td>SNS/검색 유입 = 모바일 브라우저 다수. Mobile blueprint 가 1차 산출물, Desktop 은 컨테이너 캡 중앙 정렬이 기본값 (구조가 달라질 때만 variant). spec mockup 도 375px viewport 기본.</td>
+        </tr>
+        <tr>
+          <td><code>web_partner</code></td>
+          <td><strong>Desktop (데스크톱 우선)</strong></td>
+          <td>운영/관리 작업 환경. Desktop blueprint 가 1차 산출물, Mobile 은 조회 중심 축소 (핵심 운영 액션은 유지). spec mockup 은 데스크톱 폭 viewport 권장.</td>
+        </tr>
+        <tr>
+          <td><code>web_admin</code></td>
+          <td><strong>Desktop only</strong></td>
+          <td>내부 admin console — 모바일 대응 비목표. <code>admin_console_dashboard</code> spec 패턴 유지.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+<!-- ============================================================
+     🎨 PERSPECTIVE 2 · STATES — breakpoint tier 별 컨테이너 동작
+     ============================================================ -->
+<div class="perspective" id="states">
+  <div class="perspective__header">
+    <span class="glyph">🎨</span>
+    <h2>States</h2>
+    <span class="lede">
+      foundation 의 "state" = breakpoint tier. 각 tier 에서 컨테이너/그리드가 어떻게 동작하는지를
+      mockup 으로 보여준다. (일반 screen spec 의 데이터 state 와 다름 — foundation 전용 해석.)
+    </span>
+  </div>
+
+  <section class="doc">
+    <h2>Breakpoint tiers</h2>
+
+    <div class="visual-gallery" style="background: var(--color-surface); padding: 16px; border-radius: var(--radius-card); display: flex; flex-direction: column; gap: 16px;">
+
+      <!-- ─── Mobile ──────────────────────────────────────── -->
+      <table class="ref state-mini">
+        <thead>
+          <tr><th colspan="3">
+            <strong>Mobile</strong> <span class="tag">&lt; 768px · 기본</span>
+          </th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td rowspan="6" class="state-mini__mock">
+              <div class="viewport" style="height: 420px;">
+                <div class="wfr-canvas">
+                  <span class="wfr-label">MOBILE · fluid · gutter 16px</span>
+                  <div class="wfr-container" style="margin: 28px 16px 12px;">
+                    <div class="wfr-cell">content 1col</div>
+                    <div class="wfr-cell">content 1col</div>
+                    <div class="wfr-cell">content 1col</div>
+                  </div>
+                </div>
+                <span class="annotation" style="top:8px;left:8px;">gutter: spacing-screen-edge (16px)</span>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>viewport 폭 768px 미만 — 모바일 브라우저 · 좁은 창</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">사용자 액션</td>
+            <td>세로 스크롤 단일 흐름 — 터치 타깃 44px · 스와이프는 보조 수단</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">에지케이스</td>
+            <td><strong>초소형 (&lt;360px)</strong> — 별도 분기 없음, fluid 축소로 흡수. 줄바꿈 깨짐만 화면별 검수</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>page container (fluid) · 1-col content grid</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td><code>spacing-screen-edge (16px)</code> · <code>spacing-medium (16px)</code> — CSS: <code>var(--spacing-screen-edge)</code> · <code>var(--spacing-medium)</code></td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">노트</td>
+            <td>📝 web_user 의 1차 디자인 대상 tier — 모바일 앱 spec 과 같은 시각 감각 유지</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- ─── Tablet ──────────────────────────────────────── -->
+      <table class="ref state-mini">
+        <thead>
+          <tr><th colspan="3">
+            <strong>Tablet</strong> <span class="tag tag--mute">768 – 1279px</span>
+          </th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td rowspan="6" class="state-mini__mock">
+              <div class="viewport" style="width: 560px; height: 420px;">
+                <div class="wfr-canvas">
+                  <span class="wfr-label">TABLET · fluid · gutter 24px · 2col</span>
+                  <div class="wfr-container wfr-grid-2" style="margin: 28px 24px 12px;">
+                    <div class="wfr-cell">col 1</div>
+                    <div class="wfr-cell">col 2</div>
+                    <div class="wfr-cell">col 1</div>
+                    <div class="wfr-cell">col 2</div>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>viewport 폭 768–1279px — 태블릿 · 중간 폭 창</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">사용자 액션</td>
+            <td>입력 수단 혼재 — capability query 로 hover/터치 판정 (breakpoint 로 가정 금지)</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">에지케이스</td>
+            <td><strong>별도 blueprint 없는 tier</strong> — web_user 는 Mobile 레이아웃 유지, web_partner 는 Desktop 레이아웃 축소. 화면별 예외만 해당 spec 에 명시</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>↔ 1-col grid → 2-col grid · 읽기 콘텐츠 720px 캡</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td>↔ gutter <code>spacing-screen-edge (16px)</code> → <code>24px</code></td>
+          </tr>
+          <tr><td class="state-mini__aspect">노트</td><td>—</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── Desktop ─────────────────────────────────────── -->
+      <table class="ref state-mini">
+        <thead>
+          <tr><th colspan="3">
+            <strong>Desktop</strong> <span class="tag tag--mute">≥ 1280px</span>
+          </th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td rowspan="6" class="state-mini__mock">
+              <div class="viewport" style="width: 720px; height: 420px;">
+                <div class="wfr-canvas">
+                  <span class="wfr-label">DESKTOP · max-width 1200px 캡 · 중앙 정렬 · 12col</span>
+                  <div class="wfr-container wfr-container--capped wfr-grid-12" style="margin: 28px 0 12px;">
+                    <div class="wfr-cell" style="grid-column: span 8;">main · 8col</div>
+                    <div class="wfr-cell" style="grid-column: span 4;">side · 4col</div>
+                    <div class="wfr-cell" style="grid-column: span 4;">card</div>
+                    <div class="wfr-cell" style="grid-column: span 4;">card</div>
+                    <div class="wfr-cell" style="grid-column: span 4;">card</div>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>viewport 폭 1280px 이상 — 데스크톱 브라우저</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">사용자 액션</td>
+            <td>hover 피드백 (<code>motion-fast (200ms)</code>) + cursor pointer · 키보드 tab 네비게이션 필수</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">에지케이스</td>
+            <td><strong>초광폭 (≥1920px)</strong> — 1200px 캡 유지, 잉여 폭은 배경으로. 풀-와이드 도구 화면만 1440px 캡 허용</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>+ 12-col 레이아웃 그리드 (main/side 분할) · 카드 3–4 col</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td>↔ gutter → <code>32px</code> · grid gap <code>24px</code></td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">노트</td>
+            <td>📝 web_partner / web_admin 의 1차 디자인 대상 tier</td>
+          </tr>
+        </tbody>
+      </table>
+
+    </div>
+  </section>
+</div>
+
+<!-- ============================================================
+     🔄 PERSPECTIVE 3 · GLOBAL BEHAVIOR — resize · pointer · motion
+     ============================================================ -->
+<div class="perspective" id="global-behavior">
+  <div class="perspective__header">
+    <span class="glyph">🔄</span>
+    <h2>Global Behavior</h2>
+    <span class="lede">
+      breakpoint 전환 · 입력 capability 전환 등 모든 웹 화면에 공통으로 적용되는 동작.
+    </span>
+  </div>
+
+  <section class="doc">
+    <h2>Cross-cutting interactions</h2>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 240px;">사용자 액션</th>
+          <th>화면에 보이는 결과</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>창 리사이즈 (tier 경계 통과)</td>
+          <td>레이아웃 즉시 reflow — 전환 애니메이션 없음. 스크롤 위치·입력값·열린 모달 유지.</td>
+        </tr>
+        <tr>
+          <td>모바일 기기 회전 (portrait ↔ landscape)</td>
+          <td>리사이즈와 동일 처리 — landscape 폭이 768px 을 넘으면 Tablet tier 적용.</td>
+        </tr>
+        <tr>
+          <td>브라우저 줌 (텍스트 확대)</td>
+          <td>200% 줌에서 가로 스크롤 없이 사용 가능해야 함 (effective viewport 가 좁아지면 하위 tier 레이아웃 적용).</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Motion &amp; timing</h2>
+    <p class="intro">
+      duration 토큰 체계는 모바일 MDS 와 동일 (micro 100 / fast 200 / medium 350 / slow 500).
+      웹 구현은 CSS <code>transition-duration</code> / Tailwind <code>duration-N</code> 으로 같은 ms 값 소비.
+      breakpoint 전환 자체에는 모션을 걸지 않는다.
+    </p>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 220px;">Transition</th>
+          <th style="width: 140px;">Duration (token)</th>
+          <th>Curve / notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>breakpoint reflow</td><td>없음 (0ms)</td><td>즉시 reflow — 중간 폭 애니메이션 금지</td></tr>
+        <tr><td>hover 피드백 (fine pointer)</td><td><code>fast</code> (200ms)</td><td>ease-out — color/elevation 변화</td></tr>
+        <tr><td>press 피드백 (coarse pointer)</td><td><code>micro</code> (100ms)</td><td>즉각 시각 변화</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Global edge cases</h2>
+    <ul class="notes">
+      <li><strong>다크 모드</strong> — 컨테이너/그리드 규칙은 다크 모드와 무관 (배경 토큰만 전환).</li>
+      <li><strong>접근성</strong> — 200% 줌 + 가로 스크롤 금지 · visible focus ring · 터치 타깃 44px — 본 문서의 규칙이 모든 화면의 baseline.</li>
+      <li><strong>reduced motion</strong> — <code>prefers-reduced-motion</code> 시 hover/press 피드백은 유지하되 transition 을 0ms 로.</li>
+      <li><strong>브라우저 호환</strong> — evergreen 브라우저 기준. <code>hover/pointer</code> media query 미지원 환경은 coarse pointer 로 폴백.</li>
+    </ul>
+  </section>
+</div>
+
+<!-- ============================================================
+     📖 PERSPECTIVE 4 · REFERENCE
+     ============================================================ -->
+<div class="perspective" id="reference">
+  <div class="perspective__header">
+    <span class="glyph">📖</span>
+    <h2>Reference</h2>
+    <span class="lede">foundation 이므로 implementation source 대신 소비처/관련 문서 링크.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Implementation source</h2>
+    <table class="ref">
+      <thead>
+        <tr><th style="width: 200px;">항목</th><th>Path / Reference</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Web user app</strong></td>
+          <td><code>apps/landing_user/</code> — 유저웹 (모바일웹 우선) · 구현 시 이 문서의 breakpoint/컨테이너 값 적용 <code>TBD</code></td>
+        </tr>
+        <tr>
+          <td><strong>Web partner app</strong></td>
+          <td><code>apps/landing_partner/</code> — 파트너웹 (데스크톱 우선) <code>TBD</code></td>
+        </tr>
+        <tr>
+          <td><strong>Token SSOT</strong></td>
+          <td><code>shared/packages/mds/tokens/</code> — generated CSS 는 docs 의 <code>public/tokens.css</code> 로 sync</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Related screens</h2>
+    <table class="ref">
+      <thead><tr><th style="width: 280px;">Spec</th><th>Relation</th></tr></thead>
+      <tbody>
+        <tr>
+          <td><a href="/specs/_template_web.html"><code>_template_web.html</code></a></td>
+          <td>web screen spec 템플릿 — Responsive Layout 섹션이 본 문서를 인용</td>
+        </tr>
+        <tr>
+          <td><a href="/specs/admin_console_dashboard/"><code>AdminConsoleDashboard</code></a></td>
+          <td>web_admin desktop-only 패턴의 선례</td>
+        </tr>
+        <tr>
+          <td><a href="/foundations/layout">Layout foundations</a></td>
+          <td>모바일 앱 layout foundation — spacing 토큰 체계 공유</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+</div>
+
+<script>
+  document.getElementById('spec-toggle').addEventListener('change', (e) => {
+    document.body.classList.toggle('spec-mode', e.target.checked);
+  });
+  document.getElementById('dark-toggle').addEventListener('change', (e) => {
+    document.body.classList.toggle('dark-mode', e.target.checked);
+  });
+</script>
+
+</body>
+</html>

--- a/apps/mds/docs/src/app/screens/page.tsx
+++ b/apps/mds/docs/src/app/screens/page.tsx
@@ -9,9 +9,10 @@ export default function ScreensPage() {
         </p>
         <h1 className="text-3xl font-bold text-[var(--color-text-primary)] mb-3">Screens</h1>
         <p className="text-[var(--color-text-secondary)]">
-          Screen definitions grouped by surface: app_user, app_partner, and web_admin.
-          Flutter app rows are derived from GoRouter route maps; web_admin starts as a
-          manual registry until its app root exists. Click a screen name to open its MDS spec; use{' '}
+          Screen definitions grouped by surface: app_user, app_partner, web_admin,
+          web_user, and web_partner. Flutter app rows are derived from GoRouter route
+          maps; web surfaces (admin, user, partner) are manual registries until their
+          app roots exist. Click a screen name to open its MDS spec; use{' '}
           <code className="text-xs bg-[var(--color-surface)] px-1 rounded">code ↗</code>{' '}
           for implementation source when it exists.
         </p>

--- a/apps/mds/docs/src/lib/screen-definitions.ts
+++ b/apps/mds/docs/src/lib/screen-definitions.ts
@@ -7,7 +7,7 @@ import {
   widgetNameFor,
 } from './flow-data';
 
-export type ScreenSurfaceId = 'user' | 'partner' | 'web_admin';
+export type ScreenSurfaceId = 'user' | 'partner' | 'web_admin' | 'web_user' | 'web_partner';
 
 export type ScreenKind = 'route' | 'sub-component' | 'spec-only' | 'web-route';
 
@@ -55,6 +55,18 @@ export const SCREEN_SURFACES: ScreenSurface[] = [
     label: 'web_admin',
     description: 'Desktop web admin console screens. Defined manually until apps/admin_web exists.',
   },
+  {
+    id: 'web_user',
+    label: 'web_user',
+    description:
+      'Consumer web screens (landing_user extension). Mobile-web-first; manual registry, web specs authored from /specs/_template_web.html.',
+  },
+  {
+    id: 'web_partner',
+    label: 'web_partner',
+    description:
+      'Partner web screens (landing_partner extension). Desktop-first; manual registry, web specs authored from /specs/_template_web.html.',
+  },
 ];
 
 const WEB_ADMIN_SCREENS: ScreenDefinition[] = [
@@ -71,6 +83,22 @@ const WEB_ADMIN_SCREENS: ScreenDefinition[] = [
     note: 'P0 shell/entry: Supabase Google OAuth login, admin guard, extensible menu frame.',
   },
 ];
+
+// Web MVP pivot: user/partner web screens are new web specs (mobile app specs
+// remain as behavior sources). Register each authored spec here following the
+// WEB_ADMIN_SCREENS shape — no route-pages.json / flow-data dependency.
+const WEB_USER_SCREENS: ScreenDefinition[] = [];
+
+const WEB_PARTNER_SCREENS: ScreenDefinition[] = [];
+
+const STATIC_WEB_SCREENS: Record<
+  Exclude<ScreenSurfaceId, 'user' | 'partner'>,
+  ScreenDefinition[]
+> = {
+  web_admin: WEB_ADMIN_SCREENS,
+  web_user: WEB_USER_SCREENS,
+  web_partner: WEB_PARTNER_SCREENS,
+};
 
 function appPathSegment(app: 'user' | 'partner'): 'app_user' | 'app_partner' {
   return app === 'user' ? 'app_user' : 'app_partner';
@@ -138,10 +166,10 @@ function flutterRouteScreens(app: 'user' | 'partner'): ScreenDefinition[] {
 
 export function getScreenGroups(): ScreenGroup[] {
   return SCREEN_SURFACES.map((surface) => {
-    if (surface.id === 'web_admin') {
-      return { surface, screens: WEB_ADMIN_SCREENS };
+    if (surface.id === 'user' || surface.id === 'partner') {
+      return { surface, screens: flutterRouteScreens(surface.id) };
     }
 
-    return { surface, screens: flutterRouteScreens(surface.id) };
+    return { surface, screens: STATIC_WEB_SCREENS[surface.id] };
   });
 }

--- a/docs/architecture/web-mvp-pivot.md
+++ b/docs/architecture/web-mvp-pivot.md
@@ -1,6 +1,6 @@
 # Web MVP Pivot (2026-06-06)
 
-> 2026-06-06 Mark 결정. Flutter 모바일 앱 개발을 동결하고 웹 MVP 로 전환하며, 제품 코어를 "이벤트 → 티켓 → 입장 → 정산" 플로우로 축소한 피벗의 결정 기록이다.
+> 2026-06-06 Mark 결정. Flutter 모바일 앱 개발을 동결하고 웹 MVP 로 전환하며, 제품 코어를 "이벤트 → 티켓 구매·신청 → 정산" 플로우로 축소한 피벗의 결정 기록이다.
 > 각 BLUEDOC 의 동결 배너와 `docs/features/` 의 status 배너는 이 문서를 기준으로 한다.
 
 ---
@@ -32,14 +32,16 @@
 
 ## 4. 코어 플로우 정의
 
-웹 MVP 가 검증하는 제품 코어는 아래 한 줄이다.
+웹 MVP 가 검증하는 제품 코어는 아래 한 줄이다 (2026-06-06 2차 축소: QR 체크인/입장권한 제외).
 
 ```text
-이벤트 생성/수정 ──> 티켓 구매 · 신청/대기 ──> 입장 권한 (QR 체크인) ──> 정산
+이벤트 생성/수정 ──> 티켓 구매 · 신청/대기 ──> 정산
 ```
 
-- **유저 웹**: 기존 유저앱 흐름 (탐색 → 이벤트 상세 → 결제/신청 → 내 티켓/QR) 을 거의 유지하며 웹으로 옮긴다.
-- **파트너 측**: 추후 재조정 — admin console 수준으로 축소될 가능성 있음 ([admin-dashboard PRD](../features/admin/admin-dashboard/prd.md) 의 `apps/admin_web/` 방향과 정렬).
+- **유저 웹** (`landing_user` 확장): 탐색 → 이벤트 상세 → 결제/신청 → 구매 내역. QR 티켓 없음 — 입장 확인은 파트너가 참가자 명단으로 수동 처리.
+- **파트너 웹** (`landing_partner` 확장): 이벤트/파티 생성·수정 → 신청 승인/거절 → 참가자 명단 → 정산 조회. 멤버/권한 관리·체크인·커스텀 자격심사는 범위 외.
+- **파트너 입점은 수동**: 온보딩/입점 신청 플로우 없음 — 당분간 운영자 (admin) 가 직접 파트너 계정을 생성한다.
+- **신청 심사는 승인/거절만**: 커스텀 자격 요구 (verification 요구사항 설정·심사) 는 코어에서 제외.
 - **법적 필수 영역은 코어에 포함**: 계정/동의 (signup-consent, privacy-protection), 탈퇴 (account-deletion), 환불 (refund-policy-v2), 약관 (partner-terms-privacy).
 
 ## 5. Deprecated 기능
@@ -51,8 +53,12 @@
 | 매칭/투표/결과 공개 (`event-operation/matching-results-reveal` 등) | 소셜 매칭 레이어 전체를 코어에서 제외 |
 | AI 추천·개인화 피드 (`discovery/tag-discovery` 의 AI 부분) | 추천/임베딩 파이프라인 단순화. 기본 태그 탐색은 웹 재설계 시 단순화 재검토 |
 | 신뢰 배지 고도화 (`discovery/trust-badge`) | 매칭 전제의 신뢰 시각화 — 코어 외 |
+| QR 체크인/입장권한 (`event-operation/partner-qr-checkin-ux`, `ticket-qr-improvement`, `event-now-bar`) | 2차 축소 (2026-06-06): 입장 확인은 참가자 명단 수동 처리로 충분 |
+| 파트너 온보딩/입점 신청 플로우 | 운영자 수동 입점으로 대체 |
+| 커스텀 자격심사 (verification 요구 설정·심사) | 신청 심사는 승인/거절만 |
+| 운영 통계 인프라 (`admin/statistics-tools`) | Supabase 대시보드로 충분 |
 
-기능 자체는 유효하나 Flutter UI 전제라 웹 재설계를 기다리는 것들은 deprecated 가 아니라 **on-hold** 로 구분한다 (예: event-now-bar, ticket-qr-improvement). 분류 전체는 `docs/features/` 각 `prd.md` 최상단 status 배너 참조.
+기능 자체는 유효하나 Flutter UI 전제라 웹 재설계를 기다리는 것들은 deprecated 가 아니라 **on-hold** 로 구분한다. 분류 전체는 `docs/features/` 각 `prd.md` 최상단 status 배너 참조.
 
 ## 6. Phase 로드맵
 
@@ -73,6 +79,56 @@
 | `> **Status: deprecated (web-mvp pivot, 2026-06-06)**` | 코어 외 — 신규 작업 금지 |
 
 배너 없는 feature 는 분류 보류 (판단 필요) 상태다. prd.md 가 없는 legacy 폴더 (entry-group-management, party-entry-group-management, event-detail-empty-state, partner-detail-event-card, notification-settings, purchase-history-color-hierarchy) 는 feature audit 시 일괄 정리한다.
+
+MDS 화면 spec (`apps/mds/docs/public/specs/<screen>/index.html`) 은 `<meta name="feature-status">` 로 같은 분류를 표시한다: `behavior-reference` (모바일 UI 동결, States/조건/에지케이스는 웹 spec 의 behavior 원천) / `on-hold` / `deprecated`. 웹 화면 spec 은 기존 spec 재사용이 아니라 `web_user` / `web_partner` surface 에 신규 작성한다 (`_template_web.html`, responsive 규칙은 `web_foundation_responsive` spec).
+
+## 8. Feature 문서/테스트 마이그레이션 정책
+
+feature 문서는 일괄 재작성하지 않는다. prd.md 와 spec.md 의 CUJ 시나리오는 플랫폼 중립이므로 유지하고, **해당 feature 의 웹 구현 착수 시점에** 아래만 feature 단위로 갱신한다 (웹 화면 spec + spec.md 헤더 + 웹 CUJ 테스트가 한 PR 단위):
+
+| 항목 | 변경 |
+|------|------|
+| spec.md 헤더 6섹션 | MDS specs → `web_user/web_partner` spec 경로, Apps → `apps/landing_*`, CUJ tests → 웹 e2e 경로 |
+| 모바일 전용 CUJ | 푸시 알림·카메라 QR 등 — 웹 동작으로 수정 또는 제거 |
+| NFR | "에뮬레이터 baseline" → 웹 baseline (브라우저/뷰포트 명시) 으로 재정의 |
+| CUJ 테스트 | `apps/landing_<user|partner>/e2e/cuj/<category>/<feature>.spec.ts` (Playwright 예정) — feature 당 파일 1개, 기존 cujGroup 구조 이식 |
+
+웹 CUJ 가 안정화되면 `dev-rc-cut-gate` 의 required evidence 로 추가한다 (동결된 Flutter CUJ 신호의 대체 — [promotion-contract.md](../infra/branch-strategy/promotion-contract.md) CUJ Contract 참조).
+
+## 9. 웹 MVP 화면 목록 초안
+
+신규 웹 spec 의 출발 목록. `Behavior Source` 는 States/조건/에지케이스를 상속할 기존 모바일 spec.
+
+### web_user (11)
+
+| 화면 | Behavior Source (`apps/mds/docs/public/specs/`) |
+|------|------|
+| 홈/이벤트 목록 | `home_page`, `event_card` |
+| 검색 | `search_page` |
+| 이벤트 상세 | `event_detail_page`, `event_bottom_ticket_bar` |
+| 파트너 상세 | `partner_detail_page`, `partner_events_page` |
+| 신청/결제 위저드 | `event_application_wizard_page`, `ticket_selection_sheet` |
+| 신청 상태/구매 내역 | `purchase_history_page`, `purchase_history_detail_page`, `event_application_review_page` |
+| 로그인/OAuth 콜백 | `login_page`, `auth_callback_page` |
+| 가입 동의 | `signup_consent_page` |
+| 본인인증 | `identity_verification_screen` |
+| 계정 관리 (마이) | `my_page`, `account_management_page`, `privacy_page` |
+| 탈퇴 플로우 | `deletion_info_page`, `deletion_reason_page`, `deletion_verify_page`, `deletion_complete_page` |
+
+### web_partner (8)
+
+| 화면 | Behavior Source |
+|------|------|
+| 파트너 홈 (오늘 할 일) | `partner_home_page` |
+| 파티/이벤트 목록 | `party_list_page`, `party_detail_page` |
+| 파티 생성 위저드 | `party_create_wizard_page`, `recurrence_management_screen` |
+| 이벤트 생성/수정 | `event_create_page`, `event_edit_page`, `partner_event_detail_page` |
+| 티켓 템플릿 관리 | `ticket_create_page`, `ticket_edit_page` |
+| 신청 관리 (승인/거절 + 참가자 명단) | `event_application_list_page`, `event_application_manage_page`, `event_application_detail_page` |
+| 정산 | `settlement_page`, `settlement_detail_page`, `bank_account_page` |
+| 파트너 로그인 | `partner_login_page` |
+
+유저 웹은 모바일웹 우선, 파트너 웹은 데스크톱 우선 (`web_foundation_responsive` 참조).
 
 ---
 

--- a/docs/features/event-operation/event-now-bar/prd.md
+++ b/docs/features/event-operation/event-now-bar/prd.md
@@ -1,6 +1,6 @@
 # PRD: 이벤트 나우바 (Event Now Bar)
 
-> **Status: on-hold (mobile frozen, 2026-06-06)** — 모바일 홈 전용 UX. 매칭 단계 surface 는 deprecated 범위에 포함. 배경: `docs/architecture/web-mvp-pivot.md`
+> **Status: deprecated (web-mvp pivot, 2026-06-06)** — 체크인/매칭 진행 surface 전체가 2차 축소로 코어 제외. 배경: `docs/architecture/web-mvp-pivot.md`
 
 ## Summary
 

--- a/docs/features/event-operation/partner-qr-checkin-ux/prd.md
+++ b/docs/features/event-operation/partner-qr-checkin-ux/prd.md
@@ -1,6 +1,6 @@
 # PRD: 파트너 QR 체크인 UX 강화
 
-> **Status: on-hold (mobile frozen, 2026-06-06)** — 체크인 자체는 코어이나 파트너 모바일 앱 UX 전제. 파트너 측 재조정 대기. 배경: `docs/architecture/web-mvp-pivot.md`
+> **Status: deprecated (web-mvp pivot, 2026-06-06)** — 2차 축소로 QR 체크인 제외. 입장 확인은 참가자 명단 수동 처리. 배경: `docs/architecture/web-mvp-pivot.md`
 
 ## Summary
 

--- a/docs/features/event-operation/ticket-qr-improvement/prd.md
+++ b/docs/features/event-operation/ticket-qr-improvement/prd.md
@@ -1,6 +1,6 @@
 # PRD: 티켓 QR Boarding Pass 리디자인 (Ticket QR Improvement)
 
-> **Status: on-hold (mobile frozen, 2026-06-06)** — 모바일 보딩패스 UX 전용. 웹 입장 QR 화면 재설계 대기. 배경: `docs/architecture/web-mvp-pivot.md`
+> **Status: deprecated (web-mvp pivot, 2026-06-06)** — 2차 축소로 QR 티켓 제외. 입장 확인은 참가자 명단 수동 처리. 배경: `docs/architecture/web-mvp-pivot.md`
 
 ## Summary
 


### PR DESCRIPTION
## Summary

웹 MVP 피벗 Phase 1c. **2차 범위 축소 반영**: 코어 = 이벤트 생성 → 구매·신청/대기 → 정산 (QR 체크인/입장, 파트너 온보딩, 커스텀 자격심사 제외 — 입장은 참가자 명단 수동 확인, 입점은 운영자 수동).

### MDS specs
- 모바일 화면 spec 70개 전수에 `<meta name="feature-status">` 마킹: **behavior-reference 46 / on-hold 8 / deprecated 16** (deprecated는 가시 배너 포함)
- `web_user` / `web_partner` surface 신설 (web_admin 정적 목록 패턴, tsc/eslint 통과)
- `_template_web.html` 신설 — Responsive Layout 섹션(같은 spec 안 breakpoint variant, States 공유), Behavior Source 행
- `web_foundation_responsive` spec 신설 — breakpoint 3단/그리드/터치 규칙, 유저웹 모바일 우선·파트너웹 데스크톱 우선

### Docs
- `web-mvp-pivot.md`: 코어 재정의 + deprecated 표 확장 + **§8 feature 문서/CUJ 마이그레이션 정책** (착수 시점 feature 단위 갱신, Playwright e2e 컨벤션 예약) + **§9 웹 화면 목록 초안** (web_user 11 / web_partner 8, behavior 상속 매핑)
- feature 배너 3개 on-hold → deprecated (event-now-bar, partner-qr-checkin-ux, ticket-qr-improvement)

### Note
- `web_foundation_responsive/`의 index.md/PNG 산출물은 컨벤션대로 미커밋 — `sync-mds-mockups.yml`이 머지 후 생성

No linked issue: web-mvp pivot Phase 1c (Mark 직접 지시) — 배경은 `docs/architecture/web-mvp-pivot.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)