### PR TITLE
fix(security): harden advisor helper execute grants

### DIFF
--- a/.github/advisor-accepted-findings.json
+++ b/.github/advisor-accepted-findings.json
@@ -5,5 +5,117 @@
     "envs": ["dev", "main"],
     "issue": 2756,
     "reason": "Minglit production auth does not support email/password signup or login. Password-backed accounts are limited to dev/test seed and simulator flows, so Supabase Auth leaked-password protection is not an applicable production control."
+  },
+  {
+    "name": "rls_disabled_in_public",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "rls_disabled_in_public_public_spatial_ref_sys",
+    "reason": "public.spatial_ref_sys is PostGIS extension catalog metadata. It is documented as the only public RLS-disabled table exception and should not be modified by Minglit migrations."
+  },
+  {
+    "name": "extension_in_public",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "extension_in_public_pgroonga",
+    "reason": "PGroonga is an extension dependency used for Korean full-text search. Moving extension objects requires a separate extension-schema migration plan."
+  },
+  {
+    "name": "extension_in_public",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "extension_in_public_citext",
+    "reason": "citext is extension-owned infrastructure. Moving extension objects requires a separate extension-schema migration plan."
+  },
+  {
+    "name": "extension_in_public",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "extension_in_public_postgis",
+    "reason": "PostGIS is an extension dependency used for geospatial search. Moving extension objects requires a separate extension-schema migration plan."
+  },
+  {
+    "name": "anon_security_definer_function_executable",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "anon_security_definer_function_executable_public_st_estimatedextent_text, text",
+    "reason": "st_estimatedextent(text, text) is a PostGIS extension-owned function. Its execute posture should be handled with the broader extension-schema migration plan."
+  },
+  {
+    "name": "anon_security_definer_function_executable",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "anon_security_definer_function_executable_public_st_estimatedextent_text, text, text",
+    "reason": "st_estimatedextent(text, text, text) is a PostGIS extension-owned function. Its execute posture should be handled with the broader extension-schema migration plan."
+  },
+  {
+    "name": "anon_security_definer_function_executable",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "anon_security_definer_function_executable_public_st_estimatedextent_text, text, text, boolean",
+    "reason": "st_estimatedextent(text, text, text, boolean) is a PostGIS extension-owned function. Its execute posture should be handled with the broader extension-schema migration plan."
+  },
+  {
+    "name": "rls_enabled_no_policy",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "rls_enabled_no_policy_public_active_storage_uploads",
+    "reason": "active_storage_uploads is intentionally RLS-enabled with no publishable-role policy; writes go through storage-upload Edge Function service_role flow."
+  },
+  {
+    "name": "rls_enabled_no_policy",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "rls_enabled_no_policy_public_app_roles",
+    "reason": "app_roles is intentionally default-deny to publishable roles and is accessed only by service_role/admin paths and SECURITY DEFINER helpers."
+  },
+  {
+    "name": "rls_enabled_no_policy",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "rls_enabled_no_policy_public_party_embeddings",
+    "reason": "party_embeddings is intentionally default-deny to publishable roles; embedding writes and reads are service_role/internal pipeline concerns."
+  },
+  {
+    "name": "rls_enabled_no_policy",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "rls_enabled_no_policy_public_storage_upload_bucket_policies",
+    "reason": "storage_upload_bucket_policies is intentionally default-deny to publishable roles and is managed by service_role storage-upload infrastructure."
+  },
+  {
+    "name": "rls_enabled_no_policy",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "rls_enabled_no_policy_public_user_actions",
+    "reason": "user_actions is intentionally default-deny to publishable roles; user action data is written through controlled backend flows."
+  },
+  {
+    "name": "rls_enabled_no_policy",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "rls_enabled_no_policy_public_user_embeddings",
+    "reason": "user_embeddings is intentionally default-deny to publishable roles; embedding writes and reads are service_role/internal pipeline concerns."
+  },
+  {
+    "name": "rls_enabled_no_policy",
+    "type": "security",
+    "envs": ["dev", "main"],
+    "issue": 3424,
+    "cache_key": "rls_enabled_no_policy_public_webhook_imp_uid_log",
+    "reason": "webhook_imp_uid_log is intentionally default-deny to publishable roles and is populated by backend webhook processing."
   }
 ]

--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -33,4 +33,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-06-06 16:49_
+_Reviewed: 2026-06-08 13:31_

