### PR TITLE
fix: align apply-event cascade availability

### DIFF
--- a/supabase/functions/_shared/domains/event/BLUEDOC.md
+++ b/supabase/functions/_shared/domains/event/BLUEDOC.md
@@ -22,8 +22,8 @@
 
 ## 알려진 정합성 이슈
 
-- `apply-event/index.ts` 의 status 가드는 `scheduled only` 로 Fix #998 의
-  user-create-order 와 불일치. 별도 이슈로 관리.
+- 없음. `apply-event` / `user-create-order` 모두 `isEventOpenForApplication`
+  (`scheduled` / `active`) 을 따른다.
 
 ## 관련
 
@@ -32,4 +32,4 @@
 
 ---
 
-_Reviewed: 2026-05-24 00:00_
+_Reviewed: 2026-06-07 19:30_

--- a/supabase/functions/apply-event/index.ts
+++ b/supabase/functions/apply-event/index.ts
@@ -8,6 +8,7 @@ import { parseJsonBody } from "../_shared/request_utils.ts";
 import { isPlainRecord } from "../_shared/input_validation.ts";
 import {
   isEventFull,
+  isEventOpenForApplication,
   isTicketSoldOut,
 } from "../_shared/domains/event/availability.ts";
 import { blocksReapplication } from "../_shared/domains/payment/application_status.ts";
@@ -190,10 +191,8 @@ export const handler = async (
       return errorResponse("Event not found", 404);
     }
 
