### PR TITLE
fix(event-flow): restore simulator event supply

### DIFF
--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -33,4 +33,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-06-09 13:54_
+_Reviewed: 2026-06-10 04:35_

--- a/supabase/functions/event-flow-simulator/action/new_actions_test.ts
+++ b/supabase/functions/event-flow-simulator/action/new_actions_test.ts
@@ -12,9 +12,46 @@ import { blockAction } from "./block.ts";
 import { partnerApproveAction } from "./partner_approve.ts";
 import { partnerRejectAction } from "./partner_reject.ts";
 import { partnerCreateEventAction } from "./partner_create_event.ts";
-import { createPRNG } from "../core/types.ts";
+import { createPRNG, type PRNG } from "../core/types.ts";
 
 const rng = createPRNG(1);
+const DAY_MS = 86_400_000;
+
+function sequenceRng(values: number[]): PRNG {
+  let index = 0;
+  return {
+    next() {
+      return values[index++] ?? values.at(-1) ?? 0;
+    },
+    split() {
+      return sequenceRng(values.slice(index));
+    },
+  };
+}
+
+function withFixedNow<T>(isoNow: string, fn: () => T): T {
+  const fixedNow = new Date(isoNow).getTime();
+  const originalNow = Date.now;
+  Date.now = () => fixedNow;
+  try {
+    return fn();
+  } finally {
+    Date.now = originalNow;
+  }
+}
+
+function createEventStartDelayDays(rng: PRNG): number {
+  const fixedNow = new Date("2026-06-08T00:00:00.000Z").getTime();
+  return withFixedNow("2026-06-08T00:00:00.000Z", () => {
+    const payload = partnerCreateEventAction.buildPayload({
+      myParties: [{ id: "party1", status: "active" }],
+      myEvents: [],
+    }, rng);
+    const startTime = (payload.event as Record<string, unknown>)
+      .start_time as string;
+    return (new Date(startTime).getTime() - fixedNow) / DAY_MS;
+  });
+}
 
 // ============================================================
 // Identity 가드 — type / role / ef wiring
@@ -241,6 +278,17 @@ Deno.test({
       Error,
       "without an existing party",
     );
+  },
+});
+
+Deno.test({
+  name:
+    "partnerCreateEventAction.buildPayload - start horizon crosses refund 7-day cutoff",
+  fn: () => {
+    // First rng value selects the party; second value selects start delay.
+    assertEquals(createEventStartDelayDays(sequenceRng([0, 0])), 2);
+    assertEquals(createEventStartDelayDays(sequenceRng([0, 0.39])), 7);
+    assertEquals(createEventStartDelayDays(sequenceRng([0, 0.999999])), 14);
   },
 });
 

--- a/supabase/functions/event-flow-simulator/action/partner_create_event.ts
+++ b/supabase/functions/event-flow-simulator/action/partner_create_event.ts
@@ -5,8 +5,15 @@ import { registerAction } from "./_registry.ts";
 
 const MIN_SCHEDULED_EVENTS = 2;
 const EVENT_DURATION_MS = 2 * 60 * 60 * 1000;