--- a/supabase/migrations/20260608041500_restrict_helper_security_definer_anon_execute.sql
+++ b/supabase/migrations/20260608041500_restrict_helper_security_definer_anon_execute.sql
@@ -1,0 +1,42 @@
+-- Issue #3424: close anon direct RPC access to RLS predicate helpers.
+--
+-- These helpers are still used by authenticated RLS policies and backend
+-- service_role paths, so keep those grants explicit while removing the default
+-- PUBLIC/anon execute surface reported by Supabase Security Advisor.
+
+DO $$
+DECLARE
+  target_policy record;
+BEGIN
+  FOR target_policy IN
+    SELECT schemaname, tablename, policyname
+    FROM pg_policies
+    WHERE schemaname IN ('public', 'storage')
+      AND roles && ARRAY['public', 'anon']::name[]
+      AND (
+        coalesce(qual, '') || ' ' || coalesce(with_check, '')
+      ) ~ '(^|[^[:alnum:]_])((public\.)?(has_partner_permission|is_super_admin|is_visible_user_profile))\('
+  LOOP
+    EXECUTE format(
+      'ALTER POLICY %I ON %I.%I TO authenticated',
+      target_policy.policyname,
+      target_policy.schemaname,
+      target_policy.tablename
+    );
+  END LOOP;
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.has_partner_permission(uuid, text)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.has_partner_permission(uuid, text)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.is_super_admin()
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.is_super_admin()
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.is_visible_user_profile(uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.is_visible_user_profile(uuid)
+  TO authenticated, service_role;

--- a/supabase/tests/database/109_security_definer_execute_posture_test.sql
+++ b/supabase/tests/database/109_security_definer_execute_posture_test.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(5);
+SELECT plan(8);
 
 SELECT is_empty(
   $$
@@ -158,6 +158,53 @@ SELECT is_empty(
   ORDER BY 1
   $$,
   'service_role can EXECUTE EF/cron/trigger-only SECURITY DEFINER functions'
+);
+
+SELECT is_empty(
+  $$
+  WITH target(function_oid) AS (
+    VALUES
+      ('public.has_partner_permission(uuid, text)'::regprocedure),
+      ('public.is_super_admin()'::regprocedure),
+      ('public.is_visible_user_profile(uuid)'::regprocedure)
+  )
+  SELECT function_oid::regprocedure::text
+  FROM target
+  WHERE has_function_privilege('anon', function_oid, 'EXECUTE')
+  ORDER BY 1
+  $$,
+  'anon cannot EXECUTE authenticated RLS predicate SECURITY DEFINER helpers directly'
+);
+
+SELECT is_empty(
+  $$
+  WITH target(function_oid) AS (
+    VALUES
+      ('public.has_partner_permission(uuid, text)'::regprocedure),
+      ('public.is_super_admin()'::regprocedure),
+      ('public.is_visible_user_profile(uuid)'::regprocedure)
+  )
+  SELECT function_oid::regprocedure::text
+  FROM target
+  WHERE NOT has_function_privilege('authenticated', function_oid, 'EXECUTE')
+     OR NOT has_function_privilege('service_role', function_oid, 'EXECUTE')
+  ORDER BY 1
+  $$,
+  'authenticated and service_role can EXECUTE RLS predicate SECURITY DEFINER helpers'
+);
+
+SELECT is_empty(
+  $$
+  SELECT schemaname, tablename, policyname, roles
+  FROM pg_policies
+  WHERE schemaname IN ('public', 'storage')
+    AND roles && ARRAY['public', 'anon']::name[]
+    AND (
+      coalesce(qual, '') || ' ' || coalesce(with_check, '')
+    ) ~ '(^|[^[:alnum:]_])((public\.)?(has_partner_permission|is_super_admin|is_visible_user_profile))\('
+  ORDER BY schemaname, tablename, policyname
+  $$,
+  'anon-targeted RLS policies do not reference authenticated helper SECURITY DEFINER functions'
 );
 
 SELECT is_empty(


### PR DESCRIPTION
Scheduler: swe-codex-gpt55-medium-1

## What changed
- Added object-scoped accepted Security Advisor findings for already-reviewed extension/default-deny exceptions from run `27102326206`.
- Added an append-only migration that moves anon/public-targeted RLS policies off the three helper SECURITY DEFINER functions, then revokes `PUBLIC`/`anon` direct execute from `has_partner_permission(uuid,text)`, `is_super_admin()`, and `is_visible_user_profile(uuid)` while preserving `authenticated` and `service_role` execute.
- Extended `109_security_definer_execute_posture_test.sql` to cover helper grants and prevent anon-targeted RLS policies from referencing those helpers.

## Why
Refs #3424.

This handles the concrete repo-fixable follow-up from the arch decomposition: reduce accepted Security Advisor noise for reviewed object-scoped exceptions and close anon direct RPC access to three RLS predicate helpers.

This does not close #3424 because remaining public/authenticated SECURITY DEFINER RPC posture still needs the separate product/architecture decision noted in the issue.

## Verification
- `python3 -m json.tool .github/advisor-accepted-findings.json >/dev/null`
- `python3 .github/scripts/test_filter_advisor_findings.py`
- Re-ran the `advisor-security-dev` artifact filter from workflow run `27102326206`: accepted `15`, unsuppressed `38`; `rls_disabled_in_public`, `extension_in_public`, and `rls_enabled_no_policy` unsuppressed counts are now `0`; extension-owned `st_estimatedextent(...)` accepted count is `3`.
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- `git diff --check`
- `supabase db reset --debug` completed locally and applied `20260608041500_restrict_helper_security_definer_anon_execute.sql`.
- `supabase test db supabase/tests/database/00_setup.sql supabase/tests/database/109_security_definer_execute_posture_test.sql`
- `supabase db reset && supabase test db supabase/tests/database/00_setup.sql supabase/tests/database/24_rls_hardening_test.sql supabase/tests/database/61_recurrence_rules_rls_test.sql supabase/tests/database/109_security_definer_execute_posture_test.sql`

## Residual risk
- Full local `supabase test db` was attempted earlier, but the local DB container aborted and entered recovery during existing pgTAP tests. The CI pgTAP job is the clean-run signal for the full database suite.