### PR TITLE
feat(web): add user checkout and purchases routes

### DIFF
--- a/apps/BLUEDOC.md
+++ b/apps/BLUEDOC.md
@@ -10,7 +10,7 @@ Minglit 의 **사용자 대면 애플리케이션** 폴더. Flutter 모바일 �
 |---|---|
 | [`app_user/`](./app_user/BLUEDOC.md) | 일반 사용자 Flutter 앱 (**동결**) — 파티 탐색·결제·인증 제출 |
 | [`app_partner/`](./app_partner/BLUEDOC.md) | 파트너 사장님 Flutter 앱 (**동결**) — 매장 관리·심사·정산 |
-| [`landing_user/`](./landing_user/) | 사용자 웹 MVP — 이벤트 탐색/상세/구매 진입 (Next.js) |
+| [`landing_user/`](./landing_user/) | 사용자 웹 MVP — 이벤트 탐색/상세/checkout/구매내역 (Next.js) |
 | [`landing_partner/`](./landing_partner/) | 파트너 웹 MVP 콘솔/로그인 (Next.js) |
 | [`mds/docs/`](./mds/docs/BLUEDOC.md) | Minglit Design System spec/문서 (Next.js) |
 | [`architecture.md`](./architecture.md) | Flutter 앱 공통 아키텍처 (Tech Stack, Patterns, Data Flow) |
@@ -28,7 +28,7 @@ Minglit 의 **사용자 대면 애플리케이션** 폴더. Flutter 모바일 �
 
 - **MDS spec-first** — UI 변경은 `apps/mds/docs/public/specs/` 화면 spec 과 `src/lib/components.ts` 컴포넌트 manifest 를 먼저 인용한다.
 - **유저웹 공개 browse** — `landing_user` 는 비로그인 이벤트 탐색/상세를 허용하고, 신청·결제 같은 보호 액션에서 로그인으로 보낸다.
-- **데이터 경계** — 공개 read 는 Supabase RLS/PostgREST, write 는 Edge Function/checkout 후속 화면에서 처리한다.
+- **데이터 경계** — 공개 read 는 Supabase RLS/PostgREST, 보호 read/write 는 Supabase Auth + RLS/Edge Function 으로 처리한다.
 
 ## 관련
 
@@ -39,4 +39,4 @@ Minglit 의 **사용자 대면 애플리케이션** 폴더. Flutter 모바일 �
 - [CLAUDE.md `## Build Defaults`](../CLAUDE.md) — flutter build 명령 / Java 17 설정
 
 ---
-_Reviewed: 2026-06-08 01:47_
+_Reviewed: 2026-06-08 04:00_

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -7,10 +7,11 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsc -p tsconfig.test.json && node --test .test-build/lib/events.test.js"
+    "test": "tsc -p tsconfig.test.json && node --test .test-build/lib/events.test.js .test-build/lib/user-orders.test.js"
   },
   "dependencies": {
     "@statsig/react-bindings": "^3.33.2",
+    "@supabase/supabase-js": "^2.107.0",
     "lucide-react": "^1.17.0",
     "next": "16.2.6",
     "react": "19.2.6",

--- a/apps/landing_user/src/app/auth/callback/page.tsx
+++ b/apps/landing_user/src/app/auth/callback/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+import { getSupabaseBrowserClient } from "@/lib/supabase";
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense fallback={<CallbackShell message="로그인을 확인하고 있습니다." />}>
+      <AuthCallbackContent />
+    </Suspense>
+  );
+}
+
+function AuthCallbackContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const next = normalizeReturnPath(searchParams.get("next") ?? undefined);
+  const [message, setMessage] = useState("로그인을 확인하고 있습니다.");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function finishLogin() {
+      const supabase = getSupabaseBrowserClient();
+      if (!supabase) {
+        setMessage("Supabase 공개 환경변수가 없어 로그인을 확인할 수 없습니다.");
+        return;
+      }
+
+      const { error } = await supabase.auth.getSession();
+      if (cancelled) return;
+      if (error) {
+        setMessage(error.message);
+        return;
+      }
+
+      router.replace(next);
+    }
+
+    void finishLogin();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [next, router]);
+
+  return (
+    <main className="web-login-intent">
+      <section className="web-login-intent__panel" aria-labelledby="callback-title">
+        <div className="minglit-logo web-login-intent__logo" aria-hidden="true">
+          <span className="minglit-logo__mark">M</span>
+          <span className="minglit-logo__text">Minglit</span>
+        </div>
+        <h1 id="callback-title">로그인 처리 중</h1>
+        <p>{message}</p>
+        <div className="web-login-intent__actions">
+          <Link className="web-login-intent__secondary" href={next}>
+            이전 화면으로 돌아가기
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function CallbackShell({ message }: { message: string }) {
+  return (
+    <main className="web-login-intent">
+      <section className="web-login-intent__panel" aria-labelledby="callback-fallback-title">
+        <div className="minglit-logo web-login-intent__logo" aria-hidden="true">
+          <span className="minglit-logo__mark">M</span>
+          <span className="minglit-logo__text">Minglit</span>
+        </div>
+        <h1 id="callback-fallback-title">로그인 처리 중</h1>
+        <p>{message}</p>
+      </section>
+    </main>
+  );
+}
+
+function normalizeReturnPath(value?: string): string {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) return "/";
+
+  return value;
+}

--- a/apps/landing_user/src/app/events/[id]/checkout/page.tsx
+++ b/apps/landing_user/src/app/events/[id]/checkout/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { EmptyState } from "@/components/web-user";
+import { WebUserCheckout } from "@/components/web-user-checkout";
+import { getPublicEvent } from "@/lib/events";
+import { findCheckoutTicket } from "@/lib/user-orders";
+
+type CheckoutPageProps = {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ ticket?: string }>;
+};
+
+export async function generateMetadata({ params }: CheckoutPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const event = await getPublicEvent(id);
+
+  return {
+    title: event ? `${event.title} 신청 · 결제 | Minglit` : "신청 · 결제 | Minglit",
+  };
+}
+
+export default async function CheckoutPage({ params, searchParams }: CheckoutPageProps) {
+  const { id } = await params;
+  const { ticket: ticketId } = await searchParams;
+  const event = await getPublicEvent(id);
+
+  if (!event) {
+    return <EmptyState title="이벤트를 찾을 수 없어요" description="주소가 바뀌었거나 공개되지 않은 이벤트입니다." />;
+  }
+
+  const ticket = findCheckoutTicket(event, ticketId ?? null);
+  if (!ticket) redirect(`/events/${event.id}`);
+
+  return <WebUserCheckout event={event} ticket={ticket} />;
+}

--- a/apps/landing_user/src/app/globals.css
+++ b/apps/landing_user/src/app/globals.css
@@ -1080,6 +1080,30 @@ button {
   color: var(--color-secondary);
 }
 
+.wuc-identity__body {
+  min-width: 0;
+  flex: 1;
+}
+
+.wuc-identity__btn {
+  align-self: center;
+  min-height: 36px;
+  padding: 0 14px;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 800;
+  white-space: nowrap;
+  background: var(--color-primary);
+  border: 0;
+  border-radius: 10px;
+}
+
+.wuc-identity__btn:disabled {
+  color: var(--color-text-secondary);
+  background: var(--color-divider);
+  cursor: not-allowed;
+}
+
 .wuc-check {
   display: flex;
   align-items: center;

--- a/apps/landing_user/src/app/globals.css
+++ b/apps/landing_user/src/app/globals.css
@@ -820,8 +820,903 @@ button {
   border: 1px solid var(--color-divider);
 }
 
+.web-login-intent button {
+  border: 0;
+  cursor: pointer;
+}
+
+.web-login-intent button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.web-login-intent__error {
+  margin-top: 16px;
+  color: var(--color-error);
+  font-size: 13px;
+}
+
+.wuc-header,
+.wup-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  height: 64px;
+  background: rgba(255, 255, 255, 0.96);
+  border-bottom: 1px solid var(--color-divider);
+  backdrop-filter: blur(12px);
+}
+
+.wuc-header__inner,
+.wup-header__inner {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  width: 100%;
+  max-width: 1200px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+.wuc-header__spacer,
+.wup-header__spacer {
+  flex: 1;
+}
+
+.wuc-avatar,
+.wup-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  color: var(--color-text-secondary);
+  background: var(--color-surface);
+  border: 1px solid var(--color-divider);
+  border-radius: 50%;
+}
+
+.wuc-avatar svg,
+.wup-avatar svg {
+  width: 18px;
+  height: 18px;
+}
+
+.wuc-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: 24px;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px 32px 32px;
+  align-items: start;
+}
+
+.wuc-col {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.wuc-page-title,
+.wup-title {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: 22px;
+  font-weight: 800;
+}
+
+.wuc-banner,
+.wuc-identity {
+  display: flex;
+  gap: 12px;
+  padding: 14px 16px;
+  background: rgba(153, 0, 255, 0.06);
+  border: 1px solid rgba(153, 0, 255, 0.25);
+  border-radius: 12px;
+}
+
+.wuc-banner svg,
+.wuc-identity svg {
+  width: 20px;
+  height: 20px;
+  color: var(--color-primary);
+  flex: 0 0 auto;
+}
+
+.wuc-banner__title,
+.wuc-identity__title {
+  color: var(--color-text-primary);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.wuc-banner__sub,
+.wuc-identity__sub {
+  margin: 2px 0 0;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.wuc-card,
+.wuc-summary,
+.wup-detail {
+  background: var(--color-background);
+  border: 1px solid var(--color-divider);
+  border-radius: 16px;
+}
+
+.wuc-card {
+  padding: 20px;
+}
+
+.wuc-card__title {
+  margin: 0 0 14px;
+  color: var(--color-text-primary);
+  font-size: 15px;
+  font-weight: 800;
+}
+
+.wuc-event {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.wuc-event__thumb {
+  position: relative;
+  width: 120px;
+  height: 60px;
+  overflow: hidden;
+  background: var(--color-surface);
+  border-radius: 8px;
+  flex: 0 0 auto;
+}
+
+.wuc-event__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.wuc-event__thumb span {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-secondary);
+  font-size: 11px;
+}
+
+.wuc-event__body {
+  min-width: 0;
+}
+
+.wuc-event__name {
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-size: 15px;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wuc-event__meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 4px;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+}
+
+.wuc-event__meta svg {
+  width: 13px;
+  height: 13px;
+  color: var(--color-primary);
+}
+
+.wuc-ticket-row,
+.wuc-summary__line,
+.wuc-summary__total {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.wuc-ticket-row {
+  padding-top: 14px;
+  margin-top: 14px;
+  border-top: 1px dashed var(--color-divider);
+}
+
+.wuc-ticket-row__name,
+.wuc-summary__line b {
+  color: var(--color-text-primary);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.wuc-ticket-row__qty,
+.wuc-summary__line span {
+  color: var(--color-text-secondary);
+  font-size: 13px;
+}
+
+.wuc-ticket-row__price {
+  margin-left: auto;
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.wuc-link {
+  color: var(--color-primary);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.wuc-identity {
+  background: rgba(255, 153, 0, 0.08);
+  border-color: rgba(255, 153, 0, 0.35);
+}
+
+.wuc-identity__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: rgba(255, 153, 0, 0.18);
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+
+.wuc-identity__icon svg {
+  color: var(--color-secondary);
+}
+
+.wuc-check {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px;
+  color: var(--color-text-primary);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.wuc-check input {
+  position: absolute;
+  opacity: 0;
+}
+
+.wuc-check__box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: #fff;
+  background: var(--color-background);
+  border: 1.5px solid var(--color-divider);
+  border-radius: 4px;
+  flex: 0 0 auto;
+}
+
+.wuc-check__box svg {
+  width: 12px;
+  height: 12px;
+}
+
+.wuc-check--checked .wuc-check__box {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.wuc-check__req {
+  color: var(--color-primary);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.wuc-consent__divider,
+.wup-divider {
+  height: 1px;
+  margin: 14px 0;
+  background: var(--color-divider);
+}
+
+.wuc-refund-box {
+  padding: 14px;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  line-height: 1.6;
+  background: var(--color-surface);
+  border-radius: 10px;
+}
+
+.wuc-refund-box__head {
+  display: block;
+  margin-top: 10px;
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.wuc-refund-box__head:first-child {
+  margin-top: 0;
+}
+
+.wuc-summary {
+  position: sticky;
+  top: 88px;
+  padding: 20px;
+}
+
+.wuc-summary__title {
+  color: var(--color-text-primary);
+  font-size: 17px;
+  font-weight: 900;
+}
+
+.wuc-summary__line {
+  justify-content: space-between;
+  margin-top: 14px;
+}
+
+.wuc-summary__total {
+  justify-content: space-between;
+  padding-top: 16px;
+  margin-top: 16px;
+  border-top: 1px solid var(--color-divider);
+}
+
+.wuc-summary__total span {
+  color: var(--color-text-primary);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.wuc-summary__total b {
+  color: var(--color-secondary);
+  font-size: 22px;
+  font-weight: 900;
+}
+
+.wuc-pay,
+.wuc-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 48px;
+  padding: 0 18px;
+  font-weight: 900;
+  border-radius: 12px;
+}
+
+.wuc-pay {
+  width: 100%;
+  margin-top: 18px;
+  color: #fff;
+  background: var(--color-primary);
+  border: 0;
+  cursor: pointer;
+}
+
+.wuc-pay:disabled {
+  color: var(--color-text-secondary);
+  background: var(--color-divider);
+  cursor: not-allowed;
+}
+
+.wuc-pay svg,
+.wuc-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.wuc-summary__helper {
+  margin: 8px 0 0;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.wuc-paywin {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  margin-top: 14px;
+  background: var(--color-surface);
+  border-radius: 12px;
+}
+
+.wuc-paywin__sim {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 72px;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  border: 1px dashed var(--color-divider);
+  border-radius: 8px;
+}
+
+.wuc-paywin label {
+  display: grid;
+  gap: 4px;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+}
+
+.wuc-paywin input {
+  height: 38px;
+  padding: 0 10px;
+  color: var(--color-text-primary);
+  background: var(--color-background);
+  border: 1px solid var(--color-divider);
+  border-radius: 8px;
+}
+
+.wuc-paywin button,
+.wup-btn {
+  min-height: 40px;
+  color: #fff;
+  font-weight: 800;
+  background: var(--color-primary);
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.wuc-snackbar {
+  padding: 10px 12px;
+  margin-top: 12px;
+  color: #fff;
+  font-size: 13px;
+  background: var(--color-error);
+  border-radius: 10px;
+}
+
+.wuc-done,
+.wup-gate,
+.wup-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
+  padding: 32px var(--spacing-screen-edge);
+  text-align: center;
+  flex-direction: column;
+}
+
+.wuc-done__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  color: #fff;
+  background: var(--color-tertiary);
+  border-radius: 50%;
+}
+
+.wuc-done__icon svg,
+.wup-gate svg,
+.wup-empty svg {
+  width: 32px;
+  height: 32px;
+}
+
+.wuc-done h1,
+.wup-gate h1,
+.wup-empty h2 {
+  margin: 16px 0 8px;
+  color: var(--color-text-primary);
+  font-size: 24px;
+  font-weight: 900;
+}
+
+.wuc-done p,
+.wup-gate p,
+.wup-empty p {
+  max-width: 480px;
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.wuc-done__actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+.wuc-btn--primary,
+.wup-gate a,
+.wup-empty a {
+  color: #fff;
+  background: var(--color-primary);
+}
+
+.wuc-btn--secondary {
+  color: var(--color-text-primary);
+  background: var(--color-surface);
+  border: 1px solid var(--color-divider);
+}
+
+.wuc-chip,
+.wup-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  font-size: 11.5px;
+  font-weight: 800;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.wuc-chip--info,
+.wup-chip--info {
+  color: #2563eb;
+  background: rgba(59, 130, 246, 0.16);
+}
+
+.wup-main {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px 32px 32px;
+}
+
+.wup-search {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 420px;
+  gap: 10px;
+  min-height: 44px;
+  padding: 0 18px;
+  color: var(--color-text-secondary);
+  font-size: 15px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-divider);
+  border-radius: 999px;
+}
+
+.wup-search svg {
+  width: 18px;
+  height: 18px;
+}
+
+.wup-title {
+  margin-bottom: 20px;
+}
+
+.wup-grid {
+  display: grid;
+  grid-template-columns: 363px minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.wup-list {
+  position: sticky;
+  top: 88px;
+  display: flex;
+  max-height: calc(100vh - 120px);
+  overflow: auto;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.wup-item {
+  display: flex;
+  gap: 6px;
+  width: 100%;
+  padding: 14px 16px;
+  text-align: left;
+  background: var(--color-background);
+  border: 1px solid var(--color-divider);
+  border-radius: 12px;
+  cursor: pointer;
+  flex-direction: column;
+}
+
+.wup-item--selected {
+  background: rgba(153, 0, 255, 0.04);
+  border-color: var(--color-primary);
+  box-shadow: inset 0 0 0 1px var(--color-primary);
+}
+
+.wup-item__top,
+.wup-item__bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.wup-item__date,
+.wup-item__meta {
+  color: var(--color-text-secondary);
+  font-size: 12px;
+}
+
+.wup-item__name {
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-size: 15px;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wup-item__amount {
+  color: var(--color-text-primary);
+  font-size: 14px;
+  font-weight: 900;
+}
+
+.wup-chip--success {
+  color: #059669;
+  background: rgba(5, 150, 105, 0.16);
+}
+
+.wup-chip--warning {
+  color: #d97706;
+  background: rgba(245, 158, 11, 0.18);
+}
+
+.wup-chip--error {
+  color: var(--color-error);
+  background: rgba(220, 38, 38, 0.14);
+}
+
+.wup-chip--neutral {
+  color: var(--color-text-secondary);
+  background: rgba(107, 114, 128, 0.16);
+}
+
+.wup-detail {
+  display: flex;
+  padding: 24px;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.wup-hero {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.wup-hero__thumb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 88px;
+  height: 88px;
+  overflow: hidden;
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  background: var(--color-surface);
+  border-radius: 12px;
+  flex: 0 0 auto;
+}
+
+.wup-hero__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.wup-hero__text {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.wup-hero__title {
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-size: 18px;
+  font-weight: 900;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wup-hero__meta {
+  color: var(--color-text-primary);
+  font-size: 13.5px;
+}
+
+.wup-hero__sub {
+  color: var(--color-text-secondary);
+  font-size: 12.5px;
+}
+
+.wup-sec__title {
+  margin: 0 0 12px;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-weight: 900;
+}
+
+.wup-tl {
+  display: flex;
+}
+
+.wup-tl__step {
+  position: relative;
+  min-width: 0;
+  padding-top: 22px;
+  flex: 1;
+}
+
+.wup-tl__step::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 12px;
+  height: 12px;
+  content: "";
+  background: var(--color-divider);
+  border-radius: 50%;
+}
+
+.wup-tl__step::after {
+  position: absolute;
+  top: 5px;
+  right: 8px;
+  left: 20px;
+  height: 2px;
+  content: "";
+  background: var(--color-divider);
+}
+
+.wup-tl__step:last-child::after {
+  display: none;
+}
+
+.wup-tl__step--done::before,
+.wup-tl__step--done::after {
+  background: var(--color-tertiary);
+}
+
+.wup-tl__step--now::before {
+  background: var(--color-primary);
+}
+
+.wup-tl__step--fail::before {
+  background: var(--color-error);
+}
+
+.wup-tl__label {
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.wup-tl__step--off .wup-tl__label {
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
+.wup-tl-note,
+.wup-refund-pending,
+.wup-action-message {
+  padding: 12px 14px;
+  margin: 14px 0 0;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+  background: var(--color-surface);
+  border-radius: 10px;
+}
+
+.wup-kv {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+.wup-kv div {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.wup-kv dt {
+  color: var(--color-text-secondary);
+  font-size: 13px;
+}
+
+.wup-kv dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 800;
+  text-align: right;
+}
+
+.wup-refund {
+  padding: 16px;
+  background: rgba(153, 0, 255, 0.05);
+  border: 1px solid rgba(153, 0, 255, 0.18);
+  border-radius: 12px;
+}
+
+.wup-refund h2 {
+  margin: 0 0 8px;
+  color: var(--color-text-primary);
+  font-size: 15px;
+  font-weight: 900;
+}
+
+.wup-refund p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.wup-btn--refund {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 16px;
+  margin-top: 14px;
+  background: var(--color-primary);
+}
+
+.wup-btn--refund:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.wup-btn--refund svg {
+  width: 16px;
+  height: 16px;
+}
+
+.wup-gate a,
+.wup-empty a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  margin-top: 20px;
+  font-weight: 900;
+  border-radius: 999px;
+}
+
+.spin {
+  animation: spin 900ms linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @media (max-width: 900px) {
   .wuh-header__inner {
+    gap: 12px;
+    padding: 0 var(--spacing-screen-edge);
+  }
+
+  .wuc-header__inner,
+  .wup-header__inner {
     gap: 12px;
     padding: 0 var(--spacing-screen-edge);
   }
@@ -836,7 +1731,17 @@ button {
     font-size: 0;
   }
 
+  .wup-search {
+    flex: 1;
+    min-width: 0;
+    font-size: 0;
+  }
+
   .wuh-search svg {
+    margin: 0 auto;
+  }
+
+  .wup-search svg {
     margin: 0 auto;
   }
 
@@ -846,8 +1751,15 @@ button {
   }
 
   .wuh-main,
-  .wed-main {
+  .wed-main,
+  .wuc-main,
+  .wup-main {
     padding: 16px var(--spacing-screen-edge) 28px;
+  }
+
+  .wuc-main,
+  .wup-grid {
+    grid-template-columns: 1fr;
   }
 
   .wuh-grid {
@@ -861,6 +1773,19 @@ button {
 
   .wed-panel {
     position: static;
+  }
+
+  .wuc-summary,
+  .wup-list {
+    position: static;
+    max-height: none;
+  }
+
+  .wuc-event,
+  .wup-hero,
+  .wuc-done__actions {
+    flex-direction: column;
+    align-items: stretch;
   }
 }
 
@@ -876,6 +1801,19 @@ button {
 
   .wed-panel {
     position: static;
+  }
+
+  .wuc-main {
+    grid-template-columns: 1fr;
+  }
+
+  .wuc-summary {
+    position: static;
+  }
+
+  .wup-grid {
+    grid-template-columns: 320px minmax(0, 1fr);
+    gap: 16px;
   }
 }
 

--- a/apps/landing_user/src/app/login/page.tsx
+++ b/apps/landing_user/src/app/login/page.tsx
@@ -1,12 +1,52 @@
+"use client";
+
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import { useState } from "react";
+import { getSupabaseBrowserClient } from "@/lib/supabase";
 
-type LoginPageProps = {
-  searchParams: Promise<{ next?: string }>;
-};
+type LoginProvider = "google" | "kakao";
 
-export default async function LoginPage({ searchParams }: LoginPageProps) {
-  const { next } = await searchParams;
-  const returnTo = normalizeReturnPath(next);
+const providers: Array<{ id: LoginProvider; label: string }> = [
+  { id: "google", label: "Google로 계속" },
+  { id: "kakao", label: "Kakao로 계속" },
+];
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={<LoginShell message="로그인 화면을 준비하고 있습니다." />}>
+      <LoginContent />
+    </Suspense>
+  );
+}
+
+function LoginContent() {
+  const searchParams = useSearchParams();
+  const next = normalizeReturnPath(searchParams.get("next") ?? undefined);
+  const [pendingProvider, setPendingProvider] = useState<LoginProvider | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function signIn(provider: LoginProvider) {
+    const supabase = getSupabaseBrowserClient();
+    if (!supabase) {
+      setMessage("Supabase 공개 환경변수가 없어 로그인을 시작할 수 없습니다.");
+      return;
+    }
+
+    setPendingProvider(provider);
+    setMessage(null);
+    const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: { redirectTo },
+    });
+
+    if (error) {
+      setMessage(error.message);
+      setPendingProvider(null);
+    }
+  }
 
   return (
     <main className="web-login-intent">
@@ -16,15 +56,39 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
           <span className="minglit-logo__text">Minglit</span>
         </div>
         <h1 id="login-title">로그인이 필요해요</h1>
-        <p>신청과 결제는 로그인 후 이어갈 수 있습니다. 보던 이벤트로 돌아가 정보를 계속 확인할 수 있어요.</p>
+        <p>신청, 결제, 구매 내역은 로그인 후 이어갈 수 있습니다.</p>
         <div className="web-login-intent__actions">
-          <Link className="web-login-intent__primary" href={returnTo}>
-            보던 이벤트로 돌아가기
-          </Link>
-          <Link className="web-login-intent__secondary" href="/">
-            이벤트 둘러보기
+          {providers.map((provider) => (
+            <button
+              key={provider.id}
+              className="web-login-intent__primary"
+              type="button"
+              disabled={pendingProvider !== null}
+              onClick={() => signIn(provider.id)}
+            >
+              {pendingProvider === provider.id ? "연결 중..." : provider.label}
+            </button>
+          ))}
+          <Link className="web-login-intent__secondary" href={next}>
+            이전 화면으로 돌아가기
           </Link>
         </div>
+        {message ? <p className="web-login-intent__error" role="alert">{message}</p> : null}
+      </section>
+    </main>
+  );
+}
+
+function LoginShell({ message }: { message: string }) {
+  return (
+    <main className="web-login-intent">
+      <section className="web-login-intent__panel" aria-labelledby="login-fallback-title">
+        <div className="minglit-logo web-login-intent__logo" aria-hidden="true">
+          <span className="minglit-logo__mark">M</span>
+          <span className="minglit-logo__text">Minglit</span>
+        </div>
+        <h1 id="login-fallback-title">로그인이 필요해요</h1>
+        <p>{message}</p>
       </section>
     </main>
   );

--- a/apps/landing_user/src/app/my/purchases/page.tsx
+++ b/apps/landing_user/src/app/my/purchases/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { WebUserPurchases } from "@/components/web-user-purchases";
+
+type PurchasesPageProps = {
+  searchParams: Promise<{ purchase?: string }>;
+};
+
+export const metadata: Metadata = {
+  title: "구매 내역 | Minglit",
+};
+
+export default async function PurchasesPage({ searchParams }: PurchasesPageProps) {
+  const { purchase } = await searchParams;
+
+  return <WebUserPurchases selectedId={purchase} />;
+}

--- a/apps/landing_user/src/components/web-user-checkout.tsx
+++ b/apps/landing_user/src/components/web-user-checkout.tsx
@@ -4,14 +4,18 @@ import Link from "next/link";
 import { AlertCircle, CalendarDays, Check, CreditCard, Loader2, MapPin, ShieldCheck, User } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { PublicEvent, Ticket } from "@/lib/events";
-import { createCheckoutOrder, verifyCheckoutPayment } from "@/lib/user-orders";
+import { checkoutGate, createCheckoutOrder, fetchUserVerified } from "@/lib/user-orders";
 import { getSupabaseBrowserClient } from "@/lib/supabase";
 
-type AuthState = { status: "loading" } | { status: "config-error" } | { status: "anonymous" } | { status: "ready" };
+type AuthState =
+  | { status: "loading" }
+  | { status: "config-error" }
+  | { status: "anonymous" }
+  | { status: "profile-error" }
+  | { status: "ready"; isVerified: boolean };
 type CheckoutState =
   | { status: "idle" }
   | { status: "creating" }
-  | { status: "payment"; applicationId: string; merchantUid: string }
   | { status: "done" }
   | { status: "error"; message: string };
 
@@ -38,7 +42,12 @@ export function WebUserCheckout({ event, ticket }: { event: PublicEvent; ticket:
         return;
       }
 
-      setAuthState({ status: "ready" });
+      try {
+        const isVerified = await fetchUserVerified(supabase, data.session.user.id);
+        if (!cancelled) setAuthState({ status: "ready", isVerified });
+      } catch {
+        if (!cancelled) setAuthState({ status: "profile-error" });
+      }
     }
 
     void resolveAuth();
@@ -48,19 +57,17 @@ export function WebUserCheckout({ event, ticket }: { event: PublicEvent; ticket:
     };
   }, []);
 
-  const helper = useMemo(() => {
-    if (authState.status === "loading") return "로그인 상태를 확인하고 있습니다.";
-    if (authState.status === "anonymous") return "로그인 후 같은 주문으로 돌아옵니다.";
-    if (authState.status === "config-error") return "Supabase 공개 환경변수가 없어 결제를 시작할 수 없습니다.";
-    if (!agreed) return "필수 약관과 환불 정책에 동의해 주세요.";
-    if (checkout.status === "creating") return "주문을 생성하고 있습니다.";
-    if (checkout.status === "payment") return "Portone V2 결제창 완료 후 결제 식별자를 입력해 검증합니다.";
-    return "결제 후에도 파트너 승인 전까지는 승인 대기 상태입니다.";
-  }, [agreed, authState.status, checkout.status]);
+  const gate = useMemo(() => checkoutGate({
+    authStatus: authState.status,
+    isVerified: authState.status === "ready" ? authState.isVerified : false,
+    agreed,
+    ticketPrice: ticket.price,
+    isCreating: checkout.status === "creating",
+  }), [agreed, authState, checkout.status, ticket.price]);
 
   async function startPayment() {
     const supabase = getSupabaseBrowserClient();
-    if (!supabase || authState.status !== "ready" || !agreed) return;
+    if (!supabase || !gate.canSubmit) return;
 
     setCheckout({ status: "creating" });
 
@@ -71,31 +78,9 @@ export function WebUserCheckout({ event, ticket }: { event: PublicEvent; ticket:
         return;
       }
 
-      setCheckout({
-        status: "payment",
-        applicationId: order.applicationId,
-        merchantUid: order.applicationId,
-      });
+      setCheckout({ status: "error", message: "유료 결제창은 아직 연결되지 않아 주문을 완료할 수 없습니다." });
     } catch (error) {
       setCheckout({ status: "error", message: error instanceof Error ? error.message : "주문 생성에 실패했습니다." });
-    }
-  }
-
-  async function verifyPayment(formData: FormData) {
-    const supabase = getSupabaseBrowserClient();
-    const impUid = String(formData.get("imp_uid") ?? "").trim();
-    const merchantUid = String(formData.get("merchant_uid") ?? "").trim();
-
-    if (!supabase || !impUid || !merchantUid) {
-      setCheckout({ status: "error", message: "결제 식별자를 입력해 주세요." });
-      return;
-    }
-
-    try {
-      await verifyCheckoutPayment(supabase, impUid, merchantUid);
-      setCheckout({ status: "done" });
-    } catch (error) {
-      setCheckout({ status: "error", message: error instanceof Error ? error.message : "결제 검증에 실패했습니다." });
     }
   }
 
@@ -151,13 +136,7 @@ export function WebUserCheckout({ event, ticket }: { event: PublicEvent; ticket:
             </div>
           </section>
 
-          <section className="wuc-identity">
-            <div className="wuc-identity__icon"><ShieldCheck aria-hidden="true" /></div>
-            <div>
-              <div className="wuc-identity__title">본인인증은 결제 단계에서 확인합니다</div>
-              <p className="wuc-identity__sub">Portone V2 웹 인증이 연결되면 최초 1회 인증 후 결제를 이어갑니다.</p>
-            </div>
-          </section>
+          {authState.status === "ready" && !authState.isVerified ? <IdentityVerificationCard /> : null}
 
           <section className="wuc-card">
             <h2 className="wuc-card__title">약관 및 환불 정책</h2>
@@ -192,15 +171,14 @@ export function WebUserCheckout({ event, ticket }: { event: PublicEvent; ticket:
             <button
               className="wuc-pay"
               type="button"
-              disabled={authState.status !== "ready" || !agreed || checkout.status === "creating"}
+              disabled={!gate.canSubmit}
               onClick={startPayment}
             >
               {checkout.status === "creating" ? <Loader2 className="spin" aria-hidden="true" /> : <CreditCard aria-hidden="true" />}
-              결제 진행
+              {ticket.price > 0 ? "결제 준비 중" : "무료 신청"}
             </button>
           )}
-          <p className="wuc-summary__helper">{helper}</p>
-          {checkout.status === "payment" ? <PaymentReturnForm merchantUid={checkout.merchantUid} onVerify={verifyPayment} /> : null}
+          <p className="wuc-summary__helper">{gate.helper}</p>
           {checkout.status === "error" ? <div className="wuc-snackbar" role="alert">{checkout.message}</div> : null}
         </aside>
       </main>
@@ -236,20 +214,18 @@ function EventThumb({ event }: { event: PublicEvent }) {
   );
 }
 
-function PaymentReturnForm({ merchantUid, onVerify }: { merchantUid: string; onVerify: (formData: FormData) => void }) {
+function IdentityVerificationCard() {
   return (
-    <form className="wuc-paywin" action={onVerify}>
-      <div className="wuc-paywin__sim">Portone V2 웹 결제창 연결 대기</div>
-      <label>
-        imp_uid
-        <input name="imp_uid" placeholder="imp_xxx" />
-      </label>
-      <label>
-        merchant_uid
-        <input name="merchant_uid" defaultValue={merchantUid} />
-      </label>
-      <button type="submit">결제 검증</button>
-    </form>
+    <section className="wuc-identity">
+      <div className="wuc-identity__icon"><ShieldCheck aria-hidden="true" /></div>
+      <div className="wuc-identity__body">
+        <div className="wuc-identity__title">본인인증이 필요해요</div>
+        <p className="wuc-identity__sub">안전한 참여를 위해 최초 1회 본인 명의 확인이 필요해요.</p>
+      </div>
+      <button className="wuc-identity__btn" type="button" disabled>
+        본인인증 준비 중
+      </button>
+    </section>
   );
 }
 

--- a/apps/landing_user/src/components/web-user-checkout.tsx
+++ b/apps/landing_user/src/components/web-user-checkout.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import Link from "next/link";
+import { AlertCircle, CalendarDays, Check, CreditCard, Loader2, MapPin, ShieldCheck, User } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import type { PublicEvent, Ticket } from "@/lib/events";
+import { createCheckoutOrder, verifyCheckoutPayment } from "@/lib/user-orders";
+import { getSupabaseBrowserClient } from "@/lib/supabase";
+
+type AuthState = { status: "loading" } | { status: "config-error" } | { status: "anonymous" } | { status: "ready" };
+type CheckoutState =
+  | { status: "idle" }
+  | { status: "creating" }
+  | { status: "payment"; applicationId: string; merchantUid: string }
+  | { status: "done" }
+  | { status: "error"; message: string };
+
+export function WebUserCheckout({ event, ticket }: { event: PublicEvent; ticket: Ticket }) {
+  const [authState, setAuthState] = useState<AuthState>({ status: "loading" });
+  const [agreed, setAgreed] = useState(false);
+  const [checkout, setCheckout] = useState<CheckoutState>({ status: "idle" });
+  const total = ticket.price;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function resolveAuth() {
+      const supabase = getSupabaseBrowserClient();
+      if (!supabase) {
+        setAuthState({ status: "config-error" });
+        return;
+      }
+
+      const { data, error } = await supabase.auth.getSession();
+      if (cancelled) return;
+      if (error || !data.session?.user) {
+        setAuthState({ status: "anonymous" });
+        return;
+      }
+
+      setAuthState({ status: "ready" });
+    }
+
+    void resolveAuth();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const helper = useMemo(() => {
+    if (authState.status === "loading") return "로그인 상태를 확인하고 있습니다.";
+    if (authState.status === "anonymous") return "로그인 후 같은 주문으로 돌아옵니다.";
+    if (authState.status === "config-error") return "Supabase 공개 환경변수가 없어 결제를 시작할 수 없습니다.";
+    if (!agreed) return "필수 약관과 환불 정책에 동의해 주세요.";
+    if (checkout.status === "creating") return "주문을 생성하고 있습니다.";
+    if (checkout.status === "payment") return "Portone V2 결제창 완료 후 결제 식별자를 입력해 검증합니다.";
+    return "결제 후에도 파트너 승인 전까지는 승인 대기 상태입니다.";
+  }, [agreed, authState.status, checkout.status]);
+
+  async function startPayment() {
+    const supabase = getSupabaseBrowserClient();
+    if (!supabase || authState.status !== "ready" || !agreed) return;
+
+    setCheckout({ status: "creating" });
+
+    try {
+      const order = await createCheckoutOrder(supabase, event.id, ticket.id);
+      if (!order.requiresPayment || order.amount === 0) {
+        setCheckout({ status: "done" });
+        return;
+      }
+
+      setCheckout({
+        status: "payment",
+        applicationId: order.applicationId,
+        merchantUid: order.applicationId,
+      });
+    } catch (error) {
+      setCheckout({ status: "error", message: error instanceof Error ? error.message : "주문 생성에 실패했습니다." });
+    }
+  }
+
+  async function verifyPayment(formData: FormData) {
+    const supabase = getSupabaseBrowserClient();
+    const impUid = String(formData.get("imp_uid") ?? "").trim();
+    const merchantUid = String(formData.get("merchant_uid") ?? "").trim();
+
+    if (!supabase || !impUid || !merchantUid) {
+      setCheckout({ status: "error", message: "결제 식별자를 입력해 주세요." });
+      return;
+    }
+
+    try {
+      await verifyCheckoutPayment(supabase, impUid, merchantUid);
+      setCheckout({ status: "done" });
+    } catch (error) {
+      setCheckout({ status: "error", message: error instanceof Error ? error.message : "결제 검증에 실패했습니다." });
+    }
+  }
+
+  if (checkout.status === "done") {
+    return (
+      <div className="web-user-shell">
+        <CheckoutHeader />
+        <main className="wuc-done">
+          <div className="wuc-done__icon"><Check aria-hidden="true" /></div>
+          <span className="wuc-chip wuc-chip--info">파트너 승인 대기</span>
+          <h1>신청이 접수됐습니다</h1>
+          <p>결제는 참여 확정이 아닙니다. 파트너가 승인하면 확정되고, 거절되면 전액 자동 환불됩니다.</p>
+          <div className="wuc-done__actions">
+            <Link className="wuc-btn wuc-btn--primary" href="/my/purchases">구매내역 보기</Link>
+            <Link className="wuc-btn wuc-btn--secondary" href={`/events/${event.id}`}>이벤트로 돌아가기</Link>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="web-user-shell">
+      <CheckoutHeader />
+      <main className="wuc-main">
+        <section className="wuc-col" aria-labelledby="checkout-title">
+          <h1 id="checkout-title" className="wuc-page-title">신청 · 결제</h1>
+          <div className="wuc-banner">
+            <AlertCircle aria-hidden="true" />
+            <div>
+              <div className="wuc-banner__title">결제는 참여 확정이 아닙니다</div>
+              <p className="wuc-banner__sub">파트너 승인 후 최종 확정됩니다. 거절되면 결제 금액은 전액 자동 환불됩니다.</p>
+            </div>
+          </div>
+
+          <section className="wuc-card">
+            <h2 className="wuc-card__title">주문 정보</h2>
+            <div className="wuc-event">
+              <EventThumb event={event} />
+              <div className="wuc-event__body">
+                <div className="wuc-event__name">{event.title}</div>
+                <div className="wuc-event__meta"><CalendarDays aria-hidden="true" />{formatDateRange(event.startsAt, event.endsAt)}</div>
+                <div className="wuc-event__meta"><MapPin aria-hidden="true" />{event.locationName}</div>
+              </div>
+            </div>
+            <div className="wuc-ticket-row">
+              <div>
+                <div className="wuc-ticket-row__name">{ticket.name}</div>
+                <div className="wuc-ticket-row__qty">1매 · {ticket.description ?? "표준 티켓"}</div>
+              </div>
+              <Link className="wuc-link" href={`/events/${event.id}`}>변경</Link>
+              <div className="wuc-ticket-row__price">{formatPrice(total)}</div>
+            </div>
+          </section>
+
+          <section className="wuc-identity">
+            <div className="wuc-identity__icon"><ShieldCheck aria-hidden="true" /></div>
+            <div>
+              <div className="wuc-identity__title">본인인증은 결제 단계에서 확인합니다</div>
+              <p className="wuc-identity__sub">Portone V2 웹 인증이 연결되면 최초 1회 인증 후 결제를 이어갑니다.</p>
+            </div>
+          </section>
+
+          <section className="wuc-card">
+            <h2 className="wuc-card__title">약관 및 환불 정책</h2>
+            <label className={`wuc-check wuc-check--all${agreed ? " wuc-check--checked" : ""}`}>
+              <input type="checkbox" checked={agreed} onChange={(eventValue) => setAgreed(eventValue.currentTarget.checked)} />
+              <span className="wuc-check__box" aria-hidden="true"><Check /></span>
+              필수 약관과 환불 정책에 모두 동의합니다
+              <span className="wuc-check__req">필수</span>
+            </label>
+            <div className="wuc-consent__divider" />
+            <div className="wuc-refund-box">
+              <span className="wuc-refund-box__head">자동 환불 (전액)</span>
+              파트너 귀책 취소·승인 거절 시 전액 자동 환불됩니다.
+              <span className="wuc-refund-box__head">직접 취소 (전액)</span>
+              결제 후 3시간 이내 또는 이벤트 시작 7일 전까지 전액 환불됩니다.
+              <span className="wuc-refund-box__head">그 외</span>
+              자동 환불 불가 기간의 파트너 환불 요청은 backend follow-up이 필요합니다.
+            </div>
+          </section>
+        </section>
+
+        <aside className="wuc-summary" aria-label="주문 요약">
+          <div className="wuc-summary__title">주문 요약</div>
+          <div className="wuc-summary__line"><span>{ticket.name}</span><b>{formatPrice(total)}</b></div>
+          <div className="wuc-summary__line"><span>수량</span><b>1매</b></div>
+          <div className="wuc-summary__total"><span>총 결제금액</span><b>{formatPrice(total)}</b></div>
+          {authState.status === "anonymous" ? (
+            <Link className="wuc-pay" href={`/login?next=${encodeURIComponent(`/events/${event.id}/checkout?ticket=${ticket.id}`)}`}>
+              <User aria-hidden="true" /> 로그인하고 계속
+            </Link>
+          ) : (
+            <button
+              className="wuc-pay"
+              type="button"
+              disabled={authState.status !== "ready" || !agreed || checkout.status === "creating"}
+              onClick={startPayment}
+            >
+              {checkout.status === "creating" ? <Loader2 className="spin" aria-hidden="true" /> : <CreditCard aria-hidden="true" />}
+              결제 진행
+            </button>
+          )}
+          <p className="wuc-summary__helper">{helper}</p>
+          {checkout.status === "payment" ? <PaymentReturnForm merchantUid={checkout.merchantUid} onVerify={verifyPayment} /> : null}
+          {checkout.status === "error" ? <div className="wuc-snackbar" role="alert">{checkout.message}</div> : null}
+        </aside>
+      </main>
+    </div>
+  );
+}
+
+function CheckoutHeader() {
+  return (
+    <header className="wuc-header">
+      <div className="wuc-header__inner">
+        <Link className="minglit-logo" href="/" aria-label="Minglit 홈">
+          <span className="minglit-logo__mark">M</span>
+          <span className="minglit-logo__text">Minglit</span>
+        </Link>
+        <div className="wuc-header__spacer" />
+        <Link className="wuc-avatar" href="/my/purchases" aria-label="구매 내역"><User aria-hidden="true" /></Link>
+      </div>
+    </header>
+  );
+}
+
+function EventThumb({ event }: { event: PublicEvent }) {
+  return (
+    <div className="wuc-event__thumb">
+      {event.imageUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={event.imageUrl} alt="" />
+      ) : (
+        <span>Minglit Event</span>
+      )}
+    </div>
+  );
+}
+
+function PaymentReturnForm({ merchantUid, onVerify }: { merchantUid: string; onVerify: (formData: FormData) => void }) {
+  return (
+    <form className="wuc-paywin" action={onVerify}>
+      <div className="wuc-paywin__sim">Portone V2 웹 결제창 연결 대기</div>
+      <label>
+        imp_uid
+        <input name="imp_uid" placeholder="imp_xxx" />
+      </label>
+      <label>
+        merchant_uid
+        <input name="merchant_uid" defaultValue={merchantUid} />
+      </label>
+      <button type="submit">결제 검증</button>
+    </form>
+  );
+}
+
+function formatPrice(price: number): string {
+  return price === 0 ? "무료" : `${price.toLocaleString("ko-KR")}원`;
+}
+
+function formatDateRange(start: string, end: string): string {
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  const day = new Intl.DateTimeFormat("ko-KR", {
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+    timeZone: "Asia/Seoul",
+  }).format(startDate);
+  const time = new Intl.DateTimeFormat("ko-KR", { hour: "numeric", minute: "2-digit", timeZone: "Asia/Seoul" });
+
+  return `${day} ${time.format(startDate)} - ${time.format(endDate)}`;
+}

--- a/apps/landing_user/src/components/web-user-purchases.tsx
+++ b/apps/landing_user/src/components/web-user-purchases.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import Link from "next/link";
+import { Loader2, RotateCcw, Search, User } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { cancelUserOrder, canRequestAutomaticRefund, fetchUserPurchases, statusCopy, type UserPurchase } from "@/lib/user-orders";
+import { getSupabaseBrowserClient } from "@/lib/supabase";
+
+type PurchaseState =
+  | { status: "loading" }
+  | { status: "config-error" }
+  | { status: "anonymous" }
+  | { status: "error"; message: string }
+  | { status: "ready"; purchases: UserPurchase[] };
+
+export function WebUserPurchases({ selectedId }: { selectedId?: string }) {
+  const [state, setState] = useState<PurchaseState>({ status: "loading" });
+  const [activeId, setActiveId] = useState(selectedId ?? "");
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [pendingCancel, setPendingCancel] = useState(false);
+
+  async function load() {
+    const supabase = getSupabaseBrowserClient();
+    if (!supabase) {
+      setState({ status: "config-error" });
+      return;
+    }
+
+    const { data, error } = await supabase.auth.getSession();
+    if (error || !data.session?.user) {
+      setState({ status: "anonymous" });
+      return;
+    }
+
+    try {
+      const purchases = await fetchUserPurchases(supabase);
+      setState({ status: "ready", purchases });
+      setActiveId((current) => current || selectedId || purchases[0]?.id || "");
+    } catch (purchaseError) {
+      setState({
+        status: "error",
+        message: purchaseError instanceof Error ? purchaseError.message : "구매 내역을 불러오지 못했습니다.",
+      });
+    }
+  }
+
+  useEffect(() => {
+    void Promise.resolve().then(load);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function cancelOrder(purchase: UserPurchase) {
+    const supabase = getSupabaseBrowserClient();
+    if (!supabase || pendingCancel) return;
+
+    setPendingCancel(true);
+    setActionMessage(null);
+    try {
+      const message = await cancelUserOrder(supabase, purchase.eventId, "web_user_purchase_cancel");
+      setActionMessage(message);
+      await load();
+    } catch (error) {
+      setActionMessage(error instanceof Error ? error.message : "환불 요청을 처리하지 못했습니다.");
+    } finally {
+      setPendingCancel(false);
+    }
+  }
+
+  if (state.status !== "ready") {
+    return <PurchasesGate state={state} />;
+  }
+
+  const selected = state.purchases.find((purchase) => purchase.id === activeId) ?? state.purchases[0] ?? null;
+
+  return (
+    <div className="web-user-shell">
+      <PurchasesHeader />
+      <main className="wup-main">
+        <h1 className="wup-title">구매 내역</h1>
+        {state.purchases.length === 0 || !selected ? (
+          <div className="wup-empty">
+            <Search aria-hidden="true" />
+            <h2>구매 내역이 없습니다</h2>
+            <p>이벤트 신청과 결제를 완료하면 이곳에서 승인 상태와 환불 가능 여부를 확인할 수 있습니다.</p>
+            <Link href="/">이벤트 둘러보기</Link>
+          </div>
+        ) : (
+          <div className="wup-grid">
+            <section className="wup-list" aria-label="구매 목록">
+              {state.purchases.map((purchase) => (
+                <PurchaseListItem
+                  key={purchase.id}
+                  purchase={purchase}
+                  selected={purchase.id === selected.id}
+                  onSelect={() => setActiveId(purchase.id)}
+                />
+              ))}
+            </section>
+            <PurchaseDetail purchase={selected} actionMessage={actionMessage} pendingCancel={pendingCancel} onCancel={() => cancelOrder(selected)} />
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function PurchasesGate({ state }: { state: Exclude<PurchaseState, { status: "ready" }> }) {
+  const title = state.status === "anonymous" ? "로그인이 필요해요" : state.status === "config-error" ? "설정이 필요해요" : state.status === "error" ? "구매 내역을 불러오지 못했어요" : "구매 내역을 불러오는 중";
+  const description =
+    state.status === "anonymous"
+      ? "개인 결제 정보는 로그인 후 확인할 수 있습니다."
+      : state.status === "config-error"
+        ? "Supabase 공개 환경변수가 없어 로그인 상태를 확인할 수 없습니다."
+        : state.status === "error"
+          ? state.message
+          : "잠시만 기다려 주세요.";
+
+  return (
+    <div className="web-user-shell">
+      <PurchasesHeader />
+      <main className="wup-gate">
+        {state.status === "loading" ? <Loader2 className="spin" aria-hidden="true" /> : <User aria-hidden="true" />}
+        <h1>{title}</h1>
+        <p>{description}</p>
+        {state.status === "anonymous" ? <Link href={`/login?next=${encodeURIComponent("/my/purchases")}`}>로그인하기</Link> : <Link href="/">홈으로 돌아가기</Link>}
+      </main>
+    </div>
+  );
+}
+
+function PurchasesHeader() {
+  return (
+    <header className="wup-header">
+      <div className="wup-header__inner">
+        <Link className="minglit-logo" href="/" aria-label="Minglit 홈">
+          <span className="minglit-logo__mark">M</span>
+          <span className="minglit-logo__text">Minglit</span>
+        </Link>
+        <Link className="wup-search" href="/"><Search aria-hidden="true" />이벤트, 지역, 키워드 검색</Link>
+        <div className="wup-header__spacer" />
+        <Link className="wup-avatar" href="/my/purchases" aria-label="구매 내역"><User aria-hidden="true" /></Link>
+      </div>
+    </header>
+  );
+}
+
+function PurchaseListItem({ purchase, selected, onSelect }: { purchase: UserPurchase; selected: boolean; onSelect: () => void }) {
+  const status = statusCopy(purchase.status, purchase.refundStatus);
+
+  return (
+    <button className={`wup-item${selected ? " wup-item--selected" : ""}`} type="button" onClick={onSelect}>
+      <span className="wup-item__top">
+        <span className="wup-item__date">{formatShortDate(purchase.createdAt)}</span>
+        <StatusChip label={status.label} tone={status.tone} />
+      </span>
+      <span className="wup-item__name">{purchase.eventTitle}</span>
+      <span className="wup-item__bottom">
+        <span className="wup-item__meta">{purchase.ticketName}</span>
+        <span className="wup-item__amount">{formatPrice(purchase.amount)}</span>
+      </span>
+    </button>
+  );
+}
+
+function PurchaseDetail({ purchase, actionMessage, pendingCancel, onCancel }: { purchase: UserPurchase; actionMessage: string | null; pendingCancel: boolean; onCancel: () => void }) {
+  const status = statusCopy(purchase.status, purchase.refundStatus);
+  const refundable = useMemo(() => canRequestAutomaticRefund(purchase), [purchase]);
+
+  return (
+    <section className="wup-detail" aria-label={`${purchase.eventTitle} 상세`}>
+      <div className="wup-hero">
+        <div className="wup-hero__thumb">
+          {purchase.eventImageUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={purchase.eventImageUrl} alt="" />
+          ) : (
+            "Minglit"
+          )}
+        </div>
+        <div className="wup-hero__text">
+          <Link className="wup-hero__title" href={`/events/${purchase.eventId}`}>{purchase.eventTitle}</Link>
+          <div className="wup-hero__meta">{formatDateRange(purchase.startsAt, purchase.endsAt)}</div>
+          <div className="wup-hero__sub">{purchase.locationName} · {purchase.partnerName}</div>
+        </div>
+        <StatusChip label={status.label} tone={status.tone} />
+      </div>
+      <div className="wup-divider" />
+      <section>
+        <h2 className="wup-sec__title">신청 상태</h2>
+        <div className="wup-tl">
+          <TimelineStep label="신청" done />
+          <TimelineStep label="결제" done={["paid", "approved", "pending", "pending_review"].includes(purchase.status)} current={purchase.status === "payment_pending"} fail={purchase.status === "payment_failed"} />
+          <TimelineStep label="승인" done={purchase.status === "approved"} current={["paid", "pending", "pending_review"].includes(purchase.status)} fail={purchase.status === "rejected"} />
+          <TimelineStep label="입장" done={false} />
+        </div>
+        <p className="wup-tl-note">이벤트 당일 예약자 이름으로 입장합니다. QR/입장권 화면은 웹 MVP 범위에서 제외됩니다.</p>
+      </section>
+      <div className="wup-divider" />
+      <section>
+        <h2 className="wup-sec__title">결제 내역</h2>
+        <dl className="wup-kv">
+          <div><dt>티켓</dt><dd>{purchase.ticketName}</dd></div>
+          <div><dt>금액</dt><dd>{formatPrice(purchase.amount)}</dd></div>
+          <div><dt>결제 ID</dt><dd>{purchase.paymentId ?? "승인 대기"}</dd></div>
+          <div><dt>장소</dt><dd>{purchase.locationAddress}</dd></div>
+        </dl>
+      </section>
+      <section className="wup-refund">
+        <h2>환불 정책</h2>
+        <p>결제 후 3시간 이내 또는 이벤트 시작 7일 전까지 100% 자동 환불됩니다. 파트너 귀책 취소와 승인 거절은 전액 자동 환불 대상입니다.</p>
+        {refundable ? (
+          <button className="wup-btn wup-btn--refund" type="button" disabled={pendingCancel} onClick={onCancel}>
+            {pendingCancel ? <Loader2 className="spin" aria-hidden="true" /> : <RotateCcw aria-hidden="true" />}
+            환불 요청
+          </button>
+        ) : (
+          <div className="wup-refund-pending">
+            자동 환불 가능 기간이 아니거나 이미 환불 상태가 변경됐습니다. 파트너 환불 요청 Track 2는 backend EF가 추가되면 연결됩니다.
+          </div>
+        )}
+        {actionMessage ? <div className="wup-action-message" role="status">{actionMessage}</div> : null}
+      </section>
+    </section>
+  );
+}
+
+function TimelineStep({ label, done = false, current = false, fail = false }: { label: string; done?: boolean; current?: boolean; fail?: boolean }) {
+  const stateClass = fail ? "wup-tl__step--fail" : done ? "wup-tl__step--done" : current ? "wup-tl__step--now" : "wup-tl__step--off";
+
+  return (
+    <div className={`wup-tl__step ${stateClass}`}>
+      <div className="wup-tl__label">{label}</div>
+    </div>
+  );
+}
+
+function StatusChip({ label, tone }: { label: string; tone: string }) {
+  return <span className={`wup-chip wup-chip--${tone}`}>{label}</span>;
+}
+
+function formatPrice(price: number): string {
+  return price === 0 ? "무료" : `${price.toLocaleString("ko-KR")}원`;
+}
+
+function formatShortDate(value: string): string {
+  return new Intl.DateTimeFormat("ko-KR", { month: "long", day: "numeric", timeZone: "Asia/Seoul" }).format(new Date(value));
+}
+
+function formatDateRange(start: string, end: string): string {
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  const day = new Intl.DateTimeFormat("ko-KR", { month: "long", day: "numeric", weekday: "short", timeZone: "Asia/Seoul" }).format(startDate);
+  const time = new Intl.DateTimeFormat("ko-KR", { hour: "numeric", minute: "2-digit", timeZone: "Asia/Seoul" });
+
+  return `${day} ${time.format(startDate)} - ${time.format(endDate)}`;
+}

--- a/apps/landing_user/src/components/web-user.tsx
+++ b/apps/landing_user/src/components/web-user.tsx
@@ -186,8 +186,8 @@ function TicketPanel({ event }: { event: PublicEvent }) {
   const selectedTicket = event.tickets.find((ticket) => ticket.id === selectedTicketId) ?? availableTickets[0] ?? event.tickets[0];
   const closed = isEventClosed(event) || availableTickets.length === 0;
   const progress = event.maxParticipants > 0 ? Math.min(100, Math.round((event.currentParticipants / event.maxParticipants) * 100)) : 0;
-  const ctaLabel = closed ? "마감된 이벤트" : "로그인하고 신청하기";
-  const helper = closed ? "이미 마감되어 신청할 수 없어요" : "비로그인 열람은 가능하고, 신청 시 로그인으로 이동합니다.";
+  const ctaLabel = closed ? "마감된 이벤트" : "신청하고 결제하기";
+  const helper = closed ? "이미 마감되어 신청할 수 없어요" : "티켓을 확인한 뒤 결제 보호 화면으로 이동합니다.";
 
   const sortedTickets = useMemo(
     () => [...event.tickets].sort((a, b) => a.price - b.price),
@@ -250,7 +250,7 @@ function TicketPanel({ event }: { event: PublicEvent }) {
         <span>합계</span>
         <b>{closed || !selectedTicket ? "-" : formatPrice(selectedTicket.price)}</b>
       </div>
-      <Link className={`wed-cta${closed ? " wed-cta--disabled" : ""}`} href={closed ? "#" : `/login?next=/events/${event.id}`}>
+      <Link className={`wed-cta${closed ? " wed-cta--disabled" : ""}`} href={closed || !selectedTicket ? "#" : `/events/${event.id}/checkout?ticket=${selectedTicket.id}`}>
         <TicketIcon aria-hidden="true" />
         {ctaLabel}
       </Link>

--- a/apps/landing_user/src/lib/supabase.ts
+++ b/apps/landing_user/src/lib/supabase.ts
@@ -1,0 +1,26 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let browserClient: SupabaseClient | null | undefined;
+
+export function getSupabaseBrowserClient(): SupabaseClient | null {
+  if (browserClient !== undefined) return browserClient;
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+  if (!url || !publishableKey) {
+    browserClient = null;
+    return browserClient;
+  }
+
+  browserClient = createClient(url, publishableKey, {
+    auth: {
+      detectSessionInUrl: true,
+      flowType: "pkce",
+      persistSession: true,
+      autoRefreshToken: true,
+    },
+  });
+
+  return browserClient;
+}

--- a/apps/landing_user/src/lib/user-orders.test.ts
+++ b/apps/landing_user/src/lib/user-orders.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { canRequestAutomaticRefund, findCheckoutTicket, mapPurchaseRow, statusCopy } from "./user-orders";
+import { canRequestAutomaticRefund, checkoutGate, findCheckoutTicket, mapPurchaseRow, statusCopy } from "./user-orders";
 import type { PublicEvent } from "./events";
 
 test("findCheckoutTicket returns only orderable on-sale tickets", () => {
@@ -11,6 +11,42 @@ test("findCheckoutTicket returns only orderable on-sale tickets", () => {
   assert.equal(findCheckoutTicket(event, "ticket-sold-out"), null);
   assert.equal(findCheckoutTicket(event, "ticket-hidden"), null);
   assert.equal(findCheckoutTicket(event, null), null);
+});
+
+test("checkoutGate blocks unverified users before server order creation", () => {
+  assert.deepEqual(checkoutGate({
+    authStatus: "ready",
+    isVerified: false,
+    agreed: true,
+    ticketPrice: 0,
+    isCreating: false,
+  }), {
+    canSubmit: false,
+    helper: "본인인증 후 결제할 수 있어요.",
+  });
+});
+
+test("checkoutGate keeps paid tickets disabled until web payment adapter exists", () => {
+  assert.deepEqual(checkoutGate({
+    authStatus: "ready",
+    isVerified: true,
+    agreed: true,
+    ticketPrice: 39000,
+    isCreating: false,
+  }), {
+    canSubmit: false,
+    helper: "유료 결제창은 아직 연결되지 않아 출시 전입니다.",
+  });
+});
+
+test("checkoutGate allows verified free-ticket applications after consent", () => {
+  assert.equal(checkoutGate({
+    authStatus: "ready",
+    isVerified: true,
+    agreed: true,
+    ticketPrice: 0,
+    isCreating: false,
+  }).canSubmit, true);
 });
 
 test("mapPurchaseRow normalizes joined event, ticket, and status fields", () => {

--- a/apps/landing_user/src/lib/user-orders.test.ts
+++ b/apps/landing_user/src/lib/user-orders.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { canRequestAutomaticRefund, findCheckoutTicket, mapPurchaseRow, statusCopy } from "./user-orders";
+import type { PublicEvent } from "./events";
+
+test("findCheckoutTicket returns only orderable on-sale tickets", () => {
+  const event = buildEvent();
+
+  assert.equal(findCheckoutTicket(event, "ticket-open")?.id, "ticket-open");
+  assert.equal(findCheckoutTicket(event, "ticket-sold-out"), null);
+  assert.equal(findCheckoutTicket(event, "ticket-hidden"), null);
+  assert.equal(findCheckoutTicket(event, null), null);
+});
+
+test("mapPurchaseRow normalizes joined event, ticket, and status fields", () => {
+  const purchase = mapPurchaseRow({
+    id: "app-1",
+    event_id: "event-1",
+    ticket_id: "ticket-1",
+    status: "paid",
+    payment_id: "pay-1",
+    payment_amount: 39000,
+    refund_status: null,
+    rejection_reason: null,
+    created_at: "2026-07-01T00:00:00.000Z",
+    paid_at: "2026-07-01T00:30:00.000Z",
+    refunded_at: null,
+    events: {
+      id: "event-1",
+      title: null,
+      start_time: "2026-07-10T10:00:00.000Z",
+      end_time: "2026-07-10T12:00:00.000Z",
+      image_urls: [],
+      locations: { name: null, address: "서울 강남구", region_1: "서울", region_2: "강남" },
+      parties: {
+        title: "와인 소셜",
+        image_urls: ["https://example.com/event.png"],
+        partners: { name: "밍글 스튜디오" },
+      },
+    },
+    tickets: { id: "ticket-1", name: "일반 참가권", price: 39000 },
+  });
+
+  assert.equal(purchase.eventTitle, "와인 소셜");
+  assert.equal(purchase.locationName, "서울 강남");
+  assert.equal(purchase.eventImageUrl, "https://example.com/event.png");
+  assert.equal(purchase.status, "paid");
+  assert.equal(purchase.refundStatus, "none");
+});
+
+test("statusCopy prioritizes refund state over application state", () => {
+  assert.deepEqual(statusCopy("approved", "completed"), { label: "환불 완료", tone: "neutral" });
+  assert.deepEqual(statusCopy("rejected", "none"), { label: "거절됨", tone: "error" });
+});
+
+test("canRequestAutomaticRefund follows 3h grace and 7d cutoff", () => {
+  const base = {
+    id: "app-1",
+    eventId: "event-1",
+    ticketId: "ticket-1",
+    eventTitle: "이벤트",
+    eventImageUrl: null,
+    startsAt: "2026-07-10T10:00:00.000Z",
+    endsAt: "2026-07-10T12:00:00.000Z",
+    locationName: "서울",
+    locationAddress: "서울",
+    partnerName: "파트너",
+    ticketName: "티켓",
+    amount: 10000,
+    status: "paid" as const,
+    refundStatus: "none" as const,
+    rejectionReason: null,
+    paymentId: "pay-1",
+    createdAt: "2026-07-01T00:00:00.000Z",
+    paidAt: "2026-07-01T00:00:00.000Z",
+    refundedAt: null,
+  };
+
+  assert.equal(canRequestAutomaticRefund(base, new Date("2026-07-01T02:59:59.000Z")), true);
+  assert.equal(canRequestAutomaticRefund(base, new Date("2026-07-03T00:00:00.000Z")), true);
+  assert.equal(canRequestAutomaticRefund({ ...base, startsAt: "2026-07-05T10:00:00.000Z" }, new Date("2026-07-03T00:00:00.000Z")), false);
+});
+
+function buildEvent(): PublicEvent {
+  return {
+    id: "event-1",
+    title: "이벤트",
+    description: "설명",
+    imageUrl: null,
+    startsAt: "2026-07-01T10:00:00.000Z",
+    endsAt: "2026-07-01T12:00:00.000Z",
+    status: "scheduled",
+    maxParticipants: 20,
+    currentParticipants: 0,
+    partnerName: "파트너",
+    partnerIntro: "소개",
+    locationName: "서울",
+    locationAddress: "서울",
+    tags: ["소셜"],
+    tickets: [
+      { id: "ticket-open", name: "일반", description: null, price: 10000, quantity: 10, soldCount: 1, status: "on_sale" },
+      { id: "ticket-sold-out", name: "매진", description: null, price: 10000, quantity: 10, soldCount: 10, status: "on_sale" },
+      { id: "ticket-hidden", name: "숨김", description: null, price: 10000, quantity: 10, soldCount: 0, status: "hidden" },
+    ],
+  };
+}

--- a/apps/landing_user/src/lib/user-orders.ts
+++ b/apps/landing_user/src/lib/user-orders.ts
@@ -1,0 +1,238 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { PublicEvent, Ticket } from "./events";
+
+export type CheckoutOrderResult = {
+  applicationId: string;
+  amount: number;
+  requiresPayment: boolean;
+  ticketName: string;
+};
+
+export type PurchaseStatus = "pending" | "pending_review" | "approved" | "rejected" | "cancelled" | "paid" | "payment_failed" | "payment_pending";
+export type RefundStatus = "none" | "requested" | "completed" | "failed";
+
+export type UserPurchase = {
+  id: string;
+  eventId: string;
+  ticketId: string;
+  eventTitle: string;
+  eventImageUrl: string | null;
+  startsAt: string;
+  endsAt: string;
+  locationName: string;
+  locationAddress: string;
+  partnerName: string;
+  ticketName: string;
+  amount: number;
+  status: PurchaseStatus;
+  refundStatus: RefundStatus;
+  rejectionReason: string | null;
+  paymentId: string | null;
+  createdAt: string;
+  paidAt: string | null;
+  refundedAt: string | null;
+};
+
+type FunctionError = { message?: string };
+
+type PurchaseRow = {
+  id: string;
+  event_id: string;
+  ticket_id: string;
+  status: string;
+  payment_id: string | null;
+  payment_amount: number | null;
+  refund_status: string | null;
+  rejection_reason: string | null;
+  created_at: string;
+  paid_at?: string | null;
+  refunded_at?: string | null;
+  events: {
+    id: string;
+    title?: string | null;
+    start_time: string;
+    end_time: string;
+    image_urls?: string[] | null;
+    locations?: { name?: string | null; address?: string | null; region_1?: string | null; region_2?: string | null } | null;
+    parties?: {
+      title?: string | null;
+      image_urls?: string[] | null;
+      partners?: { name?: string | null } | null;
+    } | null;
+  } | null;
+  tickets: { id: string; name: string; price?: number | null } | null;
+};
+
+const PURCHASE_SELECT = [
+  "id",
+  "event_id",
+  "ticket_id",
+  "status",
+  "payment_id",
+  "payment_amount",
+  "refund_status",
+  "rejection_reason",
+  "created_at",
+  "paid_at",
+  "refunded_at",
+  "events(id,title,start_time,end_time,image_urls,locations(name,address,region_1,region_2),parties(title,image_urls,partners(name)))",
+  "tickets(id,name,price)",
+].join(",");
+
+export function findCheckoutTicket(event: PublicEvent, ticketId: string | null): Ticket | null {
+  if (!ticketId) return null;
+
+  return event.tickets.find((ticket) => ticket.id === ticketId && isTicketOrderable(ticket)) ?? null;
+}
+
+export function isTicketOrderable(ticket: Ticket): boolean {
+  return ticket.status === "on_sale" && (ticket.quantity <= 0 || ticket.soldCount < ticket.quantity);
+}
+
+export async function createCheckoutOrder(
+  supabase: SupabaseClient,
+  eventId: string,
+  ticketId: string,
+): Promise<CheckoutOrderResult> {
+  const { data, error } = await supabase.functions.invoke("user-create-order", {
+    body: { event_id: eventId, ticket_id: ticketId },
+  });
+
+  if (error) throw new Error(error.message);
+
+  const body = data as {
+    application_id?: string;
+    amount?: number;
+    requires_payment?: boolean;
+    ticket_name?: string;
+    error?: FunctionError;
+  } | null;
+
+  if (!body?.application_id) {
+    throw new Error(body?.error?.message ?? "주문을 생성하지 못했습니다.");
+  }
+
+  return {
+    applicationId: body.application_id,
+    amount: body.amount ?? 0,
+    requiresPayment: body.requires_payment ?? false,
+    ticketName: body.ticket_name ?? "티켓",
+  };
+}
+
+export async function verifyCheckoutPayment(
+  supabase: SupabaseClient,
+  impUid: string,
+  merchantUid: string,
+): Promise<void> {
+  const { data, error } = await supabase.functions.invoke("payment-verify", {
+    body: { imp_uid: impUid, merchant_uid: merchantUid },
+  });
+
+  if (error) throw new Error(error.message);
+  if ((data as { error?: FunctionError } | null)?.error) {
+    throw new Error((data as { error: FunctionError }).error.message ?? "결제를 검증하지 못했습니다.");
+  }
+}
+
+export async function fetchUserPurchases(supabase: SupabaseClient): Promise<UserPurchase[]> {
+  const { data, error } = await supabase
+    .from("event_applications")
+    .select(PURCHASE_SELECT)
+    .order("created_at", { ascending: false })
+    .limit(50)
+    .returns<PurchaseRow[]>();
+
+  if (error) throw error;
+
+  return (data ?? []).map(mapPurchaseRow);
+}
+
+export async function cancelUserOrder(supabase: SupabaseClient, eventId: string, reason: string): Promise<string> {
+  const { data, error } = await supabase.functions.invoke("user-cancel-order", {
+    body: { event_id: eventId, reason },
+  });
+
+  if (error) throw new Error(error.message);
+
+  const body = data as { type?: string; data?: { refund_amount?: number }; error?: FunctionError } | null;
+  if (body?.error) throw new Error(body.error.message ?? "환불 요청을 처리하지 못했습니다.");
+  if (body?.type === "refunded") return `${(body.data?.refund_amount ?? 0).toLocaleString("ko-KR")}원 환불이 접수됐습니다.`;
+  if (body?.type === "cancelled") return "신청 취소가 접수됐습니다.";
+
+  return "요청이 접수됐습니다.";
+}
+
+export function mapPurchaseRow(row: PurchaseRow): UserPurchase {
+  const event = row.events;
+  const location = event?.locations;
+  const ticket = row.tickets;
+  const eventTitle = event?.title ?? event?.parties?.title ?? "이벤트";
+
+  return {
+    id: row.id,
+    eventId: row.event_id,
+    ticketId: row.ticket_id,
+    eventTitle,
+    eventImageUrl: event?.image_urls?.[0] ?? event?.parties?.image_urls?.[0] ?? null,
+    startsAt: event?.start_time ?? row.created_at,
+    endsAt: event?.end_time ?? row.created_at,
+    locationName: location?.name ?? ([location?.region_1, location?.region_2].filter(Boolean).join(" ") || "장소 미정"),
+    locationAddress: location?.address ?? "상세 장소는 신청 후 안내됩니다.",
+    partnerName: event?.parties?.partners?.name ?? "Minglit Partner",
+    ticketName: ticket?.name ?? "티켓",
+    amount: row.payment_amount ?? ticket?.price ?? 0,
+    status: normalizePurchaseStatus(row.status),
+    refundStatus: normalizeRefundStatus(row.refund_status),
+    rejectionReason: row.rejection_reason,
+    paymentId: row.payment_id,
+    createdAt: row.created_at,
+    paidAt: row.paid_at ?? null,
+    refundedAt: row.refunded_at ?? null,
+  };
+}
+
+export function statusCopy(status: PurchaseStatus, refundStatus: RefundStatus): { label: string; tone: string } {
+  if (refundStatus === "completed") return { label: "환불 완료", tone: "neutral" };
+  if (refundStatus === "requested") return { label: "환불 요청됨", tone: "warning" };
+  if (refundStatus === "failed") return { label: "환불 실패", tone: "error" };
+
+  switch (status) {
+    case "approved":
+      return { label: "확정", tone: "success" };
+    case "paid":
+    case "pending_review":
+    case "pending":
+      return { label: "승인 대기", tone: "info" };
+    case "rejected":
+      return { label: "거절됨", tone: "error" };
+    case "cancelled":
+      return { label: "취소됨", tone: "neutral" };
+    case "payment_pending":
+      return { label: "결제 대기", tone: "warning" };
+    case "payment_failed":
+      return { label: "결제 실패", tone: "error" };
+  }
+}
+
+export function canRequestAutomaticRefund(purchase: UserPurchase, now = new Date()): boolean {
+  if (!["paid", "pending", "pending_review", "approved"].includes(purchase.status)) return false;
+  if (purchase.refundStatus !== "none") return false;
+
+  const paidAt = purchase.paidAt ? new Date(purchase.paidAt) : new Date(purchase.createdAt);
+  const startsAt = new Date(purchase.startsAt);
+  const graceMs = 3 * 60 * 60 * 1000;
+  const cutoffMs = 7 * 24 * 60 * 60 * 1000;
+
+  return now.getTime() - paidAt.getTime() <= graceMs || startsAt.getTime() - now.getTime() >= cutoffMs;
+}
+
+function normalizePurchaseStatus(value: string): PurchaseStatus {
+  const allowed: PurchaseStatus[] = ["pending", "pending_review", "approved", "rejected", "cancelled", "paid", "payment_failed", "payment_pending"];
+  return allowed.includes(value as PurchaseStatus) ? (value as PurchaseStatus) : "pending";
+}
+
+function normalizeRefundStatus(value: string | null): RefundStatus {
+  const allowed: RefundStatus[] = ["none", "requested", "completed", "failed"];
+  return allowed.includes(value as RefundStatus) ? (value as RefundStatus) : "none";
+}

--- a/apps/landing_user/src/lib/user-orders.ts
+++ b/apps/landing_user/src/lib/user-orders.ts
@@ -7,6 +7,14 @@ export type CheckoutOrderResult = {
   requiresPayment: boolean;
   ticketName: string;
 };
+export type CheckoutGateInput = {
+  authStatus: "loading" | "config-error" | "anonymous" | "profile-error" | "ready";
+  isVerified: boolean;
+  agreed: boolean;
+  ticketPrice: number;
+  isCreating: boolean;
+};
+export type CheckoutGate = { canSubmit: boolean; helper: string };
 
 export type PurchaseStatus = "pending" | "pending_review" | "approved" | "rejected" | "cancelled" | "paid" | "payment_failed" | "payment_pending";
 export type RefundStatus = "none" | "requested" | "completed" | "failed";
@@ -87,6 +95,31 @@ export function findCheckoutTicket(event: PublicEvent, ticketId: string | null):
 
 export function isTicketOrderable(ticket: Ticket): boolean {
   return ticket.status === "on_sale" && (ticket.quantity <= 0 || ticket.soldCount < ticket.quantity);
+}
+
+export function checkoutGate(input: CheckoutGateInput): CheckoutGate {
+  if (input.authStatus === "loading") return { canSubmit: false, helper: "로그인 상태를 확인하고 있습니다." };
+  if (input.authStatus === "anonymous") return { canSubmit: false, helper: "로그인 후 같은 주문으로 돌아옵니다." };
+  if (input.authStatus === "config-error") return { canSubmit: false, helper: "Supabase 공개 환경변수가 없어 신청을 시작할 수 없습니다." };
+  if (input.authStatus === "profile-error") return { canSubmit: false, helper: "프로필 인증 상태를 확인하지 못했습니다. 잠시 후 다시 시도해 주세요." };
+  if (!input.isVerified) return { canSubmit: false, helper: "본인인증 후 결제할 수 있어요." };
+  if (input.ticketPrice > 0) return { canSubmit: false, helper: "유료 결제창은 아직 연결되지 않아 출시 전입니다." };
+  if (!input.agreed) return { canSubmit: false, helper: "필수 약관과 환불 정책에 동의해 주세요." };
+  if (input.isCreating) return { canSubmit: false, helper: "신청을 생성하고 있습니다." };
+
+  return { canSubmit: true, helper: "무료 티켓 신청 후에도 파트너 승인 전까지는 승인 대기 상태입니다." };
+}
+
+export async function fetchUserVerified(supabase: SupabaseClient, userId: string): Promise<boolean> {
+  const { data, error } = await supabase
+    .from("user_profiles")
+    .select("is_verified")
+    .eq("id", userId)
+    .single<{ is_verified: boolean | null }>();
+
+  if (error) throw error;
+
+  return data?.is_verified === true;
 }
 
 export async function createCheckoutOrder(

--- a/apps/landing_user/tsconfig.test.json
+++ b/apps/landing_user/tsconfig.test.json
@@ -9,5 +9,5 @@
     "rootDir": "src",
     "types": ["node"]
   },
-  "include": ["src/lib/events.ts", "src/lib/events.test.ts"]
+  "include": ["src/lib/events.ts", "src/lib/events.test.ts", "src/lib/user-orders.ts", "src/lib/user-orders.test.ts"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minglit-root",
-  "version": "26.06.07-dev-staging",
+  "version": "26.06.08-dev-staging",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minglit-root",
-      "version": "26.06.07-dev-staging",
+      "version": "26.06.08-dev-staging",
       "workspaces": [
         "apps/landing_user",
         "apps/landing_partner",
@@ -17,7 +17,7 @@
       }
     },
     "apps/landing_partner": {
-      "version": "26.06.07-dev-staging",
+      "version": "26.06.08-dev-staging",
       "dependencies": {
         "@statsig/react-bindings": "^3.33.2",
         "@supabase/supabase-js": "^2.107.0",
@@ -507,9 +507,10 @@
       }
     },
     "apps/landing_user": {
-      "version": "26.06.07-dev-staging",
+      "version": "26.06.08-dev-staging",
       "dependencies": {
         "@statsig/react-bindings": "^3.33.2",
+        "@supabase/supabase-js": "^2.107.0",
         "lucide-react": "^1.17.0",
         "next": "16.2.6",
         "react": "19.2.6",


### PR DESCRIPTION
Scheduler: swe-codex-gpt55-medium-1

## Goal
Refs #3394. Implement the first web_user protected checkout and purchases surfaces in `apps/landing_user` from the MDS web MVP specs, without widening into new backend contracts.

## What Changed
- Added `/events/:id/checkout?ticket=:ticketId` with SSR event/ticket restoration, Supabase auth gate, order summary, consent/refund policy copy, free-ticket `user-create-order` submission, and approval-pending completion state.
- Added profile verification gating from `user_profiles.is_verified`: unverified users see the inline IdentityVerificationCard and checkout CTA remains locked before `user-create-order` can return `IDENTITY_REQUIRED`.
- Disabled paid-ticket checkout until a real Portone V2 web payment adapter/redirect contract exists, removing the previous manual `imp_uid` verification form that could leave orders stuck in pending payment state.
- Added `/my/purchases` with Supabase auth gate, RLS-backed `event_applications` purchase list, master-detail purchase detail, status chips/timeline, refund policy card, and `user-cancel-order` automatic refund/cancel action.
- Added Supabase browser auth client plus `/login` OAuth entry and `/auth/callback` route for protected web_user routes.
- Updated event detail CTA to enter checkout with the selected ticket.
- Added focused node tests for checkout ticket validation, checkout gating, purchase row mapping/status copy, and refund eligibility policy boundaries.

## MDS Spec References
- `apps/mds/docs/public/specs/web_user_checkout/index.html` — Overview `Route / Surface`, `Purpose`, `User journey`; Responsive Layout `Breakpoint variants`; States `Default`, `본인인증 필요`, `결제 진행 중`, `완료 · 승인 대기`, `결제 실패`; Global Behavior `비로그인 접근`, `새로고침 / URL 직접 진입`, `브라우저 탭 비활성 → 복귀`.
- `apps/mds/docs/public/specs/web_user_purchases/index.html` — Overview `Route / Surface`, `Purpose`, `Behavior Source`; Responsive Layout `Breakpoint variants`; Global Behavior `비로그인 접근`, `환불 접수/처리로 상태 변경`.
- `apps/mds/docs/public/specs/web_foundation_responsive/index.md` — `Container widths`, `Grid rules`, `Touch / pointer rules`.
- `apps/mds/docs/src/lib/components.ts` — `MinglitButton` action state/loading guidance and MDS token vocabulary references used for CTA/button states.

## Verification
- `npm run test --workspace=apps/landing_user`
- `npm run lint --workspace=apps/landing_user`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=public-key npm run build --workspace=apps/landing_user`
- `git diff --check`
- GitHub `dev-staging-pr-gate` on `2d2f4ea2dc870afaae06295a0cf70e71882420b3`

## Residual Risk / Follow-up
- This PR intentionally does not introduce a new Portone V2 browser SDK adapter. Paid checkout is disabled instead of creating pending orders without a real PG handoff. Backend/API follow-up is tracked in #3422.
- The current web identity card is a blocking state because the Portone V2 web identity handoff is not implemented in this UI PR. Verified users can proceed with free-ticket applications; unverified users are stopped before the backend identity gate.
- `refund-policy-v2` Track 2 needs a backend function such as `user-request-refund`; the repo currently documents that EF as missing. `/my/purchases` connects the existing automatic refund/cancel path via `user-cancel-order` and displays Track 2 as a backend follow-up gap.