### PR TITLE
fix(simulator): skip full events before apply

### DIFF
--- a/supabase/functions/event-flow-simulator/action/apply.ts
+++ b/supabase/functions/event-flow-simulator/action/apply.ts
@@ -3,6 +3,7 @@
 import type { ActionDef } from "./_registry.ts";
 import { registerAction } from "./_registry.ts";
 import {
+  isEventFull,
   isEventOpenForApplication,
   isTicketSoldOut,
 } from "../../_shared/domains/event/availability.ts";
@@ -17,12 +18,26 @@ type TicketCandidate = {
 type EventCandidate = {
   id: string;
   status?: string;
+  current_participants?: number;
+  max_participants?: number;
   tickets?: TicketCandidate[];
 };
 
 function isApplicationEvent(event: EventCandidate): boolean {
-  return typeof event.status === "string" &&
-    isEventOpenForApplication(event.status);
+  if (
+    typeof event.status !== "string" ||
+    !isEventOpenForApplication(event.status)
+  ) {
+    return false;
+  }
+  if (
+    typeof event.current_participants === "number" &&
+    typeof event.max_participants === "number" &&
+    isEventFull(event.current_participants, event.max_participants)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function isApplicationTicket(ticket: TicketCandidate): boolean {

--- a/supabase/functions/event-flow-simulator/action/apply_test.ts
+++ b/supabase/functions/event-flow-simulator/action/apply_test.ts
@@ -12,6 +12,8 @@ function stateWith(opts: {
   events?: Array<{
     id: string;
     status?: string;
+    current_participants?: number;
+    max_participants?: number;
     tickets?: Array<{
       id: string;
       status?: string;
@@ -39,12 +41,16 @@ function event(
   ticketId: string,
   overrides: Partial<{
     status: string;
+    current_participants: number;
+    max_participants: number;
     tickets: ReturnType<typeof ticket>[];
   }> = {},
 ) {
   return {
     id,
     status: "scheduled",
+    current_participants: 0,
+    max_participants: 10,
     tickets: [ticket(ticketId)],
     ...overrides,
   };
@@ -129,6 +135,22 @@ Deno.test({
 });
 
 Deno.test({
+  name: "applyAction.canExecute - false when event is at capacity",
+  fn: () => {
+    const state = stateWith({
+      events: [
+        event("e1", "t1", {
+          current_participants: 10,
+          max_participants: 10,
+        }),
+      ],
+      apps: [],
+    });
+    assertEquals(applyAction.canExecute(state), false);
+  },
+});
+
+Deno.test({
   name:
     "applyAction.buildPayload - returns event_id + ticket_id from a candidate",
   fn: () => {
@@ -155,6 +177,24 @@ Deno.test({
         event("e2", "t2"),
       ],
       apps: [{ event_id: "e1" }],
+    });
+    const payload = applyAction.buildPayload(state, rng);
+    assertEquals(payload.event_id, "e2");
+    assertEquals(payload.ticket_id, "t2");
+  },
+});
+
+Deno.test({
+  name: "applyAction.buildPayload - skips full events",
+  fn: () => {
+    const state = stateWith({
+      events: [
+        event("e1", "t1", {
+          current_participants: 10,
+          max_participants: 10,
+        }),
+        event("e2", "t2"),
+      ],
     });
     const payload = applyAction.buildPayload(state, rng);
     assertEquals(payload.event_id, "e2");

--- a/supabase/functions/event-flow-simulator/core/cascade.ts
+++ b/supabase/functions/event-flow-simulator/core/cascade.ts
@@ -122,6 +122,10 @@ function applySuccessfulActionToSnapshot(
       if (event.id !== eventId || !event.tickets) return event;
       return {
         ...event,
+        current_participants: Math.min(
+          event.max_participants,
+          event.current_participants + 1,
+        ),
         tickets: event.tickets.map((ticket) =>
           ticket.id === ticketId
             ? {

--- a/supabase/functions/event-flow-simulator/core/cascade_test.ts
+++ b/supabase/functions/event-flow-simulator/core/cascade_test.ts
@@ -28,6 +28,8 @@ function snapshotWithOneEvent(): WorldSnapshot {
     party_id: "p1",
     status: "scheduled",
     start_time: new Date(Date.now() + 7 * 86400_000).toISOString(),
+    current_participants: 0,
+    max_participants: 10,
     tickets: [{
       id: "t1",
       price: 0,
@@ -143,6 +145,7 @@ Deno.test({
     assertEquals(calls.length, 1);
     assertEquals(calls[0].actorId, "user-1");
     assertEquals(trace.length, 1);
+    assertEquals(finalSnapshot.events[0].current_participants, 1);
     assertEquals(finalSnapshot.events[0].tickets![0].sold_count, 1);
     assertEquals(finalSnapshot.applications, [
       {
@@ -152,6 +155,41 @@ Deno.test({
         status: "local_applied",
       },
     ]);
+  },
+});
+
+Deno.test({
+  name:
+    "runCascade - successful free apply consumes local event capacity within the same tick",
+  fn: async () => {
+    clearRegistry();
+    registerAction(applyAction);
+    const snap = snapshotWithOneEvent();
+    snap.events[0].max_participants = 1;
+    snap.events[0].tickets![0].quantity = 10;
+    snap.events[0].tickets![0].sold_count = 0;
+    const { transport, calls } = recordingTransport({
+      type: "free",
+      application_id: "app-1",
+    });
+
+    const { finalSnapshot, trace } = await runCascade({
+      actors: [
+        { id: "user-1", role: "user" },
+        { id: "user-2", role: "user" },
+      ],
+      initialSnapshot: snap,
+      rates: defaultRates,
+      transport,
+      rng: createPRNG(1),
+      ticks: 1,
+    });
+
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0].actorId, "user-1");
+    assertEquals(trace.length, 1);
+    assertEquals(finalSnapshot.events[0].current_participants, 1);
+    assertEquals(finalSnapshot.events[0].tickets![0].sold_count, 1);
   },
 });
 

--- a/supabase/functions/event-flow-simulator/core/observable.ts
+++ b/supabase/functions/event-flow-simulator/core/observable.ts
@@ -12,6 +12,8 @@ export interface WorldSnapshot {
     party_id: string;
     status: string;
     start_time: string;
+    current_participants: number;
+    max_participants: number;
     tickets?: Array<{
       id: string;
       price: number;

--- a/supabase/functions/event-flow-simulator/core/observable_test.ts
+++ b/supabase/functions/event-flow-simulator/core/observable_test.ts
@@ -13,12 +13,16 @@ Deno.test("projectForPartner scopes events and pending applications to owned par
         party_id: "party-owned",
         status: "scheduled",
         start_time: "2026-06-07T12:00:00.000Z",
+        current_participants: 0,
+        max_participants: 20,
       },
       {
         id: "event-other",
         party_id: "party-other",
         status: "scheduled",
         start_time: "2026-06-07T12:00:00.000Z",
+        current_participants: 0,
+        max_participants: 20,
       },
     ],
     applications: [

--- a/supabase/functions/event-flow-simulator/core/snapshot.ts
+++ b/supabase/functions/event-flow-simulator/core/snapshot.ts
@@ -30,6 +30,8 @@ type EventRow = {
   party_id: string;
   status: string;
   start_time: string;
+  current_participants: number;
+  max_participants: number;
 };
 
 type TicketRow = {
@@ -85,7 +87,7 @@ export async function buildSnapshot(
   const events = (await selectAllRows<EventRow>(
     supabase,
     "events",
-    "id, party_id, status, start_time",
+    "id, party_id, status, start_time, current_participants, max_participants",
   )).filter((e) => partyIdSet.has(e.party_id));
   const eventIds = events.map((e) => e.id);
   const partnerIds = uniqueStrings(parties.map((p) => p.partner_id));

--- a/supabase/functions/event-flow-simulator/core/snapshot_test.ts
+++ b/supabase/functions/event-flow-simulator/core/snapshot_test.ts
@@ -37,6 +37,8 @@ Deno.test({
         party_id: "party-1000",
         status: "scheduled",
         start_time: new Date(Date.now() + 10 * 86_400_000).toISOString(),
+        current_participants: 3,
+        max_participants: 20,
       },
     ];
     const tickets = [
@@ -107,6 +109,8 @@ Deno.test({
     assertEquals(snapshot.parties.length, 1001);
     assertEquals(snapshot.events.length, 1);
     assertEquals(snapshot.events[0].id, "event-late");
+    assertEquals(snapshot.events[0].current_participants, 3);
+    assertEquals(snapshot.events[0].max_participants, 20);
     assertEquals(snapshot.events[0].tickets, [
       {
         id: "ticket-late",

--- a/supabase/functions/event-flow-simulator/policy/user_test.ts
+++ b/supabase/functions/event-flow-simulator/policy/user_test.ts
@@ -11,6 +11,8 @@ const baseRates: Rates = { user: { user_apply: 1.0 }, partner: {} };
 const visibleEvent = {
   id: "e1",
   status: "scheduled",
+  current_participants: 0,
+  max_participants: 10,
   tickets: [{ id: "t1", status: "on_sale", quantity: 10, sold_count: 0 }],
 };
 


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## Summary
- Add `current_participants` / `max_participants` to the event-flow simulator world snapshot.
- Make `user_apply` candidate selection skip events that `apply-event` would reject as full.
- Update the same-tick local cascade model so a successful free apply consumes event capacity as well as ticket availability.

## Why
Closes #3401.

The cascade reporter was repeatedly filing `user_apply` / `apply-event` HTTP 409 failures with no invariant violations. The simulator already filtered ticket sold-out state, but it did not model event-level capacity even though `apply-event` rejects full events before creating applications. That let stochastic users keep sampling full events when ticket quantity still looked available.

## Verification
- `/home/minhyeok/.deno/bin/deno test event-flow-simulator/action/apply_test.ts event-flow-simulator/core/snapshot_test.ts event-flow-simulator/core/cascade_test.ts event-flow-simulator/core/observable_test.ts event-flow-simulator/policy/user_test.ts` — 32 passed
- `/home/minhyeok/.deno/bin/deno test --allow-env event-flow-simulator/` — 70 passed
- `/home/minhyeok/.deno/bin/deno fmt --check event-flow-simulator/action/apply.ts event-flow-simulator/action/apply_test.ts event-flow-simulator/core/cascade.ts event-flow-simulator/core/cascade_test.ts event-flow-simulator/core/observable.ts event-flow-simulator/core/observable_test.ts event-flow-simulator/core/snapshot.ts event-flow-simulator/core/snapshot_test.ts event-flow-simulator/policy/user_test.ts`
- `git diff --check`

## Residual Risk
- This prevents known full-event false-positive apply attempts. Other business 409s, such as gender-balance rejection, may still need separate simulator/feed alignment if they appear in future cascade traces.