-    // 2. 이벤트 상태 확인 — scheduled 상태여야 신청 가능
-    // NOTE: user-create-order 는 scheduled OR active 허용 (Fix #998). 이 EF 는 scheduled only —
-    // 정합성 이슈 → `_shared/domains/event/BLUEDOC.md` 의 "알려진 정합성 이슈" 참조.
-    if (event.status !== "scheduled") {
+    // 2. 이벤트 상태 확인 — 도메인 정책상 scheduled / active 는 신청 가능
+    if (!isEventOpenForApplication(event.status)) {
       return errorResponse("Event is not accepting applications", 409, {
         status: event.status,
       });

--- a/supabase/functions/apply-event/index_test.ts
+++ b/supabase/functions/apply-event/index_test.ts
@@ -65,20 +65,25 @@ Deno.test("apply-event :: event not found → 404", async () => {
   assertEquals(res.status, 404);
 });
 
-// ─── 3. event status not "scheduled" → 409 ──────────────────────────────────
+// ─── 3. event status guard ──────────────────────────────────────────────────
 
-Deno.test("apply-event :: event status=active → 409 (scheduled only)", async () => {
+Deno.test("apply-event :: event status=active → 200 (application-open)", async () => {
   const handler = await getHandler();
-  const sb = fakeSupabase().on("events", "select", {
-    data: buildEvent({ status: "active" }),
-  });
+  const sb = fakeSupabase()
+    .on("events", "select", {
+      data: buildEvent({ status: "active" }),
+    })
+    .on("tickets", "select", { data: buildTicket({ price: 0 }) })
+    .on("event_applications", "select", { data: null })
+    .on("apply_event", "rpc", { data: "app-active-1" });
   const res = await runHandler(handler, {
     body: BASE_BODY,
     ctx: makeCtx({ supabase: sb, userId: "u-1" }),
   });
-  assertEquals(res.status, 409);
-  const body = await readJson<{ error: string }>(res);
-  assertEquals(body.error, "Event is not accepting applications");
+  assertEquals(res.status, 200);
+  const body = await readJson<{ type: string; application_id: string }>(res);
+  assertEquals(body.type, "free");
+  assertEquals(body.application_id, "app-active-1");
 });
 
 Deno.test("apply-event :: event status=cancelled → 409", async () => {

--- a/supabase/functions/event-flow-simulator/BLUEDOC.md
+++ b/supabase/functions/event-flow-simulator/BLUEDOC.md
@@ -46,4 +46,4 @@ curl -X POST "https://<project>.supabase.co/functions/v1/event-flow-simulator" \
 - 단위 테스트: `cd supabase/functions && deno test event-flow-simulator/`
 
 ---
-_Reviewed: 2026-06-06 07:33_
+_Reviewed: 2026-06-07 19:41_

--- a/supabase/functions/event-flow-simulator/action/apply.ts
+++ b/supabase/functions/event-flow-simulator/action/apply.ts
@@ -2,6 +2,43 @@
 
 import type { ActionDef } from "./_registry.ts";
 import { registerAction } from "./_registry.ts";
+import {
+  isEventOpenForApplication,
+  isTicketSoldOut,
+} from "../../_shared/domains/event/availability.ts";
+
+type TicketCandidate = {
+  id: string;
+  status?: string;
+  quantity?: number;
+  sold_count?: number;
+};
+
+type EventCandidate = {
+  id: string;
+  status?: string;
+  tickets?: TicketCandidate[];
+};
+
+function isApplicationEvent(event: EventCandidate): boolean {
+  return typeof event.status === "string" &&
+    isEventOpenForApplication(event.status);
+}
+
+function isApplicationTicket(ticket: TicketCandidate): boolean {
+  return ticket.status === "on_sale" &&
+    typeof ticket.quantity === "number" &&
+    typeof ticket.sold_count === "number" &&
+    !isTicketSoldOut(ticket.sold_count, ticket.quantity);
+}
+
+function availableApplicationCandidates(events: EventCandidate[]) {
+  return events.flatMap((event) => {
+    if (!isApplicationEvent(event)) return [];
+    const ticket = event.tickets?.find(isApplicationTicket);
+    return ticket ? [{ event, ticket }] : [];
+  });
+}
 
 export const applyAction: ActionDef = {
   type: "user_apply",
@@ -10,29 +47,29 @@ export const applyAction: ActionDef = {
 
   canExecute(state) {
     const apps = (state.myApplications as Array<{ event_id: string }>) ?? [];
-    const events = (state.visibleEvents as Array<{ id: string; tickets?: unknown[] }>) ?? [];
+    const events = (state.visibleEvents as EventCandidate[]) ?? [];
     if (events.length === 0) return false;
     const appliedEventIds = new Set(apps.map((a) => a.event_id));
     // 신청 가능한 (티켓 있고 미신청) 이벤트 존재
-    return events.some(
-      (e) => !appliedEventIds.has(e.id) && (e.tickets?.length ?? 0) > 0,
+    return availableApplicationCandidates(events).some(
+      ({ event }) => !appliedEventIds.has(event.id),
     );
   },
 
   buildPayload(state, rng) {
     const apps = (state.myApplications as Array<{ event_id: string }>) ?? [];
-    const events =
-      (state.visibleEvents as Array<{ id: string; tickets?: Array<{ id: string }> }>) ?? [];
+    const events = (state.visibleEvents as EventCandidate[]) ?? [];
     const appliedEventIds = new Set(apps.map((a) => a.event_id));
-    const candidates = events.filter(
-      (e) => !appliedEventIds.has(e.id) && (e.tickets?.length ?? 0) > 0,
+    const candidates = availableApplicationCandidates(events).filter(
+      ({ event }) => !appliedEventIds.has(event.id),
     );
     if (candidates.length === 0) {
-      throw new Error("apply.buildPayload called when no candidate event — canExecute should have gated");
+      throw new Error(
+        "apply.buildPayload called when no candidate event — canExecute should have gated",
+      );
     }
     const idx = Math.floor(rng.next() * candidates.length);
-    const event = candidates[idx];
-    const ticket = event.tickets![0];
+    const { event, ticket } = candidates[idx];
     return { event_id: event.id, ticket_id: ticket.id };
   },
 };

--- a/supabase/functions/event-flow-simulator/action/apply_test.ts
+++ b/supabase/functions/event-flow-simulator/action/apply_test.ts
@@ -9,11 +9,44 @@ const rng = createPRNG(42);
 
 function stateWith(opts: {
   apps?: Array<{ event_id: string }>;
-  events?: Array<{ id: string; tickets?: Array<{ id: string }> }>;
+  events?: Array<{
+    id: string;
+    status?: string;
+    tickets?: Array<{
+      id: string;
+      status?: string;
+      quantity?: number;
+      sold_count?: number;
+    }>;
+  }>;
 }): ObservableState {
   return {
     myApplications: opts.apps ?? [],
     visibleEvents: opts.events ?? [],
+  };
+}
+
+function ticket(
+  id: string,
+  overrides: Partial<{ status: string; quantity: number; sold_count: number }> =
+    {},
+) {
+  return { id, status: "on_sale", quantity: 10, sold_count: 0, ...overrides };
+}
+
+function event(
+  id: string,
+  ticketId: string,
+  overrides: Partial<{
+    status: string;
+    tickets: ReturnType<typeof ticket>[];
+  }> = {},
+) {
+  return {
+    id,
+    status: "scheduled",
+    tickets: [ticket(ticketId)],
+    ...overrides,
   };
 }
 
@@ -28,7 +61,7 @@ Deno.test({
   name: "applyAction.canExecute - false when all events already applied",
   fn: () => {
     const state = stateWith({
-      events: [{ id: "e1", tickets: [{ id: "t1" }] }],
+      events: [event("e1", "t1")],
       apps: [{ event_id: "e1" }],
     });
     assertEquals(applyAction.canExecute(state), false);
@@ -38,16 +71,19 @@ Deno.test({
 Deno.test({
   name: "applyAction.canExecute - false when candidate event has no tickets",
   fn: () => {
-    const state = stateWith({ events: [{ id: "e1", tickets: [] }] });
+    const state = stateWith({
+      events: [event("e1", "t1", { tickets: [] })],
+    });
     assertEquals(applyAction.canExecute(state), false);
   },
 });
 
 Deno.test({
-  name: "applyAction.canExecute - true when unapplied event with tickets exists",
+  name:
+    "applyAction.canExecute - true when unapplied event with tickets exists",
   fn: () => {
     const state = stateWith({
-      events: [{ id: "e1", tickets: [{ id: "t1" }] }],
+      events: [event("e1", "t1")],
       apps: [],
     });
     assertEquals(applyAction.canExecute(state), true);
@@ -55,12 +91,51 @@ Deno.test({
 });
 
 Deno.test({
-  name: "applyAction.buildPayload - returns event_id + ticket_id from a candidate",
+  name: "applyAction.canExecute - true when active event is application-open",
+  fn: () => {
+    const state = stateWith({
+      events: [event("e1", "t1", { status: "active" })],
+      apps: [],
+    });
+    assertEquals(applyAction.canExecute(state), true);
+  },
+});
+
+Deno.test({
+  name: "applyAction.canExecute - false when event is not application-open",
+  fn: () => {
+    const state = stateWith({
+      events: [event("e1", "t1", { status: "cancelled" })],
+      apps: [],
+    });
+    assertEquals(applyAction.canExecute(state), false);
+  },
+});
+
+Deno.test({
+  name: "applyAction.canExecute - false when tickets are unavailable",
   fn: () => {
     const state = stateWith({
       events: [
-        { id: "e1", tickets: [{ id: "t1" }] },
-        { id: "e2", tickets: [{ id: "t2" }] },
+        event("e1", "t1", { tickets: [ticket("t1", { status: "closed" })] }),
+        event("e2", "t2", {
+          tickets: [ticket("t2", { quantity: 10, sold_count: 10 })],
+        }),
+      ],
+      apps: [],
+    });
+    assertEquals(applyAction.canExecute(state), false);
+  },
+});
+
+Deno.test({
+  name:
+    "applyAction.buildPayload - returns event_id + ticket_id from a candidate",
+  fn: () => {
+    const state = stateWith({
+      events: [
+        event("e1", "t1"),
+        event("e2", "t2"),
       ],
     });
     const payload = applyAction.buildPayload(state, rng);
@@ -76,8 +151,8 @@ Deno.test({
   fn: () => {
     const state = stateWith({
       events: [
-        { id: "e1", tickets: [{ id: "t1" }] },
-        { id: "e2", tickets: [{ id: "t2" }] },
+        event("e1", "t1"),
+        event("e2", "t2"),
       ],
       apps: [{ event_id: "e1" }],
     });
@@ -88,10 +163,30 @@ Deno.test({
 });
 
 Deno.test({
-  name: "applyAction.buildPayload - throws when no candidate (canExecute should gate)",
+  name: "applyAction.buildPayload - skips unavailable tickets",
+  fn: () => {
+    const state = stateWith({
+      events: [
+        event("e1", "t1", { tickets: [ticket("t1", { status: "closed" })] }),
+        event("e2", "t2"),
+      ],
+    });
+    const payload = applyAction.buildPayload(state, rng);
+    assertEquals(payload.event_id, "e2");
+    assertEquals(payload.ticket_id, "t2");
+  },
+});
+
+Deno.test({
+  name:
+    "applyAction.buildPayload - throws when no candidate (canExecute should gate)",
   fn: () => {
     const state = stateWith({});
-    assertThrows(() => applyAction.buildPayload(state, rng), Error, "canExecute");
+    assertThrows(
+      () => applyAction.buildPayload(state, rng),
+      Error,
+      "canExecute",
+    );
   },
 });
 

--- a/supabase/functions/event-flow-simulator/core/cascade.ts
+++ b/supabase/functions/event-flow-simulator/core/cascade.ts
@@ -75,7 +75,11 @@ export async function runCascade(
       trace.push(entry);
 
       if (result.ok) {
-        snapshot = applySuccessfulActionToSnapshot(snapshot, action);
+        snapshot = applySuccessfulActionToSnapshot(
+          snapshot,
+          action,
+          result.data,
+        );
       }
 
       // Fix #2545: Supabase per-trace rate limit 회피. EF 호출 후만 sleep (skip-action 시는 즉시 다음).
@@ -95,6 +99,7 @@ export async function runCascade(
 function applySuccessfulActionToSnapshot(
   snapshot: WorldSnapshot,
   action: Action,
+  responseData: unknown,
 ): WorldSnapshot {
   if (action.type !== "user_apply") return snapshot;
 
@@ -104,20 +109,30 @@ function applySuccessfulActionToSnapshot(
     return snapshot;
   }
 
-  const events = snapshot.events.map((event) => {
-    if (event.id !== eventId || !event.tickets) return event;
-    return {
-      ...event,
-      tickets: event.tickets.map((ticket) =>
-        ticket.id === ticketId
-          ? {
-            ...ticket,
-            sold_count: Math.min(ticket.quantity, ticket.sold_count + 1),
-          }
-          : ticket
-      ),
-    };
-  });
+  const targetTicket = snapshot.events
+    .find((event) => event.id === eventId)
+    ?.tickets?.find((ticket) => ticket.id === ticketId);
+  const shouldReserveCapacity = shouldReserveApplyTicketCapacity(
+    targetTicket?.price,
+    responseData,
+  );
+
+  const events = shouldReserveCapacity
+    ? snapshot.events.map((event) => {
+      if (event.id !== eventId || !event.tickets) return event;
+      return {
+        ...event,
+        tickets: event.tickets.map((ticket) =>
+          ticket.id === ticketId
+            ? {
+              ...ticket,
+              sold_count: Math.min(ticket.quantity, ticket.sold_count + 1),
+            }
+            : ticket
+        ),
+      };
+    })
+    : snapshot.events;
 
   const applications =
     snapshot.applications.some((application) =>
@@ -136,4 +151,27 @@ function applySuccessfulActionToSnapshot(
       ];
 
   return { ...snapshot, events, applications };
+}
+
+function shouldReserveApplyTicketCapacity(
+  ticketPrice: number | undefined,
+  responseData: unknown,
+): boolean {
+  const responseType = applyResponseType(responseData);
+  if (responseType === "free") return true;
+  if (responseType === "paid") return false;
+  return ticketPrice === 0;
+}
+
+function applyResponseType(responseData: unknown): string | null {
+  if (
+    typeof responseData !== "object" ||
+    responseData === null ||
+    Array.isArray(responseData)
+  ) {
+    return null;
+  }
+
+  const type = (responseData as { type?: unknown }).type;
+  return typeof type === "string" ? type : null;
 }

--- a/supabase/functions/event-flow-simulator/core/cascade.ts
+++ b/supabase/functions/event-flow-simulator/core/cascade.ts
@@ -1,7 +1,11 @@
 // v2/core/cascade.ts — Stochastic Cascade 엔진
 
 import type { Action, Actor, PRNG } from "./types.ts";
-import { projectForPartner, projectForUser, type WorldSnapshot } from "./observable.ts";
+import {
+  projectForPartner,
+  projectForUser,
+  type WorldSnapshot,
+} from "./observable.ts";
 import type { Trace, TraceEntry } from "./trace.ts";
 import { userPolicy } from "../policy/user.ts";
 import { partnerPolicy } from "../policy/partner.ts";
@@ -29,7 +33,10 @@ export interface CascadeConfig {
   /** 시뮬할 tick 수 */
   ticks: number;
   /** 각 tick 후 snapshot 갱신 콜백 (실 운영: 재조회 RPC). 미제공 시 snapshot 변경 X */
-  refreshSnapshot?: (current: WorldSnapshot, trace: Trace) => Promise<WorldSnapshot> | WorldSnapshot;
+  refreshSnapshot?: (
+    current: WorldSnapshot,
+    trace: Trace,
+  ) => Promise<WorldSnapshot> | WorldSnapshot;
   /** EF 호출 후 throttle delay (ms). Supabase 의 per-trace rate limit (Fix #2545) 회피용. 기본 0 = 즉시. 실 운영 권장 200~400ms */
   delayBetweenCallsMs?: number;
 }
@@ -39,7 +46,9 @@ export interface CascadeResult {
   finalSnapshot: WorldSnapshot;
 }
 
-export async function runCascade(config: CascadeConfig): Promise<CascadeResult> {
+export async function runCascade(
+  config: CascadeConfig,
+): Promise<CascadeResult> {
   const trace: Trace = [];
   let snapshot = config.initialSnapshot;
 
@@ -65,6 +74,10 @@ export async function runCascade(config: CascadeConfig): Promise<CascadeResult> 
       if (result.error) entry.error = result.error;
       trace.push(entry);
 
+      if (result.ok) {
+        snapshot = applySuccessfulActionToSnapshot(snapshot, action);
+      }
+
       // Fix #2545: Supabase per-trace rate limit 회피. EF 호출 후만 sleep (skip-action 시는 즉시 다음).
       if (config.delayBetweenCallsMs && config.delayBetweenCallsMs > 0) {
         await new Promise((r) => setTimeout(r, config.delayBetweenCallsMs));
@@ -77,4 +90,50 @@ export async function runCascade(config: CascadeConfig): Promise<CascadeResult> 
   }
 
   return { trace, finalSnapshot: snapshot };
+}
+
+function applySuccessfulActionToSnapshot(
+  snapshot: WorldSnapshot,
+  action: Action,
+): WorldSnapshot {
+  if (action.type !== "user_apply") return snapshot;
+
+  const eventId = action.payload.event_id;
+  const ticketId = action.payload.ticket_id;
+  if (typeof eventId !== "string" || typeof ticketId !== "string") {
+    return snapshot;
+  }
+
+  const events = snapshot.events.map((event) => {
+    if (event.id !== eventId || !event.tickets) return event;
+    return {
+      ...event,
+      tickets: event.tickets.map((ticket) =>
+        ticket.id === ticketId
+          ? {
+            ...ticket,
+            sold_count: Math.min(ticket.quantity, ticket.sold_count + 1),
+          }
+          : ticket
+      ),
+    };
+  });
+
+  const applications =
+    snapshot.applications.some((application) =>
+        application.user_id === action.actorId &&
+        application.event_id === eventId
+      )
+      ? snapshot.applications
+      : [
+        ...snapshot.applications,
+        {
+          id: `local:${action.actorId}:${eventId}`,
+          user_id: action.actorId,
+          event_id: eventId,
+          status: "local_applied",
+        },
+      ];
+
+  return { ...snapshot, events, applications };
 }

--- a/supabase/functions/event-flow-simulator/core/cascade_test.ts
+++ b/supabase/functions/event-flow-simulator/core/cascade_test.ts
@@ -28,7 +28,13 @@ function snapshotWithOneEvent(): WorldSnapshot {
     party_id: "p1",
     status: "scheduled",
     start_time: new Date(Date.now() + 7 * 86400_000).toISOString(),
-    tickets: [{ id: "t1", price: 0 }],
+    tickets: [{
+      id: "t1",
+      price: 0,
+      status: "on_sale",
+      quantity: 10,
+      sold_count: 0,
+    }],
   });
   return snap;
 }
@@ -73,7 +79,7 @@ Deno.test({
     const { transport, calls } = recordingTransport();
     await runCascade({
       actors: [{ id: "user-1", role: "user" }],
-      initialSnapshot: emptySnapshot(),  // no events → applyAction.canExecute=false
+      initialSnapshot: emptySnapshot(), // no events → applyAction.canExecute=false
       rates: defaultRates,
       transport,
       rng: createPRNG(1),
@@ -130,7 +136,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "runCascade - refreshSnapshot callback advances world state between ticks",
+  name:
+    "runCascade - refreshSnapshot callback advances world state between ticks",
   fn: async () => {
     clearRegistry();
     registerAction(applyAction);
@@ -148,7 +155,11 @@ Deno.test({
         return cur;
       },
     });
-    assertEquals(refreshCalls, 3, "refreshSnapshot must be invoked after each tick");
+    assertEquals(
+      refreshCalls,
+      3,
+      "refreshSnapshot must be invoked after each tick",
+    );
   },
 });
 
@@ -199,7 +210,11 @@ Deno.test({
     // 3 호출 사이 2 delay × 50ms = 100ms 최소 (모든 actor 가 action 발생 시)
     // policy 가 일부 skip 해도 1 call 발생하면 +50ms 보장. 최소 50ms 확인 (느슨한 lower bound).
     assertEquals(calls.length > 0, true, "at least one EF call expected");
-    assertEquals(elapsed >= 50, true, `elapsed (${elapsed}ms) should be >= 50ms with throttle`);
+    assertEquals(
+      elapsed >= 50,
+      true,
+      `elapsed (${elapsed}ms) should be >= 50ms with throttle`,
+    );
   },
 });
 
@@ -225,6 +240,10 @@ Deno.test({
     });
     const elapsed = performance.now() - start;
     assertEquals(calls.length > 0, true);
-    assertEquals(elapsed < 50, true, `elapsed (${elapsed}ms) should be < 50ms without throttle`);
+    assertEquals(
+      elapsed < 50,
+      true,
+      `elapsed (${elapsed}ms) should be < 50ms without throttle`,
+    );
   },
 });

--- a/supabase/functions/event-flow-simulator/core/cascade_test.ts
+++ b/supabase/functions/event-flow-simulator/core/cascade_test.ts
@@ -40,13 +40,15 @@ function snapshotWithOneEvent(): WorldSnapshot {
 }
 
 /** Record-only transport — captures actions, always returns 200 OK */
-function recordingTransport(): { transport: Transport; calls: Action[] } {
+function recordingTransport(
+  data?: unknown,
+): { transport: Transport; calls: Action[] } {
   const calls: Action[] = [];
   return {
     transport: {
       execute(action) {
         calls.push(action);
-        return Promise.resolve({ ok: true, status: 200 });
+        return Promise.resolve({ ok: true, status: 200, data });
       },
     },
     calls,
@@ -114,14 +116,17 @@ Deno.test({
 
 Deno.test({
   name:
-    "runCascade - successful apply consumes local ticket availability within the same tick",
+    "runCascade - successful free apply consumes local ticket availability within the same tick",
   fn: async () => {
     clearRegistry();
     registerAction(applyAction);
     const snap = snapshotWithOneEvent();
     snap.events[0].tickets![0].quantity = 1;
     snap.events[0].tickets![0].sold_count = 0;
-    const { transport, calls } = recordingTransport();
+    const { transport, calls } = recordingTransport({
+      type: "free",
+      application_id: "app-1",
+    });
 
     const { finalSnapshot, trace } = await runCascade({
       actors: [
@@ -143,6 +148,56 @@ Deno.test({
       {
         id: "local:user-1:e1",
         user_id: "user-1",
+        event_id: "e1",
+        status: "local_applied",
+      },
+    ]);
+  },
+});
+
+Deno.test({
+  name:
+    "runCascade - successful paid apply does not consume local ticket availability within the same tick",
+  fn: async () => {
+    clearRegistry();
+    registerAction(applyAction);
+    const snap = snapshotWithOneEvent();
+    snap.events[0].tickets![0].price = 15000;
+    snap.events[0].tickets![0].quantity = 1;
+    snap.events[0].tickets![0].sold_count = 0;
+    const { transport, calls } = recordingTransport({
+      type: "paid",
+      application_id: "app-1",
+      order_id: "order-1",
+      payment_amount: 15000,
+    });
+
+    const { finalSnapshot, trace } = await runCascade({
+      actors: [
+        { id: "user-1", role: "user" },
+        { id: "user-2", role: "user" },
+      ],
+      initialSnapshot: snap,
+      rates: defaultRates,
+      transport,
+      rng: createPRNG(1),
+      ticks: 1,
+    });
+
+    assertEquals(calls.length, 2);
+    assertEquals(calls.map((call) => call.actorId), ["user-1", "user-2"]);
+    assertEquals(trace.length, 2);
+    assertEquals(finalSnapshot.events[0].tickets![0].sold_count, 0);
+    assertEquals(finalSnapshot.applications, [
+      {
+        id: "local:user-1:e1",
+        user_id: "user-1",
+        event_id: "e1",
+        status: "local_applied",
+      },
+      {
+        id: "local:user-2:e1",
+        user_id: "user-2",
         event_id: "e1",
         status: "local_applied",
       },

--- a/supabase/functions/event-flow-simulator/core/cascade_test.ts
+++ b/supabase/functions/event-flow-simulator/core/cascade_test.ts
@@ -113,6 +113,44 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "runCascade - successful apply consumes local ticket availability within the same tick",
+  fn: async () => {
+    clearRegistry();
+    registerAction(applyAction);
+    const snap = snapshotWithOneEvent();
+    snap.events[0].tickets![0].quantity = 1;
+    snap.events[0].tickets![0].sold_count = 0;
+    const { transport, calls } = recordingTransport();
+
+    const { finalSnapshot, trace } = await runCascade({
+      actors: [
+        { id: "user-1", role: "user" },
+        { id: "user-2", role: "user" },
+      ],
+      initialSnapshot: snap,
+      rates: defaultRates,
+      transport,
+      rng: createPRNG(1),
+      ticks: 1,
+    });
+
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0].actorId, "user-1");
+    assertEquals(trace.length, 1);
+    assertEquals(finalSnapshot.events[0].tickets![0].sold_count, 1);
+    assertEquals(finalSnapshot.applications, [
+      {
+        id: "local:user-1:e1",
+        user_id: "user-1",
+        event_id: "e1",
+        status: "local_applied",
+      },
+    ]);
+  },
+});
+
+Deno.test({
   name: "runCascade - records error in trace when transport fails",
   fn: async () => {
     clearRegistry();

--- a/supabase/functions/event-flow-simulator/core/observable.ts
+++ b/supabase/functions/event-flow-simulator/core/observable.ts
@@ -12,7 +12,13 @@ export interface WorldSnapshot {
     party_id: string;
     status: string;
     start_time: string;
-    tickets?: Array<{ id: string; price: number }>;
+    tickets?: Array<{
+      id: string;
+      price: number;
+      status: string;
+      quantity: number;
+      sold_count: number;
+    }>;
   }>;
   applications: Array<{
     id: string;
@@ -47,7 +53,10 @@ export interface ObservableState {
   [key: string]: unknown;
 }
 
-export function projectForUser(snapshot: WorldSnapshot, userId: string): ObservableState {
+export function projectForUser(
+  snapshot: WorldSnapshot,
+  userId: string,
+): ObservableState {
   return {
     myApplications: snapshot.applications.filter((a) => a.user_id === userId),
     visibleEvents: snapshot.events.filter((e) =>
@@ -59,7 +68,10 @@ export function projectForUser(snapshot: WorldSnapshot, userId: string): Observa
   };
 }
 
-export function projectForPartner(snapshot: WorldSnapshot, partnerId: string): ObservableState {
+export function projectForPartner(
+  snapshot: WorldSnapshot,
+  partnerId: string,
+): ObservableState {
   const myPartyIds = snapshot.parties
     .filter((p) => p.partner_id === partnerId)
     .map((p) => p.id);

--- a/supabase/functions/event-flow-simulator/core/observable_test.ts
+++ b/supabase/functions/event-flow-simulator/core/observable_test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "@std/assert";
+import { projectForPartner, type WorldSnapshot } from "./observable.ts";
+
+Deno.test("projectForPartner scopes events and pending applications to owned parties", () => {
+  const snapshot: WorldSnapshot = {
+    parties: [
+      { id: "party-owned", partner_id: "partner-1", status: "active" },
+      { id: "party-other", partner_id: "partner-2", status: "active" },
+    ],
+    events: [
+      {
+        id: "event-owned",
+        party_id: "party-owned",
+        status: "scheduled",
+        start_time: "2026-06-07T12:00:00.000Z",
+      },
+      {
+        id: "event-other",
+        party_id: "party-other",
+        status: "scheduled",
+        start_time: "2026-06-07T12:00:00.000Z",
+      },
+    ],
+    applications: [
+      {
+        id: "app-pending",
+        user_id: "user-1",
+        event_id: "event-owned",
+        status: "pending_review",
+      },
+      {
+        id: "app-approved",
+        user_id: "user-2",
+        event_id: "event-owned",
+        status: "approved",
+      },
+      {
+        id: "app-other",
+        user_id: "user-3",
+        event_id: "event-other",
+        status: "pending_review",
+      },
+    ],
+    participants: [],
+    votes: [],
+    blocks: [],
+  };
+
+  const state = projectForPartner(snapshot, "partner-1");
+
+  assertEquals(state["myParties"], [snapshot.parties[0]]);
+  assertEquals(state["myEvents"], [snapshot.events[0]]);
+  assertEquals(state["pendingApplications"], [snapshot.applications[0]]);
+});

--- a/supabase/functions/event-flow-simulator/core/snapshot.ts
+++ b/supabase/functions/event-flow-simulator/core/snapshot.ts
@@ -36,6 +36,9 @@ type TicketRow = {
   id: string;
   event_id: string;
   price: number;
+  status: string;
+  quantity: number;
+  sold_count: number;
 };
 
 type ApplicationRow = {
@@ -94,7 +97,7 @@ export async function buildSnapshot(
           ? selectByInChunks<TicketRow>(
             supabase,
             "tickets",
-            "id, event_id, price",
+            "id, event_id, price, status, quantity, sold_count",
             "event_id",
             eventIds,
           )
@@ -146,11 +149,23 @@ export async function buildSnapshot(
   // tickets 를 event 에 attach (observable 모델이 event.tickets 기대)
   const ticketsByEvent = new Map<
     string,
-    Array<{ id: string; price: number }>
+    Array<{
+      id: string;
+      price: number;
+      status: string;
+      quantity: number;
+      sold_count: number;
+    }>
   >();
   for (const t of tickets) {
     if (!ticketsByEvent.has(t.event_id)) ticketsByEvent.set(t.event_id, []);
-    ticketsByEvent.get(t.event_id)!.push({ id: t.id, price: t.price });
+    ticketsByEvent.get(t.event_id)!.push({
+      id: t.id,
+      price: t.price,
+      status: t.status,
+      quantity: t.quantity,
+      sold_count: t.sold_count,
+    });
   }
   const eventsWithTickets = events.map((e) => ({
     ...e,

--- a/supabase/functions/event-flow-simulator/core/snapshot_test.ts
+++ b/supabase/functions/event-flow-simulator/core/snapshot_test.ts
@@ -40,7 +40,14 @@ Deno.test({
       },
     ];
     const tickets = [
-      { id: "ticket-late", event_id: "event-late", price: 15000 },
+      {
+        id: "ticket-late",
+        event_id: "event-late",
+        price: 15000,
+        status: "on_sale",
+        quantity: 20,
+        sold_count: 3,
+      },
     ];
     const blocks = [
       {
@@ -101,7 +108,13 @@ Deno.test({
     assertEquals(snapshot.events.length, 1);
     assertEquals(snapshot.events[0].id, "event-late");
     assertEquals(snapshot.events[0].tickets, [
-      { id: "ticket-late", price: 15000 },
+      {
+        id: "ticket-late",
+        price: 15000,
+        status: "on_sale",
+        quantity: 20,
+        sold_count: 3,
+      },
     ]);
     assertEquals(snapshot.blocks, blocks);
   },

--- a/supabase/functions/event-flow-simulator/core/transport.ts
+++ b/supabase/functions/event-flow-simulator/core/transport.ts
@@ -28,7 +28,11 @@ export class EFTransport implements Transport {
   async execute(action: Action) {
     const token = this.cfg.tokenByActor.get(action.actorId);
     if (!token) {
-      return { ok: false, status: 0, error: `no token for actor ${action.actorId}` };
+      return {
+        ok: false,
+        status: 0,
+        error: `no token for actor ${action.actorId}`,
+      };
     }
 
     // direct DB write 분기 (block 액션)
@@ -69,10 +73,12 @@ export class EFTransport implements Transport {
       token,
       extraHeaders,
     );
+    const ok = res.status >= 200 && res.status < 300;
     return {
-      ok: res.status >= 200 && res.status < 300,
+      ok,
       status: res.status,
       data: res.data,
+      error: ok ? undefined : extractResponseError(res.data),
     };
   }
 
@@ -87,4 +93,16 @@ export class EFTransport implements Transport {
         `event-flow-simulator:${runId}:${sequence}:${action.type}`,
     };
   }
+}
+
+function extractResponseError(data: unknown): string | undefined {
+  if (typeof data === "string" && data.length > 0) return data;
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return undefined;
+  }
+  const record = data as Record<string, unknown>;
+  const message = record.error ?? record.message;
+  return typeof message === "string" && message.length > 0
+    ? message
+    : undefined;
 }

--- a/supabase/functions/event-flow-simulator/core/transport_test.ts
+++ b/supabase/functions/event-flow-simulator/core/transport_test.ts
@@ -74,3 +74,36 @@ Deno.test("EFTransport omits Idempotency-Key for functions without that contract
 
   assertEquals(idempotencyKey, null);
 });
+
+Deno.test("EFTransport includes error body for failed Edge Function calls", async () => {
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req) => req.url.endsWith("/functions/v1/apply-event"),
+      handler: () =>
+        Response.json(
+          { error: "Event is not accepting applications" },
+          { status: 409 },
+        ),
+    },
+  ]);
+
+  await withMockedFetch(fetchMock, async () => {
+    const transport = new EFTransport({
+      supabase: {} as SupabaseClient,
+      supabaseUrl: "https://example.supabase.co",
+      tokenByActor: new Map([["user-1", "test-token"]]),
+      runId: "run-1",
+    });
+
+    const result = await transport.execute({
+      type: "user_apply",
+      actorId: "user-1",
+      ef: "apply-event",
+      payload: { event_id: "event-1", ticket_id: "ticket-1" },
+    });
+
+    assertEquals(result.ok, false);
+    assertEquals(result.status, 409);
+    assertEquals(result.error, "Event is not accepting applications");
+  });
+});

--- a/supabase/functions/event-flow-simulator/core/transport_test.ts
+++ b/supabase/functions/event-flow-simulator/core/transport_test.ts
@@ -6,6 +6,28 @@ import {
 } from "../../_test_utils/mock_http.ts";
 import { EFTransport } from "./transport.ts";
 
+Deno.test("EFTransport returns failure when actor token is missing", async () => {
+  const transport = new EFTransport({
+    supabase: {} as SupabaseClient,
+    supabaseUrl: "https://example.supabase.co",
+    tokenByActor: new Map(),
+    runId: "run-1",
+  });
+
+  const result = await transport.execute({
+    type: "user_apply",
+    actorId: "user-1",
+    ef: "apply-event",
+    payload: { event_id: "event-1", ticket_id: "ticket-1" },
+  });
+
+  assertEquals(result, {
+    ok: false,
+    status: 0,
+    error: "no token for actor user-1",
+  });
+});
+
 Deno.test("EFTransport adds Idempotency-Key for apply-event calls", async () => {
   let idempotencyKey: string | null = null;
   const { fetchMock } = createFetchMock([
@@ -105,5 +127,63 @@ Deno.test("EFTransport includes error body for failed Edge Function calls", asyn
     assertEquals(result.ok, false);
     assertEquals(result.status, 409);
     assertEquals(result.error, "Event is not accepting applications");
+  });
+});
+
+Deno.test("EFTransport preserves string error bodies for failed Edge Function calls", async () => {
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req) => req.url.endsWith("/functions/v1/apply-event"),
+      handler: () => Response.json("ticket sold out", { status: 409 }),
+    },
+  ]);
+
+  await withMockedFetch(fetchMock, async () => {
+    const transport = new EFTransport({
+      supabase: {} as SupabaseClient,
+      supabaseUrl: "https://example.supabase.co",
+      tokenByActor: new Map([["user-1", "test-token"]]),
+      runId: "run-1",
+    });
+
+    const result = await transport.execute({
+      type: "user_apply",
+      actorId: "user-1",
+      ef: "apply-event",
+      payload: { event_id: "event-1", ticket_id: "ticket-1" },
+    });
+
+    assertEquals(result.ok, false);
+    assertEquals(result.status, 409);
+    assertEquals(result.error, "ticket sold out");
+  });
+});
+
+Deno.test("EFTransport leaves error empty when failed response body has no message", async () => {
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req) => req.url.endsWith("/functions/v1/apply-event"),
+      handler: () => new Response(null, { status: 500 }),
+    },
+  ]);
+
+  await withMockedFetch(fetchMock, async () => {
+    const transport = new EFTransport({
+      supabase: {} as SupabaseClient,
+      supabaseUrl: "https://example.supabase.co",
+      tokenByActor: new Map([["user-1", "test-token"]]),
+      runId: "run-1",
+    });
+
+    const result = await transport.execute({
+      type: "user_apply",
+      actorId: "user-1",
+      ef: "apply-event",
+      payload: { event_id: "event-1", ticket_id: "ticket-1" },
+    });
+
+    assertEquals(result.ok, false);
+    assertEquals(result.status, 500);
+    assertEquals(result.error, undefined);
   });
 });

--- a/supabase/functions/event-flow-simulator/policy/user_test.ts
+++ b/supabase/functions/event-flow-simulator/policy/user_test.ts
@@ -8,6 +8,11 @@ import { clearRegistry, registerAction } from "../action/_registry.ts";
 import { applyAction } from "../action/apply.ts";
 
 const baseRates: Rates = { user: { user_apply: 1.0 }, partner: {} };
+const visibleEvent = {
+  id: "e1",
+  status: "scheduled",
+  tickets: [{ id: "t1", status: "on_sale", quantity: 10, sold_count: 0 }],
+};
 
 function setup() {
   clearRegistry();
@@ -30,7 +35,7 @@ Deno.test({
     setup();
     const state = {
       myApplications: [],
-      visibleEvents: [{ id: "e1", tickets: [{ id: "t1" }] }],
+      visibleEvents: [visibleEvent],
     };
     const action = userPolicy("user-1", state, baseRates, createPRNG(1));
     assertEquals(action?.type, "user_apply");
@@ -48,7 +53,7 @@ Deno.test({
     const zeroRates: Rates = { user: { user_apply: 0 }, partner: {} };
     const state = {
       myApplications: [],
-      visibleEvents: [{ id: "e1", tickets: [{ id: "t1" }] }],
+      visibleEvents: [visibleEvent],
     };
     const action = userPolicy("user-1", state, zeroRates, createPRNG(1));
     assertEquals(action, null);
@@ -62,7 +67,7 @@ Deno.test({
     setup();
     const state = {
       myApplications: [],
-      visibleEvents: [{ id: "e1", tickets: [{ id: "t1" }] }],
+      visibleEvents: [visibleEvent],
     };
     const a1 = userPolicy("user-1", state, baseRates, createPRNG(42));
     const a2 = userPolicy("user-1", state, baseRates, createPRNG(42));


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## Summary
- Align `apply-event` with the shared event availability domain policy so `scheduled` and `active` events are application-open.
- Enrich the event-flow simulator snapshot with ticket `status`, `quantity`, and `sold_count`, then filter `user_apply` candidates to application-open events with on-sale, unsold tickets.
- Preserve failed Edge Function response error/message text in cascade trace entries, so future 409 reports include the actual conflict reason.
- Update the event domain BLUEDOC known-issue note now that `apply-event` and `user-create-order` use the same status policy.
- Add focused simulator core tests for the PR diff coverage gate and refresh the simulator BLUEDOC freshness marker for the new test file.
- Apply successful `user_apply` results to the in-memory cascade snapshot: free successes reserve ticket capacity immediately, while paid successes only add local application state and leave `sold_count` unchanged until later approval/payment.

## Why
Closes #3372.

The cascade reports showed repeated `user_apply` / `apply-event` HTTP 409 failures without invariant violations. The repo already documented that `apply-event` was the outlier: the shared domain policy and DB RPC allow `scheduled` / `active`, while the EF guard still rejected `active`. The simulator also lacked ticket availability fields, so it could select tickets that `apply-event` would reject.

## Verification
- `/home/minhyeok/.deno/bin/deno fmt supabase/functions/event-flow-simulator/core/cascade.ts supabase/functions/event-flow-simulator/core/cascade_test.ts`
- `cd supabase/functions && /home/minhyeok/.deno/bin/deno test --allow-all event-flow-simulator/core/cascade_test.ts` — 10 passed
- `cd supabase/functions && /home/minhyeok/.deno/bin/deno test --allow-all event-flow-simulator/` — 67 passed
- `cd supabase && /home/minhyeok/.deno/bin/deno test --allow-all --coverage=cov_profile functions/` — passed locally
- `source /tmp/pr3374-diffcover-venv/bin/activate && diff-cover supabase/cov_profile/lcov.info --compare-branch=origin/dev-staging --src-roots . --fail-under=80` — 98% diff coverage
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh` — passed
- `git diff --check` — passed

## Residual Risk
If later cascade runs still produce 409s from party balance constraints, that is a different simulator cohort-policy issue. This PR makes that diagnosable because failure traces now include the EF error body.