### PR TITLE
test(mds): cover partner apply status async states

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/partner_apply_status_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_apply_status_page/builder.dart
@@ -14,7 +14,13 @@ import 'package:minglit_kit/minglit_kit.dart';
 
 import '../_engine/builder.dart';
 
-enum _Scenario { pending, needsCorrection, needsCorrectionWithComment }
+enum _Scenario {
+  pending,
+  needsCorrection,
+  needsCorrectionWithComment,
+  loading,
+  error,
+}
 
 class _FakePartnerRepository implements PartnerRepository {
   _FakePartnerRepository(this._application);
@@ -52,15 +58,21 @@ class PartnerApplyStatusPageBuilder
     return this;
   }
 
+  PartnerApplyStatusPageBuilder loading() {
+    _scenario = _Scenario.loading;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerApplyStatusPageBuilder error() {
+    _scenario = _Scenario.error;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
   @override
   Widget build() {
     final scenario = _scenario;
-
-    final onboardingState = switch (scenario) {
-      _Scenario.pending => OnboardingState.pendingReview,
-      _Scenario.needsCorrection ||
-      _Scenario.needsCorrectionWithComment => OnboardingState.needsCorrection,
-    };
 
     final application = switch (scenario) {
       _Scenario.pending => const PartnerApplication(
@@ -79,6 +91,7 @@ class PartnerApplyStatusPageBuilder
         status: 'needs_correction',
         adminComment: '사업자등록증 이미지가 흐립니다. 재업로드해주세요.',
       ),
+      _Scenario.loading || _Scenario.error => null,
     };
 
     return ProviderScope(
@@ -86,7 +99,20 @@ class PartnerApplyStatusPageBuilder
         currentUserProvider.overrideWith((_) => null),
         authStateChangesProvider.overrideWith((_) => const Stream.empty()),
         notificationInitializerProvider.overrideWith((_) {}),
-        onboardingStateProvider.overrideWith((_) async => onboardingState),
+        onboardingStateProvider.overrideWith((_) async {
+          switch (scenario) {
+            case _Scenario.pending:
+              return OnboardingState.pendingReview;
+            case _Scenario.needsCorrection:
+            case _Scenario.needsCorrectionWithComment:
+              return OnboardingState.needsCorrection;
+            case _Scenario.loading:
+              await Future<void>.delayed(const Duration(days: 1));
+              return OnboardingState.pendingReview;
+            case _Scenario.error:
+              throw StateError('MDS render forced onboarding status error');
+          }
+        }),
         partnerRepositoryProvider.overrideWith(
           (_) => _FakePartnerRepository(application),
         ),

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_apply_status_page/partner_apply_status_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_apply_status_page/partner_apply_status_page_test.dart
@@ -20,6 +20,13 @@ final catalog = MdsCatalog<PartnerApplyStatusPageBuilder>(
       (b) => b.needsCorrectionWithComment(),
       mdsIndex: 3,
     ),
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 4,
+      infiniteAnimation: true,
+    ),
+    MdsState('state-error', (b) => b.error(), mdsIndex: 5),
   ],
 );
 


### PR DESCRIPTION
Scheduler: swe-codex-gpt55-medium-1

## Summary
- add `partner_apply_status_page` MDS `state_4` Loading and `state_5` Error render catalog entries
- extend the render builder with deterministic loading/error `onboardingStateProvider` scenarios
- bring `partner_apply_status_page` catalog coverage to 5/5 MDS states

Refs #3078 - partial: this covers one concrete incomplete screen. Other MDS render state gaps remain and should continue in follow-up PRs.

## Validation
- `dart format apps/app_partner/integration_test/mds-emulator-render/partner_apply_status_page/builder.dart apps/app_partner/integration_test/mds-emulator-render/partner_apply_status_page/partner_apply_status_page_test.dart`
- `flutter analyze integration_test/mds-emulator-render/partner_apply_status_page/builder.dart integration_test/mds-emulator-render/partner_apply_status_page/partner_apply_status_page_test.dart` from `apps/app_partner`
- local spec/catalog index check: `partner_apply_status_page: 5/5 got=[1, 2, 3, 4, 5] missing=[]`
- `git diff --check`

## Residual risk
- `flutter test -d linux integration_test/mds-emulator-render/partner_apply_status_page/partner_apply_status_page_test.dart` could not run in this local environment because Linux Flutter testing requires CMake, which is not installed here.
- This PR does not close #3078 because broader MDS render coverage remains incomplete.