-const MIN_START_DELAY_DAYS = 7;
-const START_DELAY_WINDOW_DAYS = 21;
+// horizon 을 7일을 가로지르는 2~14일로 둔다.
+// - 과거 7~28일(중앙값 17일) 은 scheduled 가 수 주간 유지되어 모든 적격 파트너가
+//   MIN_SCHEDULED_EVENTS 캡에 묶이고 이벤트 공급이 영구 정지됐다 (auto_complete_past_events
+//   15분 cron 이 end_time 을 지나야 completed 로 내려 캡을 푼다).
+// - 7일 미만 이벤트는 며칠 안에 완료되어 캡을 풀고 create 를 재개시킨다.
+// - 7일 이상 이벤트(약 절반)는 남겨, refund 액션(event start ≥ 7일, Fix #2131)의
+//   적격성을 유지한다. 하한을 1일이 아닌 2일로 두는 것도 같은 이유.
+const MIN_START_DELAY_DAYS = 2;
+const START_DELAY_WINDOW_DAYS = 12;
 
 type PartnerParty = {
   id: string;

--- a/supabase/functions/event-flow-simulator/action/partner_create_event.ts
+++ b/supabase/functions/event-flow-simulator/action/partner_create_event.ts
@@ -13,7 +13,7 @@ const EVENT_DURATION_MS = 2 * 60 * 60 * 1000;
 // - 7일 이상 이벤트(약 절반)는 남겨, refund 액션(event start ≥ 7일, Fix #2131)의
 //   적격성을 유지한다. 하한을 1일이 아닌 2일로 두는 것도 같은 이유.
 const MIN_START_DELAY_DAYS = 2;
-const START_DELAY_WINDOW_DAYS = 12;
+const START_DELAY_WINDOW_DAYS = 13;
 
 type PartnerParty = {
   id: string;

--- a/supabase/seed.dev.sql
+++ b/supabase/seed.dev.sql
@@ -793,3 +793,35 @@ BEGIN
     WHERE id = existing_id AND is_verified IS DISTINCT FROM true;
   END IF;
 END $$;
+
+-- ── Phase 11: Simulator partner party backfill ───────────────────────────────
+-- event-flow-simulator 는 partner_member_permissions 멤버 계정이 있는 파트너만 인증하고,
+-- partner_create_event 는 비-closed party 를 보유한 파트너만 이벤트를 만들 수 있다. 인증가능
+-- 파트너 중 party 보유 파트너가 소수면(예: 95명 중 10명) MIN_SCHEDULED_EVENTS 캡과 맞물려
+-- 이벤트 공급이 말라 user_apply 가 같은 풀을 두드리며 409 cascade 가 발생한다.
+-- 인증가능 파트너 중 비-closed party 가 하나도 없는 경우 시뮬레이터용 party 를 1개 만든다.
+-- 멱등: 이미 비-closed party 가 있으면 건너뜀.
+DO $$
+DECLARE
+  sim_partner_id uuid;
+  sim_location_id uuid;
+BEGIN
+  FOR sim_partner_id IN
+    SELECT DISTINCT pmp.partner_id
+    FROM public.partner_member_permissions pmp
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.parties pa
+      WHERE pa.partner_id = pmp.partner_id
+        AND pa.status <> 'closed'
+    )
+  LOOP
+    SELECT id INTO sim_location_id FROM public.locations
+    WHERE partner_id = sim_partner_id LIMIT 1;
+
+    INSERT INTO public.parties (partner_id, location_id, title, max_participants, status, image_urls)
+    VALUES (
+      sim_partner_id, sim_location_id, '[SIM] 시뮬레이터 파티', 20, 'active',
+      ARRAY['https://picsum.photos/seed/minglit-sim-' || replace(sim_partner_id::text, '-', '') || '/800/600']
+    );
+  END LOOP;
+END $$;

--- a/supabase/tests/database/109_seed_simulator_partner_party_backfill_test.sql
+++ b/supabase/tests/database/109_seed_simulator_partner_party_backfill_test.sql
@@ -1,0 +1,182 @@
+-- Regression test for event-flow-simulator supply:
+-- seed.dev.sql must give every authenticatable partner at least one non-closed
+-- party so partner_create_event can keep producing events.
+--
+-- Self-contained: creates its own fixtures and mirrors the Phase 11 seed block.
+BEGIN;
+
+SELECT plan(5);
+
+SELECT tests.authenticate_as_service_role();
+
+CREATE TEMP TABLE _seed_sim_backfill_state (
+  no_party_partner_id uuid,
+  closed_only_partner_id uuid,
+  active_partner_id uuid
+) ON COMMIT DROP;
+
+DO $$
+DECLARE
+  no_party_partner_id uuid;
+  closed_only_partner_id uuid;
+  active_partner_id uuid;
+  no_party_user_id uuid;
+  closed_only_user_id uuid;
+  active_user_id uuid;
+BEGIN
+  no_party_user_id := tests.create_supabase_user(
+    'seed_sim_no_party',
+    'seed_sim_no_party@pgtap.local'
+  );
+  closed_only_user_id := tests.create_supabase_user(
+    'seed_sim_closed_only',
+    'seed_sim_closed_only@pgtap.local'
+  );
+  active_user_id := tests.create_supabase_user(
+    'seed_sim_active',
+    'seed_sim_active@pgtap.local'
+  );
+
+  INSERT INTO public.partners (name)
+  VALUES ('Seed Sim No Party Partner')
+  RETURNING id INTO no_party_partner_id;
+
+  INSERT INTO public.partners (name)
+  VALUES ('Seed Sim Closed Only Partner')
+  RETURNING id INTO closed_only_partner_id;
+
+  INSERT INTO public.partners (name)
+  VALUES ('Seed Sim Active Partner')
+  RETURNING id INTO active_partner_id;
+
+  INSERT INTO public.partner_member_permissions (partner_id, user_id, role)
+  VALUES
+    (no_party_partner_id, no_party_user_id, 'owner'),
+    (closed_only_partner_id, closed_only_user_id, 'owner'),
+    (active_partner_id, active_user_id, 'owner');
+
+  INSERT INTO public.parties (partner_id, title, status, image_urls)
+  VALUES
+    (closed_only_partner_id, 'Closed Seed Sim Party', 'closed', '{}'),
+    (active_partner_id, 'Existing Active Seed Sim Party', 'active', '{}');
+
+  INSERT INTO _seed_sim_backfill_state
+  VALUES (no_party_partner_id, closed_only_partner_id, active_partner_id);
+END $$;
+
+CREATE OR REPLACE FUNCTION pg_temp._seed_simulator_party_backfill()
+RETURNS void AS $$
+DECLARE
+  sim_partner_id uuid;
+  sim_location_id uuid;
+BEGIN
+  FOR sim_partner_id IN
+    SELECT DISTINCT pmp.partner_id
+    FROM public.partner_member_permissions pmp
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.parties pa
+      WHERE pa.partner_id = pmp.partner_id
+        AND pa.status <> 'closed'
+    )
+  LOOP
+    SELECT id INTO sim_location_id FROM public.locations
+    WHERE partner_id = sim_partner_id LIMIT 1;
+
+    INSERT INTO public.parties (
+      partner_id,
+      location_id,
+      title,
+      max_participants,
+      status,
+      image_urls
+    )
+    VALUES (
+      sim_partner_id,
+      sim_location_id,
+      '[SIM] 시뮬레이터 파티',
+      20,
+      'active',
+      ARRAY[
+        'https://picsum.photos/seed/minglit-sim-' ||
+        replace(sim_partner_id::text, '-', '') ||
+        '/800/600'
+      ]
+    );
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.parties
+    WHERE partner_id IN (
+      SELECT no_party_partner_id FROM _seed_sim_backfill_state
+      UNION ALL
+      SELECT closed_only_partner_id FROM _seed_sim_backfill_state
+    )
+      AND status <> 'closed'
+  ),
+  0,
+  'fixtures start without non-closed parties for exhausted partners'
+);
+
+SELECT pg_temp._seed_simulator_party_backfill();
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.parties
+    WHERE partner_id = (
+      SELECT no_party_partner_id FROM _seed_sim_backfill_state
+    )
+      AND status <> 'closed'
+  ),
+  1,
+  'backfill creates a non-closed party when partner has no parties'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.parties
+    WHERE partner_id = (
+      SELECT closed_only_partner_id FROM _seed_sim_backfill_state
+    )
+      AND status <> 'closed'
+  ),
+  1,
+  'backfill creates a non-closed party when partner only has closed parties'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.parties
+    WHERE partner_id = (
+      SELECT active_partner_id FROM _seed_sim_backfill_state
+    )
+      AND status <> 'closed'
+  ),
+  1,
+  'backfill does not duplicate partners that already have a non-closed party'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.parties
+    WHERE title = '[SIM] 시뮬레이터 파티'
+      AND status = 'active'
+      AND partner_id IN (
+        SELECT no_party_partner_id FROM _seed_sim_backfill_state
+        UNION ALL
+        SELECT closed_only_partner_id FROM _seed_sim_backfill_state
+      )
+  ),
+  2,
+  'backfilled simulator parties use the expected active marker'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## 문제
dev event-flow-simulator 의 `create`(이벤트 생성) 스텝이 06-06 이후 멈춰 이벤트 풀이 22개로 고정됐고, `user_apply` 가 같은 풀을 반복 신청하며 apply-event **409 cascade**(#3408~#3419 류)가 계속 발생. 노출 이벤트도 몇 개로 보임.

## 근본 원인 (구조적 포화)
- 시뮬레이터는 `partner_member_permissions` 멤버 계정 있는 파트너만 인증 (조사 시점 ~95명), 그 중 비-closed party 보유는 **~10명뿐**.
- `partner_create_event` 의 `MIN_SCHEDULED_EVENTS=2` 캡 + 생성 이벤트 horizon **7~28일** → 이벤트가 수 주간 `scheduled` 로 남아 적격 파트너가 전원 캡에 묶임 → create 영구 정지.
- `auto_complete_past_events`(15분 cron) 는 정상 — horizon 이 길어 캡이 안 풀린 것.

진단 근거: dev REST + Axiom(`edge-functions`) + 시뮬레이터 직접 호출(`partnersPerTick=40` → actor 15명, **trace 0** = 적격 파트너 없음).

## 변경
- **A.** `action/partner_create_event.ts`: horizon 7~28일 → **2~14일**. 7일 미만 이벤트는 며칠 내 완료되어 캡을 풀고 create 재개, 7일 이상 이벤트는 `refund` 액션(start ≥ 7일, Fix #2131) 적격성 유지 (7일을 가로지르게 설계).
- **B.** `seed.dev.sql` Phase 11: 인증 가능 파트너 중 비-closed party 없는 경우 시뮬레이터용 party 1개 멱등 생성 → 동시 생성 가능 파트너 풀 확대.

## 비고
- "이벤트 3개만 보임" 은 visibility 버그가 아니었음 — `parties.visibility` 가 NOT NULL DEFAULT 'public' 이고 피드가 `COALESCE(e.visibility, p.visibility)` 라 sim 이벤트는 노출 가능. 순수 공급 부족이라 A+B 로 해소.

## 검증
- `deno test action/` 32 passed (refund 7일 cutoff 포함), `deno fmt --check` clean, BLUEDOC freshness OK.
- ⚠️ 배포 후 dev 에서 partner-manage-event 호출 재개 / 409 cascade 소멸은 런타임 검증 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)