### PR TITLE
fix(mds-render): reset platform override before invariant

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/_engine/runner.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_engine/runner.dart
@@ -12,6 +12,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'builder.dart';
 import 'catalog.dart';
+import 'state.dart';
 
 class MdsRenderEngine {
   /// 카탈로그의 모든 state 를 testWidgets 로 실행 + PNG 캡처.
@@ -25,31 +26,57 @@ class MdsRenderEngine {
 
     for (final state in catalog.states) {
       testWidgets(state.name, (tester) async {
-        addTearDown(() {
-          debugDefaultTargetPlatformOverride = null;
-        });
-
-        final builder = state.setup(catalog.builder());
-        await tester.pumpWidget(builder.build());
-        // Fix #2590: repeat() 애니메이션은 pumpAndSettle이 timeout — 고정 pump 사용.
-        if (state.infiniteAnimation) {
-          // pulse 1회분(MinglitAnimation.medium ≈ 300ms) — 시작 직후 visible 상태 캡처.
-          await tester.pump(const Duration(milliseconds: 300));
-        } else {
-          await tester.pumpAndSettle();
-        }
-
-        // Android: Flutter surface → image 변환 후 캡처 필요.
-        await binding.convertFlutterSurfaceToImage();
-        if (state.infiniteAnimation) {
-          // surface 변환 후 추가 프레임 — 렌더링 파이프라인 완료 보장.
-          await tester.pump(const Duration(milliseconds: 100));
-        } else {
-          await tester.pumpAndSettle();
-        }
-
-        await binding.takeScreenshot('${catalog.screen}__${state.name}');
+        await _pumpState(
+          tester: tester,
+          catalog: catalog,
+          state: state,
+          binding: binding,
+        );
       });
+    }
+  }
+
+  @visibleForTesting
+  static Future<void> pumpStateForTest<B extends MdsScreenBuilder<dynamic>>({
+    required WidgetTester tester,
+    required MdsCatalog<B> catalog,
+    required MdsState<B> state,
+  }) => _pumpState(tester: tester, catalog: catalog, state: state);
+
+  static Future<void> _pumpState<B extends MdsScreenBuilder<dynamic>>({
+    required WidgetTester tester,
+    required MdsCatalog<B> catalog,
+    required MdsState<B> state,
+    IntegrationTestWidgetsFlutterBinding? binding,
+  }) async {
+    try {
+      final builder = state.setup(catalog.builder());
+      await tester.pumpWidget(builder.build());
+      // Fix #2590: repeat() 애니메이션은 pumpAndSettle이 timeout — 고정 pump 사용.
+      if (state.infiniteAnimation) {
+        // pulse 1회분(MinglitAnimation.medium ≈ 300ms) — 시작 직후 visible 상태 캡처.
+        await tester.pump(const Duration(milliseconds: 300));
+      } else {
+        await tester.pumpAndSettle();
+      }
+
+      if (binding == null) {
+        return;
+      }
+
+      // Android: Flutter surface → image 변환 후 캡처 필요.
+      await binding.convertFlutterSurfaceToImage();
+      if (state.infiniteAnimation) {
+        // surface 변환 후 추가 프레임 — 렌더링 파이프라인 완료 보장.
+        await tester.pump(const Duration(milliseconds: 100));
+      } else {
+        await tester.pumpAndSettle();
+      }
+
+      await binding.takeScreenshot('${catalog.screen}__${state.name}');
+    } finally {
+      // Flutter verifies debug globals before addTearDown callbacks run.
+      debugDefaultTargetPlatformOverride = null;
     }
   }
 }

--- a/apps/app_partner/test/BLUEDOC.md
+++ b/apps/app_partner/test/BLUEDOC.md
@@ -10,6 +10,7 @@
 | [`integration/`](./integration/) | Integration 테스트 (CI 의 `pr-gate.test-integration-app-partner-cuj` 실행) |
 | [`visual_qa/`](./visual_qa/) | 시각 QA 캡처 |
 | [`utils/`](./utils/) | 테스트 헬퍼 (mocks, utils, reporter integration) |
+| [`mds_render_engine_debug_override_test.dart`](./mds_render_engine_debug_override_test.dart) | MDS render runner debug override cleanup 회귀 테스트 |
 | [`widget_test.dart`](./widget_test.dart) | 레거시 widget test |
 | [`flutter_test_config.dart`](./flutter_test_config.dart) | 테스트 환경 setup |
 | [`reporter.dart`](./reporter.dart) | test_reporter 통합 |
@@ -38,4 +39,4 @@ CI 자동 실행: `pr-gate.test-flutter-apps` matrix. 커버리지 dev 자동 �
 - [tests/_coverage/BLUEDOC](../../../tests/_coverage/BLUEDOC.md)
 
 ---
-_Reviewed: 2026-06-05 10:37_
+_Reviewed: 2026-06-08 07:25_

--- a/apps/app_partner/test/mds_render_engine_debug_override_test.dart
+++ b/apps/app_partner/test/mds_render_engine_debug_override_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/mds-emulator-render/_engine/builder.dart';
+import '../integration_test/mds-emulator-render/_engine/catalog.dart';
+import '../integration_test/mds-emulator-render/_engine/runner.dart';
+import '../integration_test/mds-emulator-render/_engine/state.dart';
+
+class _DebugPlatformBuilder extends MdsScreenBuilder<Widget> {
+  _DebugPlatformBuilder() : super(page: const SizedBox.shrink());
+
+  @override
+  Widget build() {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    return const MaterialApp(home: SizedBox.shrink());
+  }
+}
+
+void main() {
+  testWidgets('clears debug platform override before test invariant', (
+    tester,
+  ) async {
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    final catalog = MdsCatalog<_DebugPlatformBuilder>(
+      screen: 'debug_platform',
+      mdsSpec: 'test-only',
+      builder: _DebugPlatformBuilder.new,
+      states: [
+        MdsState<_DebugPlatformBuilder>('state-default', (builder) => builder),
+      ],
+    );
+
+    await MdsRenderEngine.pumpStateForTest(
+      tester: tester,
+      catalog: catalog,
+      state: catalog.states.single,
+    );
+
+    expect(debugDefaultTargetPlatformOverride, isNull);
+  });
+}


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## Summary
- Diagnose #3420 as a repo-fixable MDS render test regression: `partner_login_page` sets `debugDefaultTargetPlatformOverride`, and the previous `addTearDown` cleanup ran after Flutter test invariant verification.
- Refactor the app_partner MDS render runner so each state path resets the debug platform override in `finally`, before the test body returns.
- Add a lightweight regression test for the runner cleanup contract without requiring an Android emulator or screenshot capture.

## Issue
Refs #3420. This PR intentionally does not close #3420 because it fixes the root cause for subsequent MDS render snapshot runs, but it does not automatically recreate the missing artifact for already-failed dev SHA `532c91a6627211c3df2aca1688413e6cd6c6cb3a`. Follow-up after the fix reaches `dev`: let the snapshot workflow run for the next dev SHA, or manually rerun it for an appropriate fixed dev commit.

## Verification
- `dart format apps/app_partner/integration_test/mds-emulator-render/_engine/runner.dart apps/app_partner/test/mds_render_engine_debug_override_test.dart`
- `flutter test test/mds_render_engine_debug_override_test.dart`
- `flutter analyze integration_test/mds-emulator-render/_engine/runner.dart test/mds_render_engine_debug_override_test.dart`
- `MDS_RENDER_DRY_RUN=1 APP_NAME=partner SHARD_INDEX=3 SHARD_TOTAL=4 bash .github/scripts/run-mds-render-shard.sh`
- `git diff --check`

## Residual Risk
- I did not run the full `flutter drive` Android emulator render locally. A direct `flutter test integration_test/mds-emulator-render/partner_login_page/partner_login_page_test.dart` attempt stopped at local device selection, so CI remains the authoritative emulator sensor.