### PR TITLE
fix(ci): scope advisor accepted findings by object

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -20,6 +20,7 @@
 | [`check-ios-connectivity-plus-cap.sh`](./check-ios-connectivity-plus-cap.sh) | iOS deploy runner 가 지원할 때까지 `connectivity_plus <7.1.0` resolution 강제 | `pr-gate.guard-ios-connectivity-plus-cap` |
 | [`scan-build-artifact-secrets.py`](./scan-build-artifact-secrets.py) | APK/AAB/`.next` 등 빌드 산출물에서 Supabase service-role secret 패턴을 redacted summary 로 검사 | `pr-gate.scan-build-artifact-secrets` |
 | [`install-dev-event-flow-cron.sh`](./install-dev-event-flow-cron.sh) | dev Supabase `dev-event-flow-simulator` pg_cron 설치/검증 | `deploy-dev-event-flow-cron` |
+| [`filter-advisor-findings.py`](./filter-advisor-findings.py) | Supabase Advisor raw findings 를 accepted/unsuppressed 로 분리하고 object-scoped accepted finding 을 적용 | `monitor-security-advisor` |
 
 ## 핵심 컨벤션
 

--- a/.github/scripts/filter-advisor-findings.py
+++ b/.github/scripts/filter-advisor-findings.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Split Supabase advisor findings into accepted and unsuppressed lists."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_ENVS = ["dev", "main"]
+
+
+def normalize_items(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        items = payload
+    elif isinstance(payload, dict):
+        items = payload.get("lints") or payload.get("data") or []
+    else:
+        items = []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def finding_name(finding: dict[str, Any]) -> str:
+    return str(finding.get("name") or finding.get("title") or finding.get("code") or "")
+
+
+def finding_cache_key(finding: dict[str, Any]) -> str:
+    return str(finding.get("cache_key") or finding.get("cacheKey") or "")
+
+
+def metadata_value(finding: dict[str, Any], key: str) -> Any:
+    metadata = finding.get("metadata")
+    if isinstance(metadata, dict) and key in metadata:
+        return metadata[key]
+    return finding.get(key)
+
+
+def metadata_matches(finding: dict[str, Any], expected: dict[str, Any]) -> bool:
+    for key, expected_value in expected.items():
+        if metadata_value(finding, key) != expected_value:
+            return False
+    return True
+
+
+def rule_accepts_finding(
+    rule: dict[str, Any],
+    finding: dict[str, Any],
+    *,
+    advisor_type: str,
+    env: str,
+) -> bool:
+    if rule.get("type") is not None and rule["type"] != advisor_type:
+        return False
+    rule_envs = rule.get("envs", DEFAULT_ENVS)
+    if rule_envs is None:
+        rule_envs = DEFAULT_ENVS
+    if env not in rule_envs:
+        return False
+    if rule.get("name") != finding_name(finding):
+        return False
+
+    if "cache_key" in rule and rule["cache_key"] != finding_cache_key(finding):
+        return False
+
+    expected_metadata = rule.get("metadata")
+    if expected_metadata is not None:
+        if not isinstance(expected_metadata, dict):
+            return False
+        if not metadata_matches(finding, expected_metadata):
+            return False
+
+    return True
+
+
+def split_findings(
+    findings: list[dict[str, Any]],
+    rules: list[dict[str, Any]],
+    *,
+    advisor_type: str,
+    env: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    accepted: list[dict[str, Any]] = []
+    unsuppressed: list[dict[str, Any]] = []
+
+    for finding in findings:
+        if any(
+            rule_accepts_finding(rule, finding, advisor_type=advisor_type, env=env)
+            for rule in rules
+            if isinstance(rule, dict)
+        ):
+            accepted.append(finding)
+        else:
+            unsuppressed.append(finding)
+
+    return accepted, unsuppressed
+
+
+def load_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    with path.open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(payload, file, indent=2, sort_keys=True)
+        file.write("\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--accepted-file", required=True, type=Path)
+    parser.add_argument("--type", required=True)
+    parser.add_argument("--env", required=True)
+    parser.add_argument("--accepted-output", required=True, type=Path)
+    parser.add_argument("--unsuppressed-output", required=True, type=Path)
+    args = parser.parse_args()
+
+    findings = normalize_items(load_json(args.input, []))
+    rules = load_json(args.accepted_file, [])
+    accepted, unsuppressed = split_findings(
+        findings,
+        rules if isinstance(rules, list) else [],
+        advisor_type=args.type,
+        env=args.env,
+    )
+
+    write_json(args.accepted_output, accepted)
+    write_json(args.unsuppressed_output, unsuppressed)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_filter_advisor_findings.py
+++ b/.github/scripts/test_filter_advisor_findings.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("filter-advisor-findings.py")
+SPEC = importlib.util.spec_from_file_location("filter_advisor_findings", SCRIPT_PATH)
+assert SPEC is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class FilterAdvisorFindingsTest(unittest.TestCase):
+    def split(self, findings, rules, *, advisor_type="security", env="dev"):
+        return MODULE.split_findings(
+            findings,
+            rules,
+            advisor_type=advisor_type,
+            env=env,
+        )
+
+    def test_legacy_name_only_rule_still_suppresses_all_matching_findings(self):
+        findings = [
+            {"name": "auth_leaked_password_protection", "cache_key": "a"},
+            {"name": "auth_leaked_password_protection", "cache_key": "b"},
+            {"name": "extension_in_public", "cache_key": "c"},
+        ]
+        rules = [{"name": "auth_leaked_password_protection", "type": "security"}]
+
+        accepted, unsuppressed = self.split(findings, rules)
+
+        self.assertEqual([finding["cache_key"] for finding in accepted], ["a", "b"])
+        self.assertEqual([finding["cache_key"] for finding in unsuppressed], ["c"])
+
+    def test_cache_key_scoped_rule_only_suppresses_exact_object(self):
+        findings = [
+            {"name": "extension_in_public", "cache_key": "extensions_public_postgis"},
+            {"name": "extension_in_public", "cache_key": "extensions_public_pgroonga"},
+        ]
+        rules = [
+            {
+                "name": "extension_in_public",
+                "type": "security",
+                "cache_key": "extensions_public_postgis",
+            }
+        ]
+
+        accepted, unsuppressed = self.split(findings, rules)
+
+        self.assertEqual(
+            [finding["cache_key"] for finding in accepted],
+            ["extensions_public_postgis"],
+        )
+        self.assertEqual(
+            [finding["cache_key"] for finding in unsuppressed],
+            ["extensions_public_pgroonga"],
+        )
+
+    def test_metadata_scoped_rule_matches_metadata_fields(self):
+        findings = [
+            {
+                "name": "anon_security_definer_function_executable",
+                "metadata": {
+                    "schema": "public",
+                    "name": "get_events_within_radius",
+                    "arguments": "lat double precision, lng double precision",
+                },
+            },
+            {
+                "name": "anon_security_definer_function_executable",
+                "metadata": {
+                    "schema": "public",
+                    "name": "is_super_admin",
+                    "arguments": "",
+                },
+            },
+        ]
+        rules = [
+            {
+                "name": "anon_security_definer_function_executable",
+                "type": "security",
+                "metadata": {
+                    "schema": "public",
+                    "name": "get_events_within_radius",
+                    "arguments": "lat double precision, lng double precision",
+                },
+            }
+        ]
+
+        accepted, unsuppressed = self.split(findings, rules)
+
+        self.assertEqual(
+            [finding["metadata"]["name"] for finding in accepted],
+            ["get_events_within_radius"],
+        )
+        self.assertEqual(
+            [finding["metadata"]["name"] for finding in unsuppressed],
+            ["is_super_admin"],
+        )
+
+    def test_type_and_env_must_match_before_object_scope(self):
+        findings = [
+            {"name": "extension_in_public", "cache_key": "extensions_public_postgis"}
+        ]
+        rules = [
+            {
+                "name": "extension_in_public",
+                "type": "performance",
+                "envs": ["main"],
+                "cache_key": "extensions_public_postgis",
+            }
+        ]
+
+        accepted, unsuppressed = self.split(
+            findings,
+            rules,
+            advisor_type="security",
+            env="dev",
+        )
+
+        self.assertEqual(accepted, [])
+        self.assertEqual(unsuppressed, findings)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/monitor-security-advisor.yml
+++ b/.github/workflows/monitor-security-advisor.yml
@@ -99,48 +99,23 @@ jobs:
           echo "$BODY" > advisor-${TYPE}.json
           echo "Wrote advisor-${TYPE}.json ($(echo "$BODY" | wc -c) bytes)"
 
-          # Count by level — support both {lints:[...]} and bare [...] shapes.
-          ITEMS=$(echo "$BODY" | jq -c '
+          ACCEPTED_FILE=".github/advisor-accepted-findings.json"
+          python3 .github/scripts/filter-advisor-findings.py \
+            --input "advisor-${TYPE}.json" \
+            --accepted-file "$ACCEPTED_FILE" \
+            --type "$TYPE" \
+            --env "$ENV" \
+            --accepted-output "advisor-${TYPE}-accepted.json" \
+            --unsuppressed-output "advisor-${TYPE}-unsuppressed.json"
+
+          ITEMS=$(jq -c '
             if type == "array" then .
             elif .lints? then .lints
             elif .data? then .data
             else [] end
-          ')
-          ACCEPTED_FILE=".github/advisor-accepted-findings.json"
-          if [ -f "$ACCEPTED_FILE" ]; then
-            ACCEPTED_ITEMS=$(echo "$ITEMS" | jq -c \
-              --slurpfile accepted "$ACCEPTED_FILE" \
-              --arg type "$TYPE" \
-              --arg env "$ENV" '
-              def finding_name: (.name // .title // .code // "");
-              def accepted:
-                . as $finding
-                | any($accepted[0][]; . as $rule
-                    | ($rule.type == null or $rule.type == $type)
-                    and (($rule.envs // ["dev", "main"]) | index($env))
-                    and ($rule.name == ($finding | finding_name)));
-              [ .[] | select(accepted) ]
-            ')
-            UNSUPPRESSED_ITEMS=$(echo "$ITEMS" | jq -c \
-              --slurpfile accepted "$ACCEPTED_FILE" \
-              --arg type "$TYPE" \
-              --arg env "$ENV" '
-              def finding_name: (.name // .title // .code // "");
-              def accepted:
-                . as $finding
-                | any($accepted[0][]; . as $rule
-                    | ($rule.type == null or $rule.type == $type)
-                    and (($rule.envs // ["dev", "main"]) | index($env))
-                    and ($rule.name == ($finding | finding_name)));
-              [ .[] | select(accepted | not) ]
-            ')
-          else
-            ACCEPTED_ITEMS="[]"
-            UNSUPPRESSED_ITEMS="$ITEMS"
-          fi
-          echo "$ACCEPTED_ITEMS" > "advisor-${TYPE}-accepted.json"
-          echo "$UNSUPPRESSED_ITEMS" > "advisor-${TYPE}-unsuppressed.json"
-
+          ' "advisor-${TYPE}.json")
+          ACCEPTED_ITEMS=$(jq -c '.' "advisor-${TYPE}-accepted.json")
+          UNSUPPRESSED_ITEMS=$(jq -c '.' "advisor-${TYPE}-unsuppressed.json")
           ERRORS=$(echo "$UNSUPPRESSED_ITEMS" | jq '[.[] | select((.level // .severity // "" | ascii_upcase) == "ERROR")] | length')
           WARNS=$(echo "$UNSUPPRESSED_ITEMS" | jq '[.[] | select((.level // .severity // "" | ascii_upcase) == "WARN")] | length')
           TOTAL=$(echo "$UNSUPPRESSED_ITEMS" | jq 'length')

--- a/docs/operations/security-advisor.md
+++ b/docs/operations/security-advisor.md
@@ -21,6 +21,18 @@ Each accepted finding must include:
 | `issue` | GitHub issue that records the decision. |
 | `reason` | Short operational rationale. |
 
+Rules may also include object scope:
+
+| Field | Meaning |
+|---|---|
+| `cache_key` | Exact Supabase Advisor `cache_key` to suppress for this finding name. |
+| `metadata` | Exact metadata key/value constraints, such as `schema`, `name`, and `arguments`. Values are matched against Advisor `metadata` first, then top-level finding fields. |
+
+Use name-only rules only for findings that are intrinsically environment-level.
+For object-level findings such as `extension_in_public`,
+`rls_enabled_no_policy`, or `*_security_definer_function_executable`, include
+`cache_key` or `metadata` so future unreviewed objects remain unsuppressed.
+
 ## Password Auth Posture
 
 Minglit production auth does not support email/password signup or login.


### PR DESCRIPTION
Scheduler: swe-codex-gpt55-medium-1

## What
- Extract Supabase Advisor accepted-finding filtering into `.github/scripts/filter-advisor-findings.py`.
- Preserve existing name/type/env suppression behavior while adding object-scoped matching via exact `cache_key` and exact `metadata` constraints.
- Update `monitor-security-advisor` to call the helper and document the accepted-finding schema.
- Add focused unit coverage for legacy name-only suppression, cache-key scoping, metadata scoping, and type/env mismatch.

## Why
Refs #2935. This implements the narrow SWE follow-up from the latest triage: object/cache-key scoped accepted-finding support must exist before reviewed residual Advisor objects can be safely suppressed. This does not close #2935 because it remains the aggregate tracker until a future monitor run confirms the residual counts are accepted or reduced.

## Verification
- `python3 .github/scripts/test_filter_advisor_findings.py`
- `python3 -m py_compile .github/scripts/filter-advisor-findings.py .github/scripts/test_filter_advisor_findings.py`
- `bash .github/scripts/check-bluedoc-freshness.sh`
- Parsed `.github/workflows/monitor-security-advisor.yml` with PyYAML.
- Smoke-tested the helper CLI with mixed legacy and cache-key accepted rules.

## Residual Risk
- The workflow change is not exercised against live Supabase Advisor output in this branch; CI can validate static checks, and the scheduled/manual monitor run will be the live integration sensor.