### PR TITLE
fix(supabase): consolidate refund request select RLS

### DIFF
--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -33,4 +33,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-06-08 15:43_
+_Reviewed: 2026-06-09 07:45_

--- a/supabase/migrations/20260609000001_consolidate_refund_requests_select_rls.sql
+++ b/supabase/migrations/20260609000001_consolidate_refund_requests_select_rls.sql
@@ -1,0 +1,12 @@
+-- Issue #3442: remove Supabase Performance Advisor
+-- multiple_permissive_policies WARN for refund_requests SELECT access.
+
+DROP POLICY IF EXISTS "Partner staff can read refund requests" ON public.refund_requests;
+DROP POLICY IF EXISTS "Users can read own refund requests" ON public.refund_requests;
+
+CREATE POLICY "Users can read own refund requests" ON public.refund_requests
+  FOR SELECT TO authenticated
+  USING (
+    (SELECT auth.uid()) = user_id
+    OR public.has_partner_permission(partner_id, 'PARTY_MANAGE')
+  );

--- a/supabase/tests/database/105_rls_multiple_permissive_select_advisor_test.sql
+++ b/supabase/tests/database/105_rls_multiple_permissive_select_advisor_test.sql
@@ -22,6 +22,7 @@ VALUES
   ('public', 'partners'),
   ('public', 'party_tags'),
   ('public', 'policies'),
+  ('public', 'refund_requests'),
   ('public', 'social_interactions'),
   ('public', 'tag_usage_daily'),
   ('public', 'tag_usage_monthly'),

--- a/supabase/tests/database/106_rls_select_consolidation_behavior_test.sql
+++ b/supabase/tests/database/106_rls_select_consolidation_behavior_test.sql
@@ -73,6 +73,27 @@ WITH application AS (
 )
 SELECT set_config('tests.select_rls_application_id', id::text, true) FROM application;
 
+WITH refund_request AS (
+  INSERT INTO public.refund_requests (
+    application_id,
+    user_id,
+    event_id,
+    partner_id,
+    reason_code,
+    response_deadline_at
+  )
+  VALUES (
+    current_setting('tests.select_rls_application_id')::uuid,
+    tests.get_supabase_uid('select_rls_applicant'),
+    current_setting('tests.select_rls_event_id')::uuid,
+    current_setting('tests.select_rls_partner_id')::uuid,
+    'schedule_change',
+    now() + interval '2 days'
+  )
+  RETURNING id
+)
+SELECT set_config('tests.select_rls_refund_request_id', id::text, true) FROM refund_request;
+
 WITH verification AS (
   INSERT INTO public.verifications (
     partner_id,
@@ -148,6 +169,12 @@ SELECT results_eq(
   'applicant can read own event application'
 );
 SELECT results_eq(
+  $$SELECT count(*)::int FROM public.refund_requests
+    WHERE id = current_setting('tests.select_rls_refund_request_id')::uuid$$,
+  $$VALUES (1)$$,
+  'applicant can read own refund request'
+);
+SELECT results_eq(
   $$SELECT count(*)::int FROM public.verification_submissions
     WHERE id = current_setting('tests.select_rls_submission_id')::uuid$$,
   $$VALUES (1)$$,
@@ -162,6 +189,12 @@ SELECT results_eq(
   'partner owner can read event applications for owned party'
 );
 SELECT results_eq(
+  $$SELECT count(*)::int FROM public.refund_requests
+    WHERE id = current_setting('tests.select_rls_refund_request_id')::uuid$$,
+  $$VALUES (1)$$,
+  'partner owner can read refund requests for owned partner'
+);
+SELECT results_eq(
   $$SELECT count(*)::int FROM public.verification_submissions
     WHERE id = current_setting('tests.select_rls_submission_id')::uuid$$,
   $$VALUES (1)$$,
@@ -173,6 +206,11 @@ SELECT is_empty(
   $$SELECT id FROM public.event_applications
     WHERE id = current_setting('tests.select_rls_application_id')::uuid$$,
   'unrelated user cannot read event application'
+);
+SELECT is_empty(
+  $$SELECT id FROM public.refund_requests
+    WHERE id = current_setting('tests.select_rls_refund_request_id')::uuid$$,
+  'unrelated user cannot read refund request'
 );
 SELECT is_empty(
   $$SELECT id FROM public.verification_submissions


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

Fixes #3442

## What
- Consolidates `public.refund_requests` authenticated SELECT RLS into one permissive policy.
- Preserves both existing access branches: requester self-read and partner staff with `PARTY_MANAGE`.
- Adds `refund_requests` to the multiple-permissive SELECT pgTAP regression list.
- Extends the SELECT consolidation behavior test for applicant, partner owner, and unrelated authenticated user access.
- Bumps `supabase/BLUEDOC.md` reviewed marker for the new migration file freshness gate.

## Why
The dev Performance Advisor reported one WARN: `multiple_permissive_policies_public_refund_requests_authenticated_SELECT`. The table had two permissive authenticated SELECT policies, which Supabase flags even though both branches are intended.

## Verification
- `supabase migration up` to apply pending local migrations without reset.
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- `timeout 20m supabase test db supabase/tests/database/105_rls_multiple_permissive_select_advisor_test.sql supabase/tests/database/106_rls_select_consolidation_behavior_test.sql`

## Residual Risk
Low. This changes policy shape, not access semantics; the behavior test covers requester, authorized partner owner, and unrelated authenticated user paths.