### PR TITLE
pivot(backend): disable AI pipeline ingestion — routes off + tag cron unscheduled (Phase 2)

### DIFF
--- a/docs/architecture/web-mvp-pivot.md
+++ b/docs/architecture/web-mvp-pivot.md
@@ -65,7 +65,7 @@
 | Phase | 내용 |
 |-------|------|
 | **Phase 1 (현재)** | 동결/상태 마킹 (본 문서 + BLUEDOC 배너 + feature status 배너), 유저 웹 MVP 설계·구축 착수 (MDS spec 기반) |
-| **Phase 2** | 비-코어 EF/크론 비활성화 (매칭·추천·임베딩 파이프라인), 파트너 측 재조정 (admin console 통합 여부 결정), Flutter 관련 CI 정리 |
+| **Phase 2** | AI 파이프라인 유입 차단만 (event_routes q_vectors/q_tags off + ai-extract-tags cron 해제 — `20260606054500` migration). 매칭/투표 EF 는 EF-gateway 특성상 호출 없으면 idle 이므로 보존 (Mark 결정 2026-06-06) |
 | **Phase 3** | 웹 코어 지표 검증 후 확장 기능 재평가 — 매칭/추천 재도입 여부, 모바일 (앱 또는 PWA) 재개 여부 판단 |
 
 ## 7. 문서 상태 마킹 컨벤션

--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -18,6 +18,7 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 
 - **상세 백엔드 설계는 문서로 이동** — DB inventory 와 도메인 관계는 `docs/architecture/backend.md` 가 기준.
 - **쓰기 경로는 Edge Function 중심** — 클라이언트 직접 write 정책을 늘리지 않고 service_role EF 에서 검증한다.
+- **AI 유입 경로는 web-mvp pivot 으로 차단** — `event_routes` q_vectors/q_tags 비활성 + ai-extract-tags cron 해제 ([web-mvp-pivot.md](../docs/architecture/web-mvp-pivot.md)).
 - **dev seed 는 actor/base 만** — user/partner/permission/verification 까지. party/event/ticket state 는 EF 경유로 만든다.
 - **migration 은 append-only** — 기존 migration 수정 대신 새 번호를 추가하고, 생성 전 `migrations/` 최신 번호를 확인한다.
 - **function 은 manifest/wrapper 경유** — `functions/auth-manifest.json` 과 `minglitEdgeFunction` 규칙을 따른다.
@@ -32,4 +33,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-06-05 07:21_
+_Reviewed: 2026-06-06 16:49_

--- a/supabase/migrations/20260606054500_web_mvp_disable_ai_pipeline_ingestion.sql
+++ b/supabase/migrations/20260606054500_web_mvp_disable_ai_pipeline_ingestion.sql
@@ -1,0 +1,22 @@
+-- Web MVP pivot (2026-06-06, docs/architecture/web-mvp-pivot.md):
+-- AI 파이프라인 유입 차단 — 코어(이벤트 생성 → 구매·신청 → 정산)와 무관한
+-- 임베딩/태그 추출 비용(OpenAI + 매분 EF 호출)을 멈춘다.
+--
+-- 1) event_routes: q_vectors(2행) / q_tags(1행) 라우트 비활성화 — 큐 적재 중단.
+--    행은 삭제하지 않는다 (복구 = is_active=true 재설정).
+-- 2) ai-extract-tags 매분 pg_cron 해제 (복구는 20260423000001 migration 의
+--    cron.schedule 블록 참조).
+--
+-- EF 코드(ai-embed, ai-extract-tags)와 테이블(user_embeddings, party_embeddings,
+-- party_tags 등)은 보존 — 매칭/투표 EF 도 idle 상태로 보존 (Mark 결정).
+
+UPDATE public.event_routes
+SET is_active = false
+WHERE target_queue IN ('q_vectors', 'q_tags');
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'ai-extract-tags') THEN
+    PERFORM cron.unschedule('ai-extract-tags');
+  END IF;
+END $$;

--- a/supabase/tests/database/70_ai_extract_tags_migration_test.sql
+++ b/supabase/tests/database/70_ai_extract_tags_migration_test.sql
@@ -3,11 +3,11 @@
 -- - event_queue_name enum에 q_tags 값 검증
 -- - event_routes 라우팅 행 검증
 -- - ai-extract-tags cron job 검증
--- Web MVP pivot (2026-06-06): q_tags 라우트 비활성 + cron 해제가 새 기대 상태
--- (20260606054500_web_mvp_disable_ai_pipeline_ingestion.sql). plan(10) → plan(7).
+-- Web MVP pivot (2026-06-06): q_tags/q_vectors 라우트 비활성 + cron 해제가 새 기대 상태
+-- (20260606054500_web_mvp_disable_ai_pipeline_ingestion.sql). plan(10) → plan(9).
 BEGIN;
 
-SELECT plan(7);
+SELECT plan(9);
 
 SET ROLE postgres;
 
@@ -71,6 +71,28 @@ SELECT is(
   ),
   1,
   'event_routes preserves party_created → q_tags route as inactive (web-mvp pivot)'
+);
+
+-- Web MVP pivot: q_vectors 라우트 2행 (party_created, user_interaction) 도 보존 + 비활성
+SELECT is(
+  (
+    SELECT count(*)::int FROM public.event_routes
+    WHERE target_queue = 'q_vectors'
+      AND is_active = false
+  ),
+  2,
+  'event_routes preserves 2 q_vectors routes as inactive (web-mvp pivot)'
+);
+
+-- AI 유입 경로에 활성 라우트가 하나도 남지 않아야 한다
+SELECT is(
+  (
+    SELECT count(*)::int FROM public.event_routes
+    WHERE target_queue IN ('q_vectors', 'q_tags')
+      AND is_active = true
+  ),
+  0,
+  'no active q_vectors/q_tags routes remain (web-mvp pivot)'
 );
 
 -- ============================================================

--- a/supabase/tests/database/70_ai_extract_tags_migration_test.sql
+++ b/supabase/tests/database/70_ai_extract_tags_migration_test.sql
@@ -3,9 +3,11 @@
 -- - event_queue_name enum에 q_tags 값 검증
 -- - event_routes 라우팅 행 검증
 -- - ai-extract-tags cron job 검증
+-- Web MVP pivot (2026-06-06): q_tags 라우트 비활성 + cron 해제가 새 기대 상태
+-- (20260606054500_web_mvp_disable_ai_pipeline_ingestion.sql). plan(10) → plan(7).
 BEGIN;
 
-SELECT plan(10);
+SELECT plan(7);
 
 SET ROLE postgres;
 
@@ -59,44 +61,26 @@ SELECT ok(
 -- 4. event_routes 라우팅 행 검증
 -- ============================================================
 
+-- Web MVP pivot: 라우트 행은 보존하되 비활성 상태여야 한다 (복구 가능성 유지)
 SELECT is(
   (
     SELECT count(*)::int FROM public.event_routes
     WHERE event_type = 'party_created'
       AND target_queue = 'q_tags'
-      AND is_active = true
+      AND is_active = false
   ),
   1,
-  'event_routes has party_created → q_tags active route'
+  'event_routes preserves party_created → q_tags route as inactive (web-mvp pivot)'
 );
 
 -- ============================================================
--- 5. ai-extract-tags cron job 검증
+-- 5. ai-extract-tags cron job 검증 (web-mvp pivot: 해제 상태)
 -- ============================================================
 
 SELECT is(
   (SELECT count(*)::int FROM cron.job WHERE jobname = 'ai-extract-tags'),
-  1,
-  'ai-extract-tags cron job is registered'
-);
-
-SELECT is(
-  (SELECT schedule FROM cron.job WHERE jobname = 'ai-extract-tags'),
-  '* * * * *',
-  'ai-extract-tags cron runs every minute'
-);
-
--- cron SQL이 supabase_url Vault 시크릿을 참조하는지 확인
-SELECT ok(
-  (SELECT command FROM cron.job WHERE jobname = 'ai-extract-tags') LIKE '%supabase_url%',
-  'ai-extract-tags cron uses vault supabase_url (not hardcoded URL)'
-);
-
--- Fix #1758: cron SQL이 service_role_key Vault 시크릿을 참조하는지 확인
--- (이전: publishable_key — requireServiceRole() 가드 추가 후 401 발생, 교체됨)
-SELECT ok(
-  (SELECT command FROM cron.job WHERE jobname = 'ai-extract-tags') LIKE '%service_role_key%',
-  'ai-extract-tags cron uses vault service_role_key (not publishable_key)'
+  0,
+  'ai-extract-tags cron job is unscheduled (web-mvp pivot)'
 );
 
 RESET ROLE;

--- a/supabase/tests/database/94_cron_service_role_key_test.sql
+++ b/supabase/tests/database/94_cron_service_role_key_test.sql
@@ -72,10 +72,12 @@ SELECT ok(
   'settlement-alarm-check cron uses service_role_key with apikey + Authorization'
 );
 
--- 6. ai-extract-tags: service_role_key 사용
-SELECT ok(
-  _check_cron_uses_service_role('ai-extract-tags'),
-  'ai-extract-tags cron uses service_role_key with apikey + Authorization'
+-- 6. ai-extract-tags: web-mvp pivot (2026-06-06) 으로 unschedule 됨 — 부재 검증
+-- (20260606054500_web_mvp_disable_ai_pipeline_ingestion.sql)
+SELECT is(
+  (SELECT count(*)::int FROM cron.job WHERE jobname = 'ai-extract-tags'),
+  0,
+  'ai-extract-tags cron is unscheduled (web-mvp pivot)'
 );
 
 -- 7. sync_github_stats: service_role_key 사용


### PR DESCRIPTION
## Summary

웹 MVP 피벗 Phase 2 — **최소판** (Mark 결정): 매칭/투표 EF는 EF-gateway 구조상 호출 없으면 idle이므로 그대로 보존하고, 실제 비용이 나가는 **AI 유입 경로만** 차단.

### Migration (`20260606054500`)
- `event_routes`: `q_vectors` 2행 (party_created, user_interaction) + `q_tags` 1행 → `is_active=false` (큐 적재 중단, 행 보존 → 한 줄로 복구 가능)
- `ai-extract-tags` 매분 pg_cron 해제 (월 ~43k EF 호출 + OpenAI 비용 중단)

### pgTAP
- `70_ai_extract_tags_migration_test.sql`: 라우트 "보존 + 비활성" 단정으로 교체, cron 부재 단정 (plan 10→7)
- `94_cron_service_role_key_test.sql`: ai-extract-tags 단정을 부재 검증으로 교체 (plan 8 유지)

### Docs
- `web-mvp-pivot.md` Phase 2 행을 최소판으로 갱신 (매칭/투표 EF 보존 결정 기록)

### 복구 방법
라우트 3행 `is_active=true` + `20260423000001` migration의 cron.schedule 블록 재등록 (이 migration은 수정 금지).

No linked issue: web-mvp pivot Phase 2 (Mark 직접 지시) — 배경은 `docs/architecture/web-mvp-pivot.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)