### PR TITLE
fix(security): route write security definer RPCs via Edge Functions

### DIFF
--- a/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_controller.dart
+++ b/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_controller.dart
@@ -8,7 +8,7 @@ part 'manual_checkin_controller.g.dart';
 /// 이벤트 참가자 목록 + 수동 체크인 처리 컨트롤러.
 ///
 /// - 초기 로드: `get_event_participants_for_checkin` RPC
-/// - 체크인 처리: `process_manual_checkin` RPC + optimistic 업데이트
+/// - 체크인 처리: `event-checkin` EF + optimistic 업데이트
 @riverpod
 class ManualCheckinController extends _$ManualCheckinController {
   @override
@@ -51,12 +51,24 @@ class ManualCheckinController extends _$ManualCheckinController {
     );
 
     try {
+      final response = await supabase.functions.invoke(
+        'event-checkin',
+        body: {
+          'action': 'manual_checkin',
+          'ticket_id': ticketId,
+          'event_id': eventId,
+        },
+      );
+      if (response.status != 200) {
+        throw FunctionException(
+          status: response.status,
+          details: response.data,
+          reasonPhrase: 'Edge function error',
+        );
+      }
+
       final result =
-          await supabase.rpc<dynamic>(
-                'process_manual_checkin',
-                params: {'p_ticket_id': ticketId, 'p_event_id': eventId},
-              )
-              as String;
+          (response.data as Map<String, dynamic>)['result'] as String;
 
       // Fix #1812: already_checked_in은 서버 실제 상태도 checked_in이므로
       // optimistic 상태를 유지한다. not_found만 이전 상태로 복구.

--- a/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_controller.g.dart
+++ b/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_controller.g.dart
@@ -11,7 +11,7 @@ part of 'manual_checkin_controller.dart';
 /// 이벤트 참가자 목록 + 수동 체크인 처리 컨트롤러.
 ///
 /// - 초기 로드: `get_event_participants_for_checkin` RPC
-/// - 체크인 처리: `process_manual_checkin` RPC + optimistic 업데이트
+/// - 체크인 처리: `event-checkin` EF + optimistic 업데이트
 
 @ProviderFor(ManualCheckinController)
 const manualCheckinControllerProvider = ManualCheckinControllerFamily._();
@@ -19,7 +19,7 @@ const manualCheckinControllerProvider = ManualCheckinControllerFamily._();
 /// 이벤트 참가자 목록 + 수동 체크인 처리 컨트롤러.
 ///
 /// - 초기 로드: `get_event_participants_for_checkin` RPC
-/// - 체크인 처리: `process_manual_checkin` RPC + optimistic 업데이트
+/// - 체크인 처리: `event-checkin` EF + optimistic 업데이트
 final class ManualCheckinControllerProvider
     extends
         $AsyncNotifierProvider<
@@ -29,7 +29,7 @@ final class ManualCheckinControllerProvider
   /// 이벤트 참가자 목록 + 수동 체크인 처리 컨트롤러.
   ///
   /// - 초기 로드: `get_event_participants_for_checkin` RPC
-  /// - 체크인 처리: `process_manual_checkin` RPC + optimistic 업데이트
+  /// - 체크인 처리: `event-checkin` EF + optimistic 업데이트
   const ManualCheckinControllerProvider._({
     required ManualCheckinControllerFamily super.from,
     required String super.argument,
@@ -73,7 +73,7 @@ String _$manualCheckinControllerHash() =>
 /// 이벤트 참가자 목록 + 수동 체크인 처리 컨트롤러.
 ///
 /// - 초기 로드: `get_event_participants_for_checkin` RPC
-/// - 체크인 처리: `process_manual_checkin` RPC + optimistic 업데이트
+/// - 체크인 처리: `event-checkin` EF + optimistic 업데이트
 
 final class ManualCheckinControllerFamily extends $Family
     with
@@ -96,7 +96,7 @@ final class ManualCheckinControllerFamily extends $Family
   /// 이벤트 참가자 목록 + 수동 체크인 처리 컨트롤러.
   ///
   /// - 초기 로드: `get_event_participants_for_checkin` RPC
-  /// - 체크인 처리: `process_manual_checkin` RPC + optimistic 업데이트
+  /// - 체크인 처리: `event-checkin` EF + optimistic 업데이트
 
   ManualCheckinControllerProvider call(String eventId) =>
       ManualCheckinControllerProvider._(argument: eventId, from: this);
@@ -108,7 +108,7 @@ final class ManualCheckinControllerFamily extends $Family
 /// 이벤트 참가자 목록 + 수동 체크인 처리 컨트롤러.
 ///
 /// - 초기 로드: `get_event_participants_for_checkin` RPC
-/// - 체크인 처리: `process_manual_checkin` RPC + optimistic 업데이트
+/// - 체크인 처리: `event-checkin` EF + optimistic 업데이트
 
 abstract class _$ManualCheckinController
     extends $AsyncNotifier<List<CheckinParticipant>> {

--- a/apps/app_partner/test/src/features/checkin/manual/manual_checkin_controller_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/manual_checkin_controller_test.dart
@@ -9,6 +9,8 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 class _MockSupabaseClient extends Mock implements SupabaseClient {}
 
+class _MockFunctionsClient extends Mock implements FunctionsClient {}
+
 /// PostgrestFilterBuilder를 구현하는 fake. rpc() 스텁 반환값으로 사용.
 class _FakeRpcBuilder<T> implements PostgrestFilterBuilder<T> {
   _FakeRpcBuilder(this._data);
@@ -28,9 +30,12 @@ class _FakeRpcBuilder<T> implements PostgrestFilterBuilder<T> {
 
 void main() {
   late _MockSupabaseClient mockClient;
+  late _MockFunctionsClient mockFunctions;
 
   setUp(() {
     mockClient = _MockSupabaseClient();
+    mockFunctions = _MockFunctionsClient();
+    when(() => mockClient.functions).thenReturn(mockFunctions);
   });
 
   void stubFetch(List<dynamic> response) {
@@ -44,11 +49,16 @@ void main() {
 
   void stubCheckin(String result) {
     when(
-      () => mockClient.rpc<dynamic>(
-        'process_manual_checkin',
-        params: any(named: 'params'),
+      () => mockFunctions.invoke(
+        'event-checkin',
+        body: any(named: 'body'),
       ),
-    ).thenAnswer((_) => _FakeRpcBuilder<dynamic>(result));
+    ).thenAnswer(
+      (_) async => FunctionResponse(
+        status: 200,
+        data: {'success': result == 'success', 'result': result},
+      ),
+    );
   }
 
   ProviderContainer makeContainer() {

--- a/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
@@ -178,7 +178,7 @@ void main() {
       expect(btn.onPressed, isNull);
     });
 
-    // Fix #1947: rapid taps must not fire duplicate process_manual_checkin RPC
+    // Fix #1947: rapid taps must not fire duplicate event-checkin EF calls
     testWidgets('체크인 버튼 탭 중 스피너 표시 — 중복 탭 차단', (tester) async {
       final completer = Completer<void>();
       late _SlowController controller;

--- a/shared/packages/minglit_kit/lib/src/data/models/user_consent.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/user_consent.dart
@@ -62,7 +62,7 @@ abstract class UserConsent with _$UserConsent {
       _$UserConsentFromJson(json);
 }
 
-/// Input for saving a consent via the `save_user_consents` RPC.
+/// Input for saving a consent via the `user-manage-settings` Edge Function.
 @freezed
 abstract class ConsentInput with _$ConsentInput {
   /// Creates a [ConsentInput].

--- a/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
@@ -102,16 +102,24 @@ class CheckinRepository {
     // expiresAt are not directly comparable across timezones.
     if (token.expiresAt.toUtc().isBefore(DateTime.now().toUtc())) return false;
 
-    // 4. Atomic DB check-in via process_qr_checkin RPC
-    // Fix #1810: Phase 2 — 서명 검증 통과 후 DB 체크인 처리
-    final result = await _supabase.rpc<String>(
-      'process_qr_checkin',
-      params: {
-        'p_ticket_id': token.ticketId,
-        'p_event_id': token.eventId,
-        'p_user_id': token.userId,
+    // 4. Atomic DB check-in via event-checkin EF.
+    final response = await _supabase.functions.invoke(
+      'event-checkin',
+      body: {
+        'action': 'qr_checkin',
+        'ticket_id': token.ticketId,
+        'event_id': token.eventId,
+        'user_id': token.userId,
+        'signature': token.signature,
+        'expires_at': token.expiresAt.toUtc().toIso8601String(),
       },
     );
+    if (response.status != 200) {
+      throw StateError('Check-in failed: ${response.data}');
+    }
+
+    final data = response.data as Map<String, dynamic>;
+    final result = data['result'] as String?;
     if (result == 'already_checked_in') return false;
     if (result != 'success') {
       throw StateError('Check-in failed: $result');

--- a/shared/packages/minglit_kit/lib/src/data/repositories/consent_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/consent_repository.dart
@@ -14,7 +14,7 @@ ConsentRepository consentRepository(Ref ref) {
 /// Repository for user consent data from Supabase.
 ///
 /// Reads use direct table queries (SELECT-only RLS).
-/// Writes use the `save_user_consents` SECURITY DEFINER RPC.
+/// Writes use the `user-manage-settings` Edge Function.
 class ConsentRepository {
   /// Creates a [ConsentRepository] with the given Supabase client.
   const ConsentRepository(this._supabase);
@@ -35,16 +35,27 @@ class ConsentRepository {
         .toList();
   }
 
-  /// Saves consents via the `save_user_consents` RPC.
+  /// Saves consents via the `user-manage-settings` Edge Function.
   ///
   /// Each [ConsentInput] is upserted: existing rows are updated,
   /// new rows are inserted. Uses ON CONFLICT (user_id, consent_key).
   Future<void> saveConsents(String userId, List<ConsentInput> consents) async {
     final payload = consents.map((c) => c.toJson()).toList();
-    await _supabase.rpc<void>(
-      'save_user_consents',
-      params: {'p_user_id': userId, 'p_consents': payload},
+    final response = await _supabase.functions.invoke(
+      'user-manage-settings',
+      body: {
+        'action': 'save_consents',
+        'user_id': userId,
+        'consents': payload,
+      },
     );
+    if (response.status != 200) {
+      throw FunctionException(
+        status: response.status,
+        details: response.data,
+        reasonPhrase: 'Edge function error',
+      );
+    }
   }
 
   /// Checks whether the user has all required consents.

--- a/shared/packages/minglit_kit/lib/src/data/repositories/settlement_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/settlement_repository.dart
@@ -363,22 +363,32 @@ class SettlementRepository {
     }
   }
 
-  /// Requests a retry payout via RPC.
+  /// Requests a retry payout via Edge Function.
   ///
-  /// Calls the request_retry_payout RPC function to retry a failed payout.
+  /// Calls the partner-manage-settlement EF to retry a failed payout.
   Future<Map<String, dynamic>> retryPayout({
     required String payoutId,
     required String partnerId,
   }) async {
     Log.d('retryPayout called | payoutId: $payoutId, partnerId: $partnerId');
     try {
-      final result = await _supabase.rpc<Map<String, dynamic>>(
-        'request_retry_payout',
-        params: {
-          'p_payout_id': payoutId,
-          'p_partner_id': partnerId,
+      final response = await _supabase.functions.invoke(
+        'partner-manage-settlement',
+        body: {
+          'action': 'retry_payout',
+          'payout_id': payoutId,
+          'partner_id': partnerId,
         },
       );
+      if (response.status != 200) {
+        throw FunctionException(
+          status: response.status,
+          details: response.data,
+          reasonPhrase: 'Edge function error',
+        );
+      }
+
+      final result = response.data as Map<String, dynamic>;
 
       Log.d('retryPayout success | payoutId: $payoutId');
       return result;

--- a/shared/packages/minglit_kit/lib/src/data/repositories/social_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/social_repository.dart
@@ -28,13 +28,9 @@ class SocialRepository {
   /// NOTHING — idempotent, never throws 23505).
   /// When [active] is false, the interaction is deleted (idempotent).
   ///
-  /// Fix #1957: explicit intent eliminates TOCTOU races — callers pass the
-  /// desired final state, so concurrent calls with the same intent are safe.
-  /// Sets the interaction state for the current user with explicit intent.
-  ///
-  /// Delegates to the `set_social_interaction` Postgres function, which runs
-  /// in a single transaction with an advisory lock — eliminating TOCTOU races
-  /// and concurrent like/dislike cross-intent races.
+  /// Delegates to the `user-manage-social` EF, which calls a service-only
+  /// Postgres function with an advisory lock — eliminating TOCTOU races and
+  /// concurrent like/dislike cross-intent races.
   ///
   /// Fix #1957: explicit intent + atomic server-side operation.
   Future<void> setInteraction({
@@ -50,17 +46,17 @@ class SocialRepository {
     Log.d('setInteraction | type: $interactionType');
 
     try {
-      // Fix #1957: single RPC call — atomic transaction + advisory lock prevents
-      // concurrent cross-intent (like vs dislike) races from both landing.
-      await _supabase.rpc<dynamic>(
-        'set_social_interaction',
-        params: {
-          'p_target_id': targetId,
-          'p_target_type': targetType.name,
-          'p_interaction_type': interactionType.name,
-          'p_active': active,
+      final response = await _supabase.functions.invoke(
+        _efSocial,
+        body: {
+          'action': 'set_interaction',
+          'target_id': targetId,
+          'target_type': targetType.name,
+          'interaction_type': interactionType.name,
+          'active': active,
         },
       );
+      _ensureSuccess(response);
     } on Object catch (e, st) {
       Log.e('❌ [SocialRepo] setInteraction Error', e, st);
       rethrow;

--- a/shared/packages/minglit_kit/test/src/data/repositories/checkin_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/checkin_repository_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/repositories/checkin_repository.dart';
 import 'package:minglit_kit/src/utils/ticket_crypto.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../helpers/mocks.dart';
 import '../../../helpers/supabase_mock_helpers.dart';
@@ -13,6 +14,7 @@ void main() {
   late SimpleKeyPair keyPair;
   late SimplePublicKey publicKey;
   late MockSupabaseClient mockClient;
+  late MockFunctionsClient mockFunctions;
 
   setUpAll(() async {
     crypto = TicketCrypto();
@@ -21,7 +23,8 @@ void main() {
   });
 
   setUp(() {
-    mockClient = MockSupabaseClient();
+    mockClient = createMockSupabase();
+    mockFunctions = mockClient.functions as MockFunctionsClient;
     repository = CheckinRepository(
       crypto: crypto,
       supabase: mockClient,
@@ -83,8 +86,8 @@ void main() {
     });
 
     group('verifyAndCheckin', () {
-      // Fix #1810: verifyAndCheckin은 서명 검증 후 process_qr_checkin RPC를 호출한다.
-      // 서명/만료 검사는 클라이언트에서, DB 업데이트는 RPC에서 원자적으로 처리.
+      // Fix #1810/#3445: verifyAndCheckin은 서명 검증 후 event-checkin EF를 호출한다.
+      // 서명/만료 검사는 클라이언트에서 먼저 수행하고, DB 업데이트는 EF 내부 RPC에서 원자 처리.
 
       test('returns false for tampered signature (before RPC call)', () async {
         final token = await repository.mintTicket(
@@ -103,7 +106,7 @@ void main() {
 
         final tamperedToken = token.copyWith(signature: otherToken.signature);
 
-        // Invalid signature → returns false immediately without calling RPC
+        // Invalid signature → returns false immediately without calling EF
         final result = await repository.verifyAndCheckin(
           token: tamperedToken,
           serverPublicKey: publicKey,
@@ -111,7 +114,7 @@ void main() {
 
         expect(result, isFalse);
         verifyNever(
-          () => mockClient.rpc<dynamic>(any(), params: any(named: 'params')),
+          () => mockFunctions.invoke(any(), body: any(named: 'body')),
         );
       });
 
@@ -133,12 +136,12 @@ void main() {
 
         expect(result, isFalse);
         verifyNever(
-          () => mockClient.rpc<dynamic>(any(), params: any(named: 'params')),
+          () => mockFunctions.invoke(any(), body: any(named: 'body')),
         );
       });
 
       test(
-        'calls process_qr_checkin RPC and returns true on success',
+        'calls event-checkin EF and returns true on success',
         () async {
           final token = await repository.mintTicket(
             ticketId: 'ticket-uuid-1',
@@ -148,15 +151,16 @@ void main() {
           );
 
           when(
-            () => mockClient.rpc<String>(
-              'process_qr_checkin',
-              params: {
-                'p_ticket_id': token.ticketId,
-                'p_event_id': token.eventId,
-                'p_user_id': token.userId,
-              },
+            () => mockFunctions.invoke(
+              'event-checkin',
+              body: any(named: 'body'),
             ),
-          ).thenAnswer((_) => FakeRpcBuilder('success'));
+          ).thenAnswer(
+            (_) async => FunctionResponse(
+              status: 200,
+              data: {'success': true, 'result': 'success'},
+            ),
+          );
 
           final result = await repository.verifyAndCheckin(
             token: token,
@@ -164,20 +168,22 @@ void main() {
           );
 
           expect(result, isTrue);
-          verify(
-            () => mockClient.rpc<String>(
-              'process_qr_checkin',
-              params: {
-                'p_ticket_id': token.ticketId,
-                'p_event_id': token.eventId,
-                'p_user_id': token.userId,
-              },
+          final captured = verify(
+            () => mockFunctions.invoke(
+              'event-checkin',
+              body: captureAny(named: 'body'),
             ),
-          ).called(1);
+          ).captured;
+          final body = captured.single as Map<String, dynamic>;
+          expect(body['action'], 'qr_checkin');
+          expect(body['ticket_id'], token.ticketId);
+          expect(body['event_id'], token.eventId);
+          expect(body['user_id'], token.userId);
+          expect(body['signature'], token.signature);
         },
       );
 
-      test('returns false when RPC returns already_checked_in', () async {
+      test('returns false when EF returns already_checked_in', () async {
         final token = await repository.mintTicket(
           ticketId: 'ticket-uuid-1',
           eventId: 'event-uuid-1',
@@ -186,11 +192,16 @@ void main() {
         );
 
         when(
-          () => mockClient.rpc<String>(
-            'process_qr_checkin',
-            params: any(named: 'params'),
+          () => mockFunctions.invoke(
+            'event-checkin',
+            body: any(named: 'body'),
           ),
-        ).thenAnswer((_) => FakeRpcBuilder('already_checked_in'));
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': false, 'result': 'already_checked_in'},
+          ),
+        );
 
         final result = await repository.verifyAndCheckin(
           token: token,
@@ -200,7 +211,7 @@ void main() {
         expect(result, isFalse);
       });
 
-      test('throws StateError when RPC returns not_found', () async {
+      test('throws StateError when EF returns not_found', () async {
         final token = await repository.mintTicket(
           ticketId: 'ticket-uuid-1',
           eventId: 'event-uuid-1',
@@ -209,11 +220,16 @@ void main() {
         );
 
         when(
-          () => mockClient.rpc<String>(
-            'process_qr_checkin',
-            params: any(named: 'params'),
+          () => mockFunctions.invoke(
+            'event-checkin',
+            body: any(named: 'body'),
           ),
-        ).thenAnswer((_) => FakeRpcBuilder('not_found'));
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': false, 'result': 'not_found'},
+          ),
+        );
 
         await expectLater(
           () => repository.verifyAndCheckin(
@@ -257,11 +273,16 @@ void main() {
           expect(reparsedToken.expiresAt.isUtc, isTrue);
 
           when(
-            () => mockClient.rpc<String>(
-              'process_qr_checkin',
-              params: any(named: 'params'),
+            () => mockFunctions.invoke(
+              'event-checkin',
+              body: any(named: 'body'),
             ),
-          ).thenAnswer((_) => FakeRpcBuilder('success'));
+          ).thenAnswer(
+            (_) async => FunctionResponse(
+              status: 200,
+              data: {'success': true, 'result': 'success'},
+            ),
+          );
 
           final result = await repository.verifyAndCheckin(
             token: reparsedToken,

--- a/shared/packages/minglit_kit/test/src/data/repositories/consent_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/consent_repository_test.dart
@@ -2,18 +2,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/models/user_consent.dart';
 import 'package:minglit_kit/src/data/repositories/consent_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../helpers/mocks.dart';
 import '../../../helpers/supabase_mock_helpers.dart';
 
 void main() {
   late MockSupabaseClient mockClient;
+  late MockFunctionsClient mockFunctions;
   late ConsentRepository repository;
 
   final now = DateTime.now();
 
   setUp(() {
     mockClient = createMockSupabase();
+    mockFunctions = mockClient.functions as MockFunctionsClient;
     repository = ConsentRepository(mockClient);
   });
 
@@ -64,13 +67,18 @@ void main() {
     });
 
     group('saveConsents', () {
-      test('calls save_user_consents RPC with correct params', () async {
+      test('calls user-manage-settings EF with correct body', () async {
         when(
-          () => mockClient.rpc<void>(
-            'save_user_consents',
-            params: any(named: 'params'),
+          () => mockFunctions.invoke(
+            'user-manage-settings',
+            body: any(named: 'body'),
           ),
-        ).thenAnswer((_) => FakeRpcBuilder(null));
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
 
         await repository.saveConsents('user_1', [
           const ConsentInput(
@@ -86,25 +94,31 @@ void main() {
         ]);
 
         final captured = verify(
-          () => mockClient.rpc<void>(
-            'save_user_consents',
-            params: captureAny(named: 'params'),
+          () => mockFunctions.invoke(
+            'user-manage-settings',
+            body: captureAny(named: 'body'),
           ),
         ).captured;
 
-        final params = captured.first as Map<String, dynamic>;
-        expect(params['p_user_id'], 'user_1');
-        expect(params['p_consents'], isList);
-        expect(params['p_consents'] as List, hasLength(2));
+        final body = captured.first as Map<String, dynamic>;
+        expect(body['action'], 'save_consents');
+        expect(body['user_id'], 'user_1');
+        expect(body['consents'], isList);
+        expect(body['consents'] as List, hasLength(2));
       });
 
-      test('throws on RPC error', () async {
+      test('throws on EF error', () async {
         when(
-          () => mockClient.rpc<void>(
-            'save_user_consents',
-            params: any(named: 'params'),
+          () => mockFunctions.invoke(
+            'user-manage-settings',
+            body: any(named: 'body'),
           ),
-        ).thenThrow(Exception('RPC error'));
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 500,
+            data: {'error': 'EF error'},
+          ),
+        );
 
         expect(
           () => repository.saveConsents('user_1', [
@@ -113,7 +127,7 @@ void main() {
               consented: true,
             ),
           ]),
-          throwsA(isA<Exception>()),
+          throwsA(isA<FunctionException>()),
         );
       });
     });

--- a/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: unawaited_futures // test stubs fire-and-forget
-import 'dart:async' show FutureOr;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/models/settlement_item_detail.dart';
@@ -9,20 +8,6 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../helpers/mocks.dart';
 import '../../../helpers/supabase_mock_helpers.dart';
-
-/// Fake RPC result builder that resolves to [_data] when awaited.
-class _FakeRpcResult<T> extends Fake implements PostgrestFilterBuilder<T> {
-  _FakeRpcResult(this._data);
-  final T _data;
-
-  @override
-  Future<U> then<U>(
-    FutureOr<U> Function(T) onValue, {
-    Function? onError,
-  }) {
-    return Future<T>.value(_data).then(onValue, onError: onError);
-  }
-}
 
 /// Minimal valid settlement item JSON for use in tests.
 Map<String, dynamic> _settlementItemJson({String id = 'item_1'}) => {
@@ -634,12 +619,12 @@ void main() {
     group('retryPayout', () {
       test('returns result map on success', () async {
         when(
-          () => mockClient.rpc<Map<String, dynamic>>(
-            'request_retry_payout',
-            params: any(named: 'params'),
+          () => mockFunctions.invoke(
+            'partner-manage-settlement',
+            body: any(named: 'body'),
           ),
         ).thenAnswer(
-          (_) => _FakeRpcResult<Map<String, dynamic>>({'status': 'ok'}),
+          (_) async => FunctionResponse(status: 200, data: {'status': 'ok'}),
         );
 
         final result = await repository.retryPayout(
@@ -648,22 +633,37 @@ void main() {
         );
 
         expect(result['status'], 'ok');
+        final captured = verify(
+          () => mockFunctions.invoke(
+            'partner-manage-settlement',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured;
+        final body = captured.single as Map<String, dynamic>;
+        expect(body['action'], 'retry_payout');
+        expect(body['payout_id'], 'payout_1');
+        expect(body['partner_id'], 'partner_1');
       });
 
-      test('throws on rpc error', () async {
+      test('throws on EF error', () async {
         when(
-          () => mockClient.rpc<Map<String, dynamic>>(
-            'request_retry_payout',
-            params: any(named: 'params'),
+          () => mockFunctions.invoke(
+            'partner-manage-settlement',
+            body: any(named: 'body'),
           ),
-        ).thenThrow(Exception('rpc error'));
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 500,
+            data: {'error': 'EF error'},
+          ),
+        );
 
         await expectLater(
           repository.retryPayout(
             payoutId: 'payout_1',
             partnerId: 'partner_1',
           ),
-          throwsA(isA<Exception>()),
+          throwsA(isA<FunctionException>()),
         );
       });
     });

--- a/shared/packages/minglit_kit/test/src/data/repositories/social_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/social_repository_test.dart
@@ -17,15 +17,6 @@ void main() {
 
   final mockUser = MockUser();
 
-  void stubRpc() {
-    when(
-      () => mockClient.rpc<dynamic>(
-        'set_social_interaction',
-        params: any(named: 'params'),
-      ),
-    ).thenAnswer((_) => FakeRpcBuilder<dynamic>(null));
-  }
-
   // Fix #2393: stub user-manage-social EF.
   void stubSocialEf({int status = 200}) {
     when(
@@ -51,7 +42,7 @@ void main() {
   group('SocialRepository', () {
     group('setInteraction', () {
       test('activates interaction without error', () async {
-        stubRpc();
+        stubSocialEf();
 
         await expectLater(
           repository.setInteraction(
@@ -65,7 +56,7 @@ void main() {
       });
 
       test('deactivates interaction without error', () async {
-        stubRpc();
+        stubSocialEf();
 
         await expectLater(
           repository.setInteraction(
@@ -78,10 +69,10 @@ void main() {
         );
       });
 
-      // Fix #1957: mutual exclusivity and advisory lock are enforced atomically
-      // inside set_social_interaction(). Verify the correct RPC params are sent.
-      test('passes correct params to set_social_interaction RPC', () async {
-        stubRpc();
+      // Fix #1957/#3445: mutual exclusivity and advisory lock are enforced
+      // atomically inside the EF service-only RPC. Verify EF payload.
+      test('passes correct body to user-manage-social EF', () async {
+        stubSocialEf();
 
         await repository.setInteraction(
           targetId: 'party_1',
@@ -91,13 +82,14 @@ void main() {
         );
 
         verify(
-          () => mockClient.rpc<dynamic>(
-            'set_social_interaction',
-            params: {
-              'p_target_id': 'party_1',
-              'p_target_type': 'party',
-              'p_interaction_type': 'like',
-              'p_active': true,
+          () => mockFunctions.invoke(
+            'user-manage-social',
+            body: {
+              'action': 'set_interaction',
+              'target_id': 'party_1',
+              'target_type': 'party',
+              'interaction_type': 'like',
+              'active': true,
             },
           ),
         ).called(1);

--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -33,4 +33,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-06-09 07:45_
+_Reviewed: 2026-06-09 13:54_

--- a/supabase/functions/auth-manifest.json
+++ b/supabase/functions/auth-manifest.json
@@ -90,7 +90,7 @@
     "user-manage-social": {
       "callers": ["user"],
       "envs": ["dev", "production"],
-      "description": "소셜 인터랙션 관리 (좋아요, 차단, 신고)"
+      "description": "소셜 인터랙션 관리 (명시적 set, 좋아요, 차단, 신고)"
     },
     "user-get-ticket-token": {
       "callers": ["user"],
@@ -129,7 +129,7 @@
     "user-manage-settings": {
       "callers": ["user"],
       "envs": ["dev", "production"],
-      "description": "FCM 토큰 및 사용자 설정 관리 — upsert/delete_token, update_settings (Fix #2040)"
+      "description": "FCM 토큰, 사용자 설정, 동의 저장 관리 — upsert/delete_token, update_settings, save_consents"
     },
     "partner-reject-application": {
       "callers": ["user"],
@@ -154,7 +154,7 @@
     "event-checkin": {
       "callers": ["user"],
       "envs": ["dev", "production"],
-      "description": "이벤트 체크인 처리"
+      "description": "이벤트 체크인 처리 — QR/수동 체크인 EF gateway"
     },
     "commit-match-likes": {
       "callers": ["user"],
@@ -179,7 +179,7 @@
     "partner-manage-settlement": {
       "callers": ["user"],
       "envs": ["dev", "production"],
-      "description": "파트너 정산 관리"
+      "description": "파트너 정산 관리 — 은행 계좌 관리 및 지급 재시도"
     },
     "apply-event": {
       "callers": ["user"],

--- a/supabase/functions/event-checkin/event_checkin_test.ts
+++ b/supabase/functions/event-checkin/event_checkin_test.ts
@@ -74,11 +74,18 @@ function participantMock(overrides = {}) {
 // ──────────────────────────────────────────────
 
 Deno.test({
-  name: "event-checkin - returns 200 and checks in participant with valid QR signature",
+  name:
+    "event-checkin - returns 200 and checks in participant with valid QR signature",
   fn: async () => {
     const { privateKey, publicKeyJwk } = await generateTestKeys();
     const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
-    const signature = await signToken(privateKey, "ticket-1", "evt-1", "user-1", expiresAt);
+    const signature = await signToken(
+      privateKey,
+      "ticket-1",
+      "evt-1",
+      "user-1",
+      expiresAt,
+    );
 
     const ENV = {
       ...BASE_ENV,
@@ -91,23 +98,35 @@ Deno.test({
         handler: () => jsonResponse({ id: "user-1", email: "test@test.com" }),
       },
       {
-        matcher: (req: Request) => req.url.includes("/rest/v1/event_participants") && req.method === "GET",
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/event_participants") &&
+          req.method === "GET",
         handler: () => jsonResponse(participantMock()),
       },
       {
-        matcher: (req: Request) => req.url.includes("/rest/v1/events") && !req.url.includes("event_participants") && req.method === "GET",
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/events") &&
+          !req.url.includes("event_participants") && req.method === "GET",
         handler: () => jsonResponse({ id: "evt-1", status: "active" }),
       },
       {
-        matcher: (req: Request) => req.url.includes("/rest/v1/event_participants") && req.method === "PATCH",
-        handler: () => new Response(null, { status: 204, headers: { "content-range": "0-0/1" } }),
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/event_participants") &&
+          req.method === "PATCH",
+        handler: () =>
+          new Response(null, {
+            status: 204,
+            headers: { "content-range": "0-0/1" },
+          }),
       },
     ]);
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
-          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
           const response = await handler(
             authenticatedJsonRequest(BASE_URL, {
               event_id: "evt-1",
@@ -140,13 +159,18 @@ Deno.test({
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
-          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
           const response = await handler(
             authenticatedJsonRequest(BASE_URL, { event_id: "evt-1" }),
           );
           assertEquals(response.status, 400);
           const body = await readJson(response);
-          assertEquals(body.error, "Missing required parameters: event_id, participant_id");
+          assertEquals(
+            body.error,
+            "Missing required parameters: event_id, participant_id",
+          );
         });
       });
     });
@@ -166,7 +190,9 @@ Deno.test({
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
-          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
           const response = await handler(
             authenticatedJsonRequest(BASE_URL, {
               event_id: "evt-1",
@@ -175,7 +201,10 @@ Deno.test({
           );
           assertEquals(response.status, 400);
           const body = await readJson(response);
-          assertEquals(body.error, "Missing required parameters: signature, expires_at");
+          assertEquals(
+            body.error,
+            "Missing required parameters: signature, expires_at",
+          );
         });
       });
     });
@@ -197,7 +226,9 @@ Deno.test({
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
-          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
           const response = await handler(
             authenticatedJsonRequest(BASE_URL, {
               event_id: "evt-1",
@@ -234,7 +265,9 @@ Deno.test({
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
-          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
           const response = await handler(
             authenticatedJsonRequest(BASE_URL, {
               event_id: "evt-1",
@@ -260,7 +293,8 @@ Deno.test({
     const { fetchMock } = createFetchMock([
       {
         matcher: "/auth/v1/user",
-        handler: () => jsonResponse({ id: "other-user", email: "other@test.com" }),
+        handler: () =>
+          jsonResponse({ id: "other-user", email: "other@test.com" }),
       },
       {
         matcher: "/rest/v1/event_participants",
@@ -271,7 +305,9 @@ Deno.test({
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
-          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
           const response = await handler(
             authenticatedJsonRequest(BASE_URL, {
               event_id: "evt-1",
@@ -282,7 +318,10 @@ Deno.test({
           );
           assertEquals(response.status, 403);
           const body = await readJson(response);
-          assertEquals(body.error, "Forbidden: caller is not the participant's user");
+          assertEquals(
+            body.error,
+            "Forbidden: caller is not the participant's user",
+          );
         });
       });
     });
@@ -306,7 +345,9 @@ Deno.test({
         handler: () => jsonResponse({ id: "user-1", email: "test@test.com" }),
       },
       {
-        matcher: (req: Request) => req.url.includes("/rest/v1/event_participants") && req.method === "GET",
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/event_participants") &&
+          req.method === "GET",
         handler: () => jsonResponse(participantMock()),
       },
     ]);
@@ -314,7 +355,9 @@ Deno.test({
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
-          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
           const response = await handler(
             authenticatedJsonRequest(BASE_URL, {
               event_id: "evt-1",
@@ -337,7 +380,13 @@ Deno.test({
   fn: async () => {
     const { privateKey, publicKeyJwk } = await generateTestKeys();
     const expiresAt = new Date(Date.now() + 3600000).toISOString();
-    const signature = await signToken(privateKey, "ticket-1", "evt-1", "user-1", expiresAt);
+    const signature = await signToken(
+      privateKey,
+      "ticket-1",
+      "evt-1",
+      "user-1",
+      expiresAt,
+    );
 
     const ENV = {
       ...BASE_ENV,
@@ -350,11 +399,15 @@ Deno.test({
         handler: () => jsonResponse({ id: "user-1", email: "test@test.com" }),
       },
       {
-        matcher: (req: Request) => req.url.includes("/rest/v1/event_participants") && req.method === "GET",
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/event_participants") &&
+          req.method === "GET",
         handler: () => jsonResponse(participantMock({ status: "checked_in" })),
       },
       {
-        matcher: (req: Request) => req.url.includes("/rest/v1/events") && !req.url.includes("event_participants") && req.method === "GET",
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/events") &&
+          !req.url.includes("event_participants") && req.method === "GET",
         handler: () => jsonResponse({ id: "evt-1", status: "active" }),
       },
     ]);
@@ -362,7 +415,9 @@ Deno.test({
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
-          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
           const response = await handler(
             authenticatedJsonRequest(BASE_URL, {
               event_id: "evt-1",
@@ -385,7 +440,13 @@ Deno.test({
   fn: async () => {
     const { privateKey, publicKeyJwk } = await generateTestKeys();
     const expiresAt = new Date(Date.now() + 3600000).toISOString();
-    const signature = await signToken(privateKey, "ticket-1", "evt-1", "user-1", expiresAt);
+    const signature = await signToken(
+      privateKey,
+      "ticket-1",
+      "evt-1",
+      "user-1",
+      expiresAt,
+    );
 
     const ENV = {
       ...BASE_ENV,
@@ -398,11 +459,15 @@ Deno.test({
         handler: () => jsonResponse({ id: "user-1", email: "test@test.com" }),
       },
       {
-        matcher: (req: Request) => req.url.includes("/rest/v1/event_participants") && req.method === "GET",
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/event_participants") &&
+          req.method === "GET",
         handler: () => jsonResponse(participantMock({ status: "cancelled" })),
       },
       {
-        matcher: (req: Request) => req.url.includes("/rest/v1/events") && !req.url.includes("event_participants") && req.method === "GET",
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/events") &&
+          !req.url.includes("event_participants") && req.method === "GET",
         handler: () => jsonResponse({ id: "evt-1", status: "active" }),
       },
     ]);
@@ -410,7 +475,9 @@ Deno.test({
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
-          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
           const response = await handler(
             authenticatedJsonRequest(BASE_URL, {
               event_id: "evt-1",
@@ -421,7 +488,10 @@ Deno.test({
           );
           assertEquals(response.status, 400);
           const body = await readJson(response);
-          assertEquals(body.error, "Cannot check in participant with status 'cancelled'");
+          assertEquals(
+            body.error,
+            "Cannot check in participant with status 'cancelled'",
+          );
         });
       });
     });
@@ -436,11 +506,16 @@ Deno.test({
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
-          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
           const request = new Request(BASE_URL, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ event_id: "evt-1", participant_id: "part-1" }),
+            body: JSON.stringify({
+              event_id: "evt-1",
+              participant_id: "part-1",
+            }),
           });
 
           const response = await handler(request);
@@ -459,12 +534,131 @@ Deno.test({
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
-          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-          const response = await handler(new Request(BASE_URL, { method: "OPTIONS" }));
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const response = await handler(
+            new Request(BASE_URL, { method: "OPTIONS" }),
+          );
           assertEquals(response.status, 200);
-          assertEquals(response.headers.get("Access-Control-Allow-Origin"), "*");
-          assertEquals(response.headers.get("Access-Control-Allow-Methods"), "GET, POST, OPTIONS");
-          assertEquals(response.headers.has("Access-Control-Allow-Headers"), true);
+          assertEquals(
+            response.headers.get("Access-Control-Allow-Origin"),
+            "*",
+          );
+          assertEquals(
+            response.headers.get("Access-Control-Allow-Methods"),
+            "GET, POST, OPTIONS",
+          );
+          assertEquals(
+            response.headers.has("Access-Control-Allow-Headers"),
+            true,
+          );
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "event-checkin - manual_checkin calls actor-aware RPC",
+  fn: async () => {
+    let rpcBody: Record<string, unknown> | null = null;
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "/auth/v1/user",
+        handler: () => jsonResponse({ id: "staff-1", email: "staff@test.com" }),
+      },
+      {
+        matcher: "/rest/v1/rpc/process_manual_checkin_for_actor",
+        handler: async (req) => {
+          rpcBody = await req.json();
+          return jsonResponse("success");
+        },
+      },
+    ]);
+
+    await withEnv(BASE_ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              action: "manual_checkin",
+              ticket_id: "ticket-1",
+              event_id: "evt-1",
+            }),
+          );
+          assertEquals(response.status, 200);
+          const body = await readJson(response);
+          assertEquals(body.result, "success");
+          assertEquals(rpcBody?.p_actor_user_id, "staff-1");
+          assertEquals(rpcBody?.p_ticket_id, "ticket-1");
+          assertEquals(rpcBody?.p_event_id, "evt-1");
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "event-checkin - qr_checkin verifies signature and calls actor-aware RPC",
+  fn: async () => {
+    const { privateKey, publicKeyJwk } = await generateTestKeys();
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const signature = await signToken(
+      privateKey,
+      "ticket-1",
+      "evt-1",
+      "ticket-user-1",
+      expiresAt,
+    );
+    let rpcBody: Record<string, unknown> | null = null;
+
+    const ENV = {
+      ...BASE_ENV,
+      TICKET_SIGNING_PUBLIC_KEY_JWK: JSON.stringify(publicKeyJwk),
+    };
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "/auth/v1/user",
+        handler: () => jsonResponse({ id: "staff-1", email: "staff@test.com" }),
+      },
+      {
+        matcher: "/rest/v1/rpc/process_qr_checkin_for_actor",
+        handler: async (req) => {
+          rpcBody = await req.json();
+          return jsonResponse("success");
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              action: "qr_checkin",
+              ticket_id: "ticket-1",
+              event_id: "evt-1",
+              user_id: "ticket-user-1",
+              signature,
+              expires_at: expiresAt,
+            }),
+          );
+          assertEquals(response.status, 200);
+          const body = await readJson(response);
+          assertEquals(body.result, "success");
+          assertEquals(rpcBody?.p_actor_user_id, "staff-1");
+          assertEquals(rpcBody?.p_ticket_id, "ticket-1");
+          assertEquals(rpcBody?.p_event_id, "evt-1");
+          assertEquals(rpcBody?.p_user_id, "ticket-user-1");
         });
       });
     });

--- a/supabase/functions/event-checkin/event_checkin_test.ts
+++ b/supabase/functions/event-checkin/event_checkin_test.ts
@@ -603,6 +603,76 @@ Deno.test({
 });
 
 Deno.test({
+  name: "event-checkin - manual_checkin returns 400 for missing ticket_id",
+  fn: async () => {
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "/auth/v1/user",
+        handler: () => jsonResponse({ id: "staff-1", email: "staff@test.com" }),
+      },
+    ]);
+
+    await withEnv(BASE_ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              action: "manual_checkin",
+              event_id: "evt-1",
+            }),
+          );
+          assertEquals(response.status, 400);
+          const body = await readJson(response);
+          assertEquals(body.error, "Missing required parameter: ticket_id");
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "event-checkin - manual_checkin maps permission RPC errors to 403",
+  fn: async () => {
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "/auth/v1/user",
+        handler: () => jsonResponse({ id: "staff-1", email: "staff@test.com" }),
+      },
+      {
+        matcher: "/rest/v1/rpc/process_manual_checkin_for_actor",
+        handler: () =>
+          jsonResponse({ message: "permission denied for event" }, {
+            status: 400,
+          }),
+      },
+    ]);
+
+    await withEnv(BASE_ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              action: "manual_checkin",
+              ticket_id: "ticket-1",
+              event_id: "evt-1",
+            }),
+          );
+          assertEquals(response.status, 403);
+          const body = await readJson(response);
+          assertEquals(body.error, "permission denied for event");
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
   name:
     "event-checkin - qr_checkin verifies signature and calls actor-aware RPC",
   fn: async () => {
@@ -659,6 +729,169 @@ Deno.test({
           assertEquals(rpcBody?.p_ticket_id, "ticket-1");
           assertEquals(rpcBody?.p_event_id, "evt-1");
           assertEquals(rpcBody?.p_user_id, "ticket-user-1");
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "event-checkin - qr_checkin returns 400 when QR token is expired",
+  fn: async () => {
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "/auth/v1/user",
+        handler: () => jsonResponse({ id: "staff-1", email: "staff@test.com" }),
+      },
+    ]);
+
+    await withEnv(BASE_ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              action: "qr_checkin",
+              ticket_id: "ticket-1",
+              event_id: "evt-1",
+              user_id: "ticket-user-1",
+              signature: "unused",
+              expires_at: new Date(Date.now() - 1000).toISOString(),
+            }),
+          );
+          assertEquals(response.status, 400);
+          const body = await readJson(response);
+          assertEquals(body.error, "QR token expired");
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "event-checkin - qr_checkin requires ticket signing public key",
+  fn: async () => {
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "/auth/v1/user",
+        handler: () => jsonResponse({ id: "staff-1", email: "staff@test.com" }),
+      },
+    ]);
+
+    await withEnv(BASE_ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              action: "qr_checkin",
+              ticket_id: "ticket-1",
+              event_id: "evt-1",
+              user_id: "ticket-user-1",
+              signature: "unused",
+              expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+            }),
+          );
+          assertEquals(response.status, 500);
+          const body = await readJson(response);
+          assertEquals(body.error, "Ticket verification key not configured");
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "event-checkin - qr_checkin returns 500 for signature verification errors",
+  fn: async () => {
+    const ENV = {
+      ...BASE_ENV,
+      TICKET_SIGNING_PUBLIC_KEY_JWK: "{invalid-json",
+    };
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "/auth/v1/user",
+        handler: () => jsonResponse({ id: "staff-1", email: "staff@test.com" }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              action: "qr_checkin",
+              ticket_id: "ticket-1",
+              event_id: "evt-1",
+              user_id: "ticket-user-1",
+              signature: "unused",
+              expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+            }),
+          );
+          assertEquals(response.status, 500);
+          const body = await readJson(response);
+          assertEquals(body.error, "Signature verification failed");
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "event-checkin - qr_checkin maps RPC failures to 500",
+  fn: async () => {
+    const { privateKey, publicKeyJwk } = await generateTestKeys();
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const signature = await signToken(
+      privateKey,
+      "ticket-1",
+      "evt-1",
+      "ticket-user-1",
+      expiresAt,
+    );
+    const ENV = {
+      ...BASE_ENV,
+      TICKET_SIGNING_PUBLIC_KEY_JWK: JSON.stringify(publicKeyJwk),
+    };
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "/auth/v1/user",
+        handler: () => jsonResponse({ id: "staff-1", email: "staff@test.com" }),
+      },
+      {
+        matcher: "/rest/v1/rpc/process_qr_checkin_for_actor",
+        handler: () =>
+          jsonResponse({ message: "database unavailable" }, { status: 500 }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              action: "qr_checkin",
+              ticket_id: "ticket-1",
+              event_id: "evt-1",
+              user_id: "ticket-user-1",
+              signature,
+              expires_at: expiresAt,
+            }),
+          );
+          assertEquals(response.status, 500);
+          const body = await readJson(response);
+          assertEquals(body.error, "database unavailable");
         });
       });
     });

--- a/supabase/functions/event-checkin/index.ts
+++ b/supabase/functions/event-checkin/index.ts
@@ -1,15 +1,35 @@
 // event-checkin/index.ts — Check-in a participant for an event
 // Fix #2185 (Batch 6): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
 import { log } from "../_shared/logger.ts";
 
 const FN = "event-checkin";
+
+function rpcErrorStatus(message: string): number {
+  if (
+    message.includes("permission denied") || message.includes("unauthorized")
+  ) {
+    return 403;
+  }
+  return 500;
+}
+
+function requireString(
+  body: Record<string, unknown>,
+  key: string,
+): string | Response {
+  const value = body[key];
+  if (typeof value !== "string" || value.trim() === "") {
+    return errorResponse(`Missing required parameter: ${key}`, 400);
+  }
+  return value.trim();
+}
 
 // Fix #1491: base64url 디코딩 — Ed25519 서명 바이트 복원
 function base64UrlDecode(str: string): Uint8Array {
@@ -24,20 +44,147 @@ function base64UrlDecode(str: string): Uint8Array {
   return bytes;
 }
 
-export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+async function verifyQrSignature(
+  ticketId: string,
+  eventId: string,
+  ticketUserId: string,
+  expiresAt: string,
+  signature: string,
+): Promise<Response | null> {
+  const expiresAtMs = new Date(expiresAt).getTime();
+  if (isNaN(expiresAtMs) || expiresAtMs < Date.now()) {
+    return errorResponse("QR token expired", 400);
+  }
+
+  const publicKeyJwkStr = Deno.env.get("TICKET_SIGNING_PUBLIC_KEY_JWK");
+  if (!publicKeyJwkStr) {
+    log({
+      function: FN,
+      level: "error",
+      message: "TICKET_SIGNING_PUBLIC_KEY_JWK not configured",
+    });
+    return errorResponse("Ticket verification key not configured", 500);
+  }
+
+  try {
+    const publicKey = await crypto.subtle.importKey(
+      "jwk",
+      JSON.parse(publicKeyJwkStr),
+      { name: "Ed25519" },
+      false,
+      ["verify"],
+    );
+
+    const payload = `${ticketId}|${eventId}|${ticketUserId}|${expiresAt}`;
+    const message = new TextEncoder().encode(payload);
+    const sigBytes = base64UrlDecode(signature);
+
+    const valid = await crypto.subtle.verify(
+      "Ed25519",
+      publicKey,
+      sigBytes,
+      message,
+    );
+    if (!valid) {
+      log({
+        function: FN,
+        level: "warn",
+        message: "QR signature verification failed",
+        metadata: { event_id: eventId, ticket_id: ticketId },
+      });
+      return errorResponse("Invalid QR signature", 403);
+    }
+  } catch (e) {
+    log({
+      function: FN,
+      level: "error",
+      message: "Signature verification error",
+      metadata: { detail: String(e) },
+    });
+    return errorResponse("Signature verification failed", 500);
+  }
+
+  return null;
+}
+
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
   const { supabase } = ctx;
-  if (ctx.auth.type !== "user") return errorResponse("Unexpected auth type", 500);
+  if (ctx.auth.type !== "user") {
+    return errorResponse("Unexpected auth type", 500);
+  }
   const userId = ctx.auth.userId;
 
   const body = await parseJsonBody(req);
   if (body instanceof Response) return body;
 
   const { event_id, participant_id, signature, expires_at } = body as {
+    action?: string;
     event_id?: string;
     participant_id?: string;
+    ticket_id?: string;
+    user_id?: string;
     signature?: string;
     expires_at?: string;
   };
+
+  if (body.action === "manual_checkin") {
+    const ticketId = requireString(body, "ticket_id");
+    if (ticketId instanceof Response) return ticketId;
+    const eventId = requireString(body, "event_id");
+    if (eventId instanceof Response) return eventId;
+
+    const { data, error } = await supabase.rpc(
+      "process_manual_checkin_for_actor",
+      {
+        p_actor_user_id: userId,
+        p_ticket_id: ticketId,
+        p_event_id: eventId,
+      },
+    );
+    if (error) {
+      return errorResponse(error.message, rpcErrorStatus(error.message));
+    }
+    return successResponse({ success: data === "success", result: data });
+  }
+
+  if (body.action === "qr_checkin") {
+    const ticketId = requireString(body, "ticket_id");
+    if (ticketId instanceof Response) return ticketId;
+    const eventId = requireString(body, "event_id");
+    if (eventId instanceof Response) return eventId;
+    const ticketUserId = requireString(body, "user_id");
+    if (ticketUserId instanceof Response) return ticketUserId;
+    const qrSignature = requireString(body, "signature");
+    if (qrSignature instanceof Response) return qrSignature;
+    const expiresAt = requireString(body, "expires_at");
+    if (expiresAt instanceof Response) return expiresAt;
+
+    const signatureError = await verifyQrSignature(
+      ticketId,
+      eventId,
+      ticketUserId,
+      expiresAt,
+      qrSignature,
+    );
+    if (signatureError) return signatureError;
+
+    const { data, error } = await supabase.rpc(
+      "process_qr_checkin_for_actor",
+      {
+        p_actor_user_id: userId,
+        p_ticket_id: ticketId,
+        p_event_id: eventId,
+        p_user_id: ticketUserId,
+      },
+    );
+    if (error) {
+      return errorResponse(error.message, rpcErrorStatus(error.message));
+    }
+    return successResponse({ success: data === "success", result: data });
+  }
 
   if (!event_id || !participant_id) {
     return errorResponse(
@@ -91,55 +238,16 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
   }
 
   // Fix #1491: 서버 측 Ed25519 QR 서명 검증 — 클라이언트 우회 방지
-  const publicKeyJwkStr = Deno.env.get("TICKET_SIGNING_PUBLIC_KEY_JWK");
-  if (!publicKeyJwkStr) {
-    log({
-      function: FN,
-      level: "error",
-      message: "TICKET_SIGNING_PUBLIC_KEY_JWK not configured",
-    });
-    return errorResponse("Ticket verification key not configured", 500);
-  }
-
-  try {
-    const publicKey = await crypto.subtle.importKey(
-      "jwk",
-      JSON.parse(publicKeyJwkStr),
-      { name: "Ed25519" },
-      false,
-      ["verify"],
-    );
-
-    const ticketId = (participant as { ticket_id: string }).ticket_id;
-    const participantUserId = (participant as { user_id: string }).user_id;
-    const payload = `${ticketId}|${event_id}|${participantUserId}|${expires_at}`;
-    const message = new TextEncoder().encode(payload);
-    const sigBytes = base64UrlDecode(signature);
-
-    const valid = await crypto.subtle.verify(
-      "Ed25519",
-      publicKey,
-      sigBytes,
-      message,
-    );
-    if (!valid) {
-      log({
-        function: FN,
-        level: "warn",
-        message: "QR signature verification failed",
-        metadata: { participant_id, event_id },
-      });
-      return errorResponse("Invalid QR signature", 403);
-    }
-  } catch (e) {
-    log({
-      function: FN,
-      level: "error",
-      message: "Signature verification error",
-      metadata: { detail: String(e) },
-    });
-    return errorResponse("Signature verification failed", 500);
-  }
+  const ticketId = (participant as { ticket_id: string }).ticket_id;
+  const participantUserId = (participant as { user_id: string }).user_id;
+  const signatureError = await verifyQrSignature(
+    ticketId,
+    event_id,
+    participantUserId,
+    expires_at,
+    signature,
+  );
+  if (signatureError) return signatureError;
 
   // Fix #998: 이벤트 상태 머신 확장 — active/ongoing 상태에서만 체크인 허용
   const { data: event, error: eventFetchErr } = await supabase

--- a/supabase/functions/partner-manage-settlement/index.ts
+++ b/supabase/functions/partner-manage-settlement/index.ts
@@ -85,6 +85,39 @@ export const handler = async (
     const { action, body } = result;
     if (!action) return errorResponse("Missing action", 400);
 
+    // ─── retry_payout ───
+    if (action === "retry_payout") {
+      const payoutId = typeof body.payout_id === "string"
+        ? body.payout_id.trim()
+        : "";
+      if (!payoutId) {
+        return errorResponse("Missing payout_id", 400);
+      }
+
+      const partnerId = typeof body.partner_id === "string"
+        ? body.partner_id.trim()
+        : "";
+      if (!partnerId) {
+        return errorResponse("Missing partner_id", 400);
+      }
+
+      const { data, error } = await supabase.rpc(
+        "request_retry_payout_for_actor",
+        {
+          p_actor_user_id: userId,
+          p_payout_id: payoutId,
+          p_partner_id: partnerId,
+        },
+      );
+
+      if (error) {
+        const status = error.message.includes("unauthorized") ? 403 : 500;
+        return errorResponse(error.message, status);
+      }
+
+      return successResponse(data as Record<string, unknown>);
+    }
+
     // ─── upsert_bank_account ───
     if (action === "upsert_bank_account") {
       const partnerId = typeof body.partner_id === "string"

--- a/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
+++ b/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
@@ -238,6 +238,64 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name: "retry_payout: returns 400 for missing partner_id",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "retry_payout",
+            payout_id: "payout-001",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing partner_id");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "retry_payout: maps unauthorized RPC errors to 403",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      {
+        matcher: "/rest/v1/rpc/request_retry_payout_for_actor",
+        handler: () =>
+          jsonResponse({ message: "unauthorized payout retry" }, {
+            status: 400,
+          }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "retry_payout",
+            payout_id: "payout-001",
+            partner_id: TEST_PARTNER_ID,
+          }),
+        );
+        assertEquals(res.status, 403);
+        const body = await readJson(res);
+        assertEquals(body.error, "unauthorized payout retry");
+      });
+    });
+  },
+});
+
 // ─── UPSERT: success ───
 Deno.test({
   name: "upsert_bank_account: upserts bank account successfully",

--- a/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
+++ b/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
@@ -169,6 +169,75 @@ Deno.test({
   },
 });
 
+// ─── RETRY: success ───
+Deno.test({
+  name: "retry_payout: calls actor-aware RPC successfully",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    let rpcBody: Record<string, unknown> | null = null;
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      {
+        matcher: "/rest/v1/rpc/request_retry_payout_for_actor",
+        handler: async (req) => {
+          rpcBody = await req.json();
+          return jsonResponse({
+            success: true,
+            payout_id: "payout-001",
+            new_idempotency_key: "retry:payout-001:1",
+          });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "retry_payout",
+            payout_id: "payout-001",
+            partner_id: TEST_PARTNER_ID,
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+        assertEquals(body.payout_id, "payout-001");
+        assertEquals(rpcBody?.p_actor_user_id, TEST_USER_ID);
+        assertEquals(rpcBody?.p_payout_id, "payout-001");
+        assertEquals(rpcBody?.p_partner_id, TEST_PARTNER_ID);
+      });
+    });
+  },
+});
+
+// ─── RETRY: missing payout_id ───
+Deno.test({
+  name: "retry_payout: returns 400 for missing payout_id",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "retry_payout",
+            partner_id: TEST_PARTNER_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing payout_id");
+      });
+    });
+  },
+});
+
 // ─── UPSERT: success ───
 Deno.test({
   name: "upsert_bank_account: upserts bank account successfully",

--- a/supabase/functions/user-manage-settings/index.ts
+++ b/supabase/functions/user-manage-settings/index.ts
@@ -1,11 +1,11 @@
 // user-manage-settings — FCM token registration and user settings management
 // Issue #2040: atomic upsert for user_settings + user_consents via RPC
 
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import { parseAction } from "../_shared/request_utils.ts";
 import { log, withSpan } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
@@ -17,10 +17,15 @@ const VALID_DEVICE_TYPES = ["android", "ios", "web"];
 
 initStatsig();
 
-export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
-  if (ctx.auth.type !== "user") return errorResponse("Unexpected auth type", 500);
+  if (ctx.auth.type !== "user") {
+    return errorResponse("Unexpected auth type", 500);
+  }
   const userId = ctx.auth.userId;
   const { supabase } = ctx;
 
@@ -41,7 +46,9 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
         }
         if (!device_type || !VALID_DEVICE_TYPES.includes(device_type)) {
           return errorResponse(
-            `Invalid device_type. Must be one of: ${VALID_DEVICE_TYPES.join(", ")}`,
+            `Invalid device_type. Must be one of: ${
+              VALID_DEVICE_TYPES.join(", ")
+            }`,
             400,
           );
         }
@@ -135,7 +142,9 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
 
         if (Object.keys(sanitized).length === 0) {
           return errorResponse(
-            `No valid settings fields. Allowed: ${ALLOWED_SETTINGS_FIELDS.join(", ")}`,
+            `No valid settings fields. Allowed: ${
+              ALLOWED_SETTINGS_FIELDS.join(", ")
+            }`,
             400,
           );
         }
@@ -176,6 +185,42 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
         ).catch(() => {});
 
         return successResponse({ success: true, settings: data });
+      }
+
+      case "save_consents": {
+        const { consents, user_id } = body as {
+          consents?: unknown;
+          user_id?: string;
+        };
+
+        if (user_id && user_id !== userId) {
+          return errorResponse("Cannot write consents for another user", 403);
+        }
+        if (!Array.isArray(consents)) {
+          return errorResponse("Missing required field: consents", 400);
+        }
+
+        const { error } = await withSpan(
+          "db.rpc.save_user_consents_for_user",
+          "db.rpc",
+          () =>
+            supabase.rpc("save_user_consents_for_user", {
+              p_user_id: userId,
+              p_consents: consents,
+            }),
+        );
+
+        if (error) {
+          log({
+            function: FN,
+            level: "error",
+            message: "Failed to save consents",
+            metadata: { userId, detail: error },
+          });
+          return errorResponse("Failed to save consents", 500);
+        }
+
+        return successResponse({ success: true });
       }
 
       default:

--- a/supabase/functions/user-manage-settings/user_manage_settings_test.ts
+++ b/supabase/functions/user-manage-settings/user_manage_settings_test.ts
@@ -519,6 +519,71 @@ Deno.test("save_consents — 다른 user_id 요청은 403", async () => {
   });
 });
 
+Deno.test("save_consents — consents가 배열이 아니면 400", async () => {
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
+
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "save_consents",
+          user_id: "user-123",
+          consents: { consent_key: "terms_of_service" },
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Missing required field: consents");
+      });
+    });
+  });
+});
+
+Deno.test("save_consents — RPC 실패 시 500", async () => {
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    {
+      matcher: (req: Request) =>
+        req.url.includes("/rest/v1/rpc/save_user_consents_for_user") &&
+        req.method === "POST",
+      handler: () =>
+        jsonResponse({ message: "consent rpc failed" }, { status: 500 }),
+    },
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
+
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "save_consents",
+          user_id: "user-123",
+          consents: [
+            {
+              consent_key: "terms_of_service",
+              consented: true,
+              policy_version: 1,
+            },
+          ],
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 500);
+        assertEquals(payload.error, "Failed to save consents");
+      });
+    });
+  });
+});
+
 // ===== Auth & Edge cases =====
 
 Deno.test("인증 없이 호출 → 401", async () => {

--- a/supabase/functions/user-manage-settings/user_manage_settings_test.ts
+++ b/supabase/functions/user-manage-settings/user_manage_settings_test.ts
@@ -1,8 +1,8 @@
 import { assertEquals } from "@std/assert";
 import {
+  authenticatedJsonRequest,
   captureServeHandler,
   createFetchMock,
-  authenticatedJsonRequest,
   jsonResponse,
   readJson,
   textRequest,
@@ -11,7 +11,6 @@ import {
   withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 import { authRoute } from "../_test_utils/fixtures.ts";
-
 
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
@@ -61,7 +60,9 @@ Deno.test("upsert_token — 정상 등록", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "upsert_token",
@@ -96,7 +97,9 @@ Deno.test("upsert_token — 같은 토큰 재등록 → last_updated_at 갱신",
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "upsert_token",
@@ -125,7 +128,9 @@ Deno.test("upsert_token — token 누락 → 400", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "upsert_token",
@@ -147,7 +152,9 @@ Deno.test("upsert_token — 잘못된 device_type → 400", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "upsert_token",
@@ -178,7 +185,9 @@ Deno.test("delete_token — 정상 삭제", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "delete_token",
@@ -208,7 +217,9 @@ Deno.test("delete_token — 존재하지 않는 토큰 → 에러 없이 성공"
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "delete_token",
@@ -230,7 +241,9 @@ Deno.test("delete_token — token 누락 → 400", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "delete_token",
@@ -256,7 +269,9 @@ Deno.test("update_settings — marketing_consent 변경 → user_settings + user
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "update_settings",
@@ -275,7 +290,11 @@ Deno.test("update_settings — marketing_consent 변경 → user_settings + user
             c.url.includes("/rest/v1/rpc/upsert_user_settings_with_consent") &&
             c.method === "POST",
         );
-        assertEquals(!!rpcCall, true, "upsert_user_settings_with_consent RPC must be called");
+        assertEquals(
+          !!rpcCall,
+          true,
+          "upsert_user_settings_with_consent RPC must be called",
+        );
         const rpcBody = JSON.parse(rpcCall!.body!);
         assertEquals(rpcBody.p_user_id, "user-123");
         assertEquals(rpcBody.p_marketing_consent, true);
@@ -293,7 +312,9 @@ Deno.test("update_settings — marketing_consent false → user_consents withdra
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "update_settings",
@@ -307,7 +328,11 @@ Deno.test("update_settings — marketing_consent false → user_consents withdra
             c.url.includes("/rest/v1/rpc/upsert_user_settings_with_consent") &&
             c.method === "POST",
         );
-        assertEquals(!!rpcCall, true, "upsert_user_settings_with_consent RPC must be called on opt-out");
+        assertEquals(
+          !!rpcCall,
+          true,
+          "upsert_user_settings_with_consent RPC must be called on opt-out",
+        );
         const rpcBody = JSON.parse(rpcCall!.body!);
         assertEquals(rpcBody.p_marketing_consent, false);
       });
@@ -324,7 +349,9 @@ Deno.test("update_settings — service_notification 변경", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "update_settings",
@@ -347,7 +374,9 @@ Deno.test("update_settings — 허용되지 않은 필드만 → 400", async () 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "update_settings",
@@ -372,7 +401,9 @@ Deno.test("update_settings — boolean이 아닌 값 → 400", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "update_settings",
@@ -382,7 +413,10 @@ Deno.test("update_settings — boolean이 아닌 값 → 400", async () => {
         const payload = await readJson(response);
 
         assertEquals(response.status, 400);
-        assertEquals(payload.error, "Field 'marketing_consent' must be a boolean");
+        assertEquals(
+          payload.error,
+          "Field 'marketing_consent' must be a boolean",
+        );
       });
     });
   });
@@ -394,7 +428,9 @@ Deno.test("update_settings — settings 누락 → 400", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "update_settings",
@@ -404,6 +440,80 @@ Deno.test("update_settings — settings 누락 → 400", async () => {
 
         assertEquals(response.status, 400);
         assertEquals(payload.error, "Missing required field: settings");
+      });
+    });
+  });
+});
+
+Deno.test("save_consents — save_user_consents_for_user RPC 호출", async () => {
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    {
+      matcher: (req: Request) =>
+        req.url.includes("/rest/v1/rpc/save_user_consents_for_user") &&
+        req.method === "POST",
+      handler: () => jsonResponse(null),
+    },
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
+
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "save_consents",
+          user_id: "user-123",
+          consents: [
+            {
+              consent_key: "terms_of_service",
+              consented: true,
+              policy_version: 1,
+            },
+          ],
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+
+        const rpcCall = calls.find(
+          (c) =>
+            c.url.includes("/rest/v1/rpc/save_user_consents_for_user") &&
+            c.method === "POST",
+        );
+        assertEquals(!!rpcCall, true);
+        const rpcBody = JSON.parse(rpcCall!.body!);
+        assertEquals(rpcBody.p_user_id, "user-123");
+        assertEquals(Array.isArray(rpcBody.p_consents), true);
+      });
+    });
+  });
+});
+
+Deno.test("save_consents — 다른 user_id 요청은 403", async () => {
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
+
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "save_consents",
+          user_id: "other-user",
+          consents: [],
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 403);
+        assertEquals(payload.error, "Cannot write consents for another user");
       });
     });
   });
@@ -422,7 +532,9 @@ Deno.test("인증 없이 호출 → 401", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "upsert_token",
@@ -443,7 +555,9 @@ Deno.test("잘못된 action → 400", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           action: "invalid_action",
@@ -464,7 +578,9 @@ Deno.test("action 누락 → 400", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = authenticatedJsonRequest("http://localhost", {
           token: "test",
@@ -485,7 +601,9 @@ Deno.test("malformed JSON → 400", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const handler = await captureServeHandler(
+          new URL("./index.ts", import.meta.url),
+        );
 
         const request = textRequest("http://localhost", "{invalid-json", {
           headers: { Authorization: "Bearer test-token" },

--- a/supabase/functions/user-manage-social/index.ts
+++ b/supabase/functions/user-manage-social/index.ts
@@ -1,12 +1,12 @@
 // user-manage-social — Manage social interactions (like, block, report)
 // Replaces direct client writes to social_interactions + report_details
 
-import {
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
+import {
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
 
 const VALID_INTERACTION_TYPES = ["like", "dislike", "subscribe", "bookmark"];
 const VALID_TARGET_TYPES = ["party", "partner", "review", "comment"];
@@ -18,13 +18,52 @@ const VALID_REPORT_REASONS = [
   "other",
 ];
 
-export const handler = async (req: Request, { auth, supabase }: EFContext): Promise<Response> => {
+export const handler = async (
+  req: Request,
+  { auth, supabase }: EFContext,
+): Promise<Response> => {
   const { userId } = auth as { type: "user"; userId: string };
 
   const result = await parseAction(req);
   if (result instanceof Response) return result;
   const { action, body } = result;
   if (!action) return errorResponse("Missing action", 400);
+
+  // ─────────────────────────────────────────
+  // set_interaction — explicit final state via service_role-only RPC
+  // ─────────────────────────────────────────
+  if (action === "set_interaction") {
+    const targetId = body.target_id as string | undefined;
+    const targetType = body.target_type as string | undefined;
+    const interactionType = body.interaction_type as string | undefined;
+    const active = body.active as boolean | undefined;
+
+    if (!targetId || !targetType || !interactionType || active == null) {
+      return errorResponse(
+        "Missing target_id, target_type, interaction_type, or active",
+        400,
+      );
+    }
+    if (!VALID_TARGET_TYPES.includes(targetType)) {
+      return errorResponse(`Invalid target_type: ${targetType}`, 400);
+    }
+    if (!VALID_INTERACTION_TYPES.includes(interactionType)) {
+      return errorResponse(`Invalid interaction_type: ${interactionType}`, 400);
+    }
+    if (typeof active !== "boolean") {
+      return errorResponse("active must be a boolean", 400);
+    }
+
+    const { error } = await supabase.rpc("set_social_interaction_for_user", {
+      p_user_id: userId,
+      p_target_id: targetId,
+      p_target_type: targetType,
+      p_interaction_type: interactionType,
+      p_active: active,
+    });
+    if (error) return errorResponse(error.message, 500);
+    return successResponse({ success: true, active });
+  }
 
   // ─────────────────────────────────────────
   // toggle — like/dislike/subscribe/bookmark

--- a/supabase/functions/user-manage-social/user_manage_social_test.ts
+++ b/supabase/functions/user-manage-social/user_manage_social_test.ts
@@ -27,13 +27,82 @@ function authRoute() {
 }
 
 // ─────────────────────────────────────────
+// set_interaction
+// ─────────────────────────────────────────
+
+Deno.test({
+  name: "set_interaction - calls actor-aware RPC",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    let rpcBody: Record<string, unknown> | null = null;
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      {
+        matcher: "/rest/v1/rpc/set_social_interaction_for_user",
+        handler: async (req) => {
+          rpcBody = await req.json();
+          return jsonResponse(null);
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(authenticatedJsonRequest("http://localhost", {
+          action: "set_interaction",
+          target_id: TEST_TARGET_ID,
+          target_type: "partner",
+          interaction_type: "bookmark",
+          active: true,
+        }));
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+        assertEquals(rpcBody?.p_user_id, TEST_USER_ID);
+        assertEquals(rpcBody?.p_target_id, TEST_TARGET_ID);
+        assertEquals(rpcBody?.p_target_type, "partner");
+        assertEquals(rpcBody?.p_interaction_type, "bookmark");
+        assertEquals(rpcBody?.p_active, true);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "set_interaction - returns 400 when active is not boolean",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(authenticatedJsonRequest("http://localhost", {
+          action: "set_interaction",
+          target_id: TEST_TARGET_ID,
+          target_type: "partner",
+          interaction_type: "bookmark",
+          active: "true",
+        }));
+        assertEquals(res.status, 400);
+      });
+    });
+  },
+});
+
+// ─────────────────────────────────────────
 // toggle
 // ─────────────────────────────────────────
 
 Deno.test({
   name: "toggle like - adds interaction when not exists",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
 
     const { fetchMock, calls } = createFetchMock([
       authRoute(),
@@ -42,7 +111,10 @@ Deno.test({
       // select existing → null
       { matcher: "social_interactions?", handler: () => jsonResponse(null) },
       // insert
-      { matcher: "social_interactions", handler: () => jsonResponse({}, { status: 201 }) },
+      {
+        matcher: "social_interactions",
+        handler: () => jsonResponse({}, { status: 201 }),
+      },
     ]);
 
     await withEnv(ENV, async () => {
@@ -64,7 +136,9 @@ Deno.test({
 Deno.test({
   name: "toggle - returns 400 for invalid interaction_type",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -84,7 +158,9 @@ Deno.test({
 Deno.test({
   name: "toggle - returns 400 for invalid target_type",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -104,7 +180,9 @@ Deno.test({
 Deno.test({
   name: "toggle - returns 400 for missing fields",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -127,10 +205,15 @@ Deno.test({
 Deno.test({
   name: "block - succeeds",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
-      { matcher: "social_interactions", handler: () => jsonResponse({}, { status: 201 }) },
+      {
+        matcher: "social_interactions",
+        handler: () => jsonResponse({}, { status: 201 }),
+      },
     ]);
 
     await withEnv(ENV, async () => {
@@ -150,7 +233,9 @@ Deno.test({
 Deno.test({
   name: "block - returns 400 when blocking self",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -168,7 +253,9 @@ Deno.test({
 Deno.test({
   name: "unblock - succeeds",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       { matcher: "social_interactions?", handler: () => jsonResponse([]) },
@@ -195,15 +282,26 @@ Deno.test({
 Deno.test({
   name: "report - succeeds with block + report + details",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       // block upsert
-      { matcher: "social_interactions", handler: () => jsonResponse({}, { status: 201 }) },
+      {
+        matcher: "social_interactions",
+        handler: () => jsonResponse({}, { status: 201 }),
+      },
       // report upsert
-      { matcher: "social_interactions", handler: () => jsonResponse({}, { status: 201 }) },
+      {
+        matcher: "social_interactions",
+        handler: () => jsonResponse({}, { status: 201 }),
+      },
       // report_details insert
-      { matcher: "report_details", handler: () => jsonResponse({}, { status: 201 }) },
+      {
+        matcher: "report_details",
+        handler: () => jsonResponse({}, { status: 201 }),
+      },
     ]);
 
     await withEnv(ENV, async () => {
@@ -225,7 +323,9 @@ Deno.test({
 Deno.test({
   name: "report - returns 400 for invalid reason",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -244,7 +344,9 @@ Deno.test({
 Deno.test({
   name: "report - returns 400 when reporting self",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -267,18 +369,25 @@ Deno.test({
 Deno.test({
   name: "returns 401 without auth",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
-      { matcher: "/auth/v1/user", handler: () => jsonResponse({ error: "invalid" }, { status: 401 }) },
+      {
+        matcher: "/auth/v1/user",
+        handler: () => jsonResponse({ error: "invalid" }, { status: 401 }),
+      },
     ]);
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(new Request("http://localhost", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ action: "block", target_id: "x" }),
-        }));
+        const res = await handler(
+          new Request("http://localhost", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ action: "block", target_id: "x" }),
+          }),
+        );
         assertEquals(res.status, 401);
       });
     });
@@ -288,7 +397,9 @@ Deno.test({
 Deno.test({
   name: "returns 400 for unknown action",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -301,4 +412,3 @@ Deno.test({
     });
   },
 });
-

--- a/supabase/functions/user-manage-social/user_manage_social_test.ts
+++ b/supabase/functions/user-manage-social/user_manage_social_test.ts
@@ -93,6 +93,82 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name: "set_interaction - returns 400 for missing fields",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(authenticatedJsonRequest("http://localhost", {
+          action: "set_interaction",
+          target_id: TEST_TARGET_ID,
+          target_type: "partner",
+        }));
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(
+          body.error,
+          "Missing target_id, target_type, interaction_type, or active",
+        );
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "set_interaction - returns 400 for invalid target_type",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(authenticatedJsonRequest("http://localhost", {
+          action: "set_interaction",
+          target_id: TEST_TARGET_ID,
+          target_type: "invalid",
+          interaction_type: "bookmark",
+          active: true,
+        }));
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Invalid target_type: invalid");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "set_interaction - returns 400 for invalid interaction_type",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(authenticatedJsonRequest("http://localhost", {
+          action: "set_interaction",
+          target_id: TEST_TARGET_ID,
+          target_type: "partner",
+          interaction_type: "invalid",
+          active: true,
+        }));
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Invalid interaction_type: invalid");
+      });
+    });
+  },
+});
+
 // ─────────────────────────────────────────
 // toggle
 // ─────────────────────────────────────────

--- a/supabase/migrations/20260609053000_security_definer_rpc_edge_gateway.sql
+++ b/supabase/migrations/20260609053000_security_definer_rpc_edge_gateway.sql
@@ -1,0 +1,506 @@
+-- Issue #3445: move remaining write-capable SECURITY DEFINER RPCs behind
+-- authenticated Edge Functions. Client roles lose direct EXECUTE; service_role
+-- EF callers use explicit actor-aware internals for the DB atomic boundary.
+
+CREATE OR REPLACE FUNCTION public.process_qr_checkin_for_actor(
+  p_actor_user_id uuid,
+  p_ticket_id uuid,
+  p_event_id uuid,
+  p_user_id uuid
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_partner_id uuid;
+  v_current_status text;
+BEGIN
+  IF p_actor_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  SELECT pa.partner_id
+    INTO v_partner_id
+    FROM public.events e
+    JOIN public.parties pa ON pa.id = e.party_id
+   WHERE e.id = p_event_id;
+
+  IF v_partner_id IS NULL THEN
+    RETURN 'not_found';
+  END IF;
+
+  IF NOT (
+    EXISTS (
+      SELECT 1
+        FROM public.partner_member_permissions pmp
+       WHERE pmp.partner_id = v_partner_id
+         AND pmp.user_id = p_actor_user_id
+         AND 'PARTY_MANAGE' = ANY(pmp.permissions)
+    )
+    OR EXISTS (
+      SELECT 1
+        FROM public.app_roles ar
+       WHERE ar.user_id = p_actor_user_id
+         AND ar.role = 'super_admin'
+    )
+  ) THEN
+    RAISE EXCEPTION 'permission denied: PARTY_MANAGE required';
+  END IF;
+
+  SELECT status
+    INTO v_current_status
+    FROM public.event_participants
+   WHERE ticket_id = p_ticket_id
+     AND event_id = p_event_id
+     AND user_id = p_user_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN 'not_found';
+  END IF;
+
+  IF v_current_status = 'checked_in' THEN
+    RETURN 'already_checked_in';
+  END IF;
+
+  UPDATE public.event_participants
+     SET status = 'checked_in',
+         checked_in_at = now()
+   WHERE ticket_id = p_ticket_id
+     AND event_id = p_event_id
+     AND user_id = p_user_id;
+
+  RETURN 'success';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.process_qr_checkin(
+  p_ticket_id uuid,
+  p_event_id uuid,
+  p_user_id uuid
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN public.process_qr_checkin_for_actor(
+    auth.uid(),
+    p_ticket_id,
+    p_event_id,
+    p_user_id
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.process_manual_checkin_for_actor(
+  p_actor_user_id uuid,
+  p_ticket_id uuid,
+  p_event_id uuid
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_partner_id uuid;
+  v_event_status text;
+  v_current_status text;
+BEGIN
+  IF p_actor_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  SELECT pa.partner_id, e.status
+    INTO v_partner_id, v_event_status
+    FROM public.events e
+    JOIN public.parties pa ON pa.id = e.party_id
+   WHERE e.id = p_event_id;
+
+  IF v_partner_id IS NULL THEN
+    RETURN 'not_found';
+  END IF;
+
+  IF v_event_status IN ('cancelled', 'completed') THEN
+    RETURN 'not_found';
+  END IF;
+
+  IF NOT (
+    EXISTS (
+      SELECT 1
+        FROM public.partner_member_permissions pmp
+       WHERE pmp.partner_id = v_partner_id
+         AND pmp.user_id = p_actor_user_id
+         AND 'PARTY_MANAGE' = ANY(pmp.permissions)
+    )
+    OR EXISTS (
+      SELECT 1
+        FROM public.app_roles ar
+       WHERE ar.user_id = p_actor_user_id
+         AND ar.role = 'super_admin'
+    )
+  ) THEN
+    RAISE EXCEPTION 'permission denied: PARTY_MANAGE required';
+  END IF;
+
+  SELECT status
+    INTO v_current_status
+    FROM public.event_participants
+   WHERE ticket_id = p_ticket_id
+     AND event_id = p_event_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN 'not_found';
+  END IF;
+
+  IF v_current_status = 'checked_in' THEN
+    RETURN 'already_checked_in';
+  END IF;
+
+  IF v_current_status != 'ticket_issued' THEN
+    RETURN 'not_found';
+  END IF;
+
+  UPDATE public.event_participants
+     SET status = 'checked_in',
+         checked_in_at = now()
+   WHERE ticket_id = p_ticket_id
+     AND event_id = p_event_id;
+
+  RETURN 'success';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.process_manual_checkin(
+  p_ticket_id uuid,
+  p_event_id uuid
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN public.process_manual_checkin_for_actor(
+    auth.uid(),
+    p_ticket_id,
+    p_event_id
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.request_retry_payout_for_actor(
+  p_actor_user_id uuid,
+  p_payout_id uuid,
+  p_partner_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_payout record;
+  v_item record;
+  v_new_idem_key text;
+BEGIN
+  IF p_actor_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM public.partner_member_permissions pmp
+     WHERE pmp.user_id = p_actor_user_id
+       AND pmp.partner_id = p_partner_id
+  ) THEN
+    RAISE EXCEPTION 'unauthorized: caller is not a member of partner %', p_partner_id;
+  END IF;
+
+  SELECT * INTO v_payout
+    FROM public.payouts
+   WHERE id = p_payout_id
+     AND partner_id = p_partner_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'payout not found or unauthorized: %', p_payout_id;
+  END IF;
+
+  IF v_payout.status != 'FAILED' THEN
+    RAISE EXCEPTION 'only FAILED payouts can be retried, current status: %', v_payout.status;
+  END IF;
+
+  v_new_idem_key := 'retry:' || p_payout_id::text || ':' || extract(epoch from now())::bigint::text;
+
+  UPDATE public.payouts
+     SET status = 'CREATED',
+         payout_request_idempotency_key = v_new_idem_key,
+         updated_at = now()
+   WHERE id = p_payout_id;
+
+  FOR v_item IN
+    SELECT si.id, si.version
+      FROM public.settlement_items si
+     WHERE si.payout_id = p_payout_id
+       AND si.status = 'FAILED'
+       AND si.retryable = true
+  LOOP
+    BEGIN
+      PERFORM public.transition_settlement_status(
+        v_item.id,
+        v_item.version,
+        'READY',
+        'PARTNER',
+        p_partner_id::text,
+        'retry_requested',
+        null::text, null::text, null::text, null::text,
+        jsonb_build_object('retry_payout_id', p_payout_id),
+        v_new_idem_key || ':' || v_item.id::text
+      );
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'transition failed for item %: %', v_item.id, sqlerrm;
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'payout_id', p_payout_id,
+    'new_idempotency_key', v_new_idem_key
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.request_retry_payout(
+  p_payout_id uuid,
+  p_partner_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN public.request_retry_payout_for_actor(
+    auth.uid(),
+    p_payout_id,
+    p_partner_id
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.save_user_consents_for_user(
+  p_user_id uuid,
+  p_consents jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_now timestamptz := now();
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF COALESCE(jsonb_typeof(p_consents), 'null') <> 'array' THEN
+    RAISE EXCEPTION 'p_consents must be a JSON array';
+  END IF;
+
+  INSERT INTO public.user_consents (
+    user_id,
+    consent_key,
+    consented,
+    policy_version,
+    consented_at,
+    withdrawn_at
+  )
+  SELECT
+    p_user_id,
+    entry.consent_key,
+    entry.consented,
+    entry.policy_version,
+    v_now,
+    CASE WHEN entry.consented THEN NULL ELSE v_now END
+  FROM jsonb_to_recordset(p_consents) AS entry(
+    consent_key text,
+    consented boolean,
+    policy_version integer
+  )
+  ON CONFLICT (user_id, consent_key) DO UPDATE
+  SET
+    consented = EXCLUDED.consented,
+    policy_version = GREATEST(
+      COALESCE(EXCLUDED.policy_version, public.user_consents.policy_version),
+      COALESCE(public.user_consents.policy_version, EXCLUDED.policy_version)
+    ),
+    consented_at = CASE
+      WHEN EXCLUDED.consented THEN v_now
+      ELSE public.user_consents.consented_at
+    END,
+    withdrawn_at = CASE
+      WHEN EXCLUDED.consented THEN NULL
+      ELSE v_now
+    END;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.save_user_consents(
+  p_user_id uuid,
+  p_consents jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_auth_user_id uuid := auth.uid();
+BEGIN
+  IF v_auth_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF v_auth_user_id IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Cannot write consents for another user';
+  END IF;
+
+  PERFORM public.save_user_consents_for_user(p_user_id, p_consents);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.set_social_interaction_for_user(
+  p_user_id uuid,
+  p_target_id text,
+  p_target_type text,
+  p_interaction_type text,
+  p_active boolean
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_opposite public.social_interaction_type;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'User not authenticated';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    ('x' || left(md5(p_user_id::text || ':' || p_target_id), 16))::bit(64)::bigint
+  );
+
+  IF p_active THEN
+    IF p_interaction_type IN ('like', 'dislike') THEN
+      v_opposite := CASE p_interaction_type
+        WHEN 'like' THEN 'dislike'::public.social_interaction_type
+        ELSE 'like'::public.social_interaction_type
+      END;
+
+      DELETE FROM public.social_interactions
+       WHERE user_id = p_user_id
+         AND target_id = p_target_id::uuid
+         AND interaction_type = v_opposite;
+    END IF;
+
+    INSERT INTO public.social_interactions (
+      user_id,
+      target_id,
+      target_type,
+      interaction_type
+    )
+    VALUES (
+      p_user_id,
+      p_target_id::uuid,
+      p_target_type::public.social_target_type,
+      p_interaction_type::public.social_interaction_type
+    )
+    ON CONFLICT (user_id, target_id, interaction_type) DO NOTHING;
+  ELSE
+    DELETE FROM public.social_interactions
+     WHERE user_id = p_user_id
+       AND target_id = p_target_id::uuid
+       AND interaction_type = p_interaction_type::public.social_interaction_type;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.set_social_interaction(
+  p_target_id text,
+  p_target_type text,
+  p_interaction_type text,
+  p_active boolean
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  PERFORM public.set_social_interaction_for_user(
+    auth.uid(),
+    p_target_id,
+    p_target_type,
+    p_interaction_type,
+    p_active
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.process_qr_checkin_for_actor(uuid, uuid, uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.process_qr_checkin_for_actor(uuid, uuid, uuid, uuid)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.process_manual_checkin_for_actor(uuid, uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.process_manual_checkin_for_actor(uuid, uuid, uuid)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.request_retry_payout_for_actor(uuid, uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.request_retry_payout_for_actor(uuid, uuid, uuid)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.save_user_consents_for_user(uuid, jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.save_user_consents_for_user(uuid, jsonb)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.set_social_interaction_for_user(uuid, text, text, text, boolean)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.set_social_interaction_for_user(uuid, text, text, text, boolean)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.process_qr_checkin(uuid, uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.process_qr_checkin(uuid, uuid, uuid)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.process_manual_checkin(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.process_manual_checkin(uuid, uuid)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.request_retry_payout(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.request_retry_payout(uuid, uuid)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.save_user_consents(uuid, jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.save_user_consents(uuid, jsonb)
+  TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.set_social_interaction(text, text, text, boolean)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.set_social_interaction(text, text, text, boolean)
+  TO service_role;

--- a/supabase/tests/database/107_rls_strict_publishable_write_lockdown_test.sql
+++ b/supabase/tests/database/107_rls_strict_publishable_write_lockdown_test.sql
@@ -65,12 +65,7 @@ SELECT is_empty(
         )
     ),
     direct_client_write_rpc_exceptions(function_oid) AS (
-      VALUES
-        ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
-        ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
-        ('public.request_retry_payout(uuid, uuid)'::regprocedure),
-        ('public.save_user_consents(uuid, jsonb)'::regprocedure),
-        ('public.set_social_interaction(text, text, text, boolean)'::regprocedure)
+      SELECT NULL::oid WHERE false
     ),
     publishable_roles AS (
       SELECT unnest(ARRAY['anon', 'authenticated']) AS role_name
@@ -91,7 +86,7 @@ SELECT is_empty(
       AND allowed.function_oid IS NULL
     ORDER BY pr.role_name, function_signature
   $$,
-  'anon/authenticated cannot execute write-capable SECURITY DEFINER RPCs outside reviewed direct-client exceptions'
+  'anon/authenticated cannot execute write-capable SECURITY DEFINER RPCs directly'
 );
 
 SELECT is_empty(
@@ -99,10 +94,15 @@ SELECT is_empty(
     WITH reviewed_functions(function_signature) AS (
       VALUES
         ('public.save_user_consents(uuid, jsonb)'),
+        ('public.save_user_consents_for_user(uuid, jsonb)'),
         ('public.process_qr_checkin(uuid, uuid, uuid)'),
+        ('public.process_qr_checkin_for_actor(uuid, uuid, uuid, uuid)'),
         ('public.process_manual_checkin(uuid, uuid)'),
+        ('public.process_manual_checkin_for_actor(uuid, uuid, uuid)'),
         ('public.request_retry_payout(uuid, uuid)'),
+        ('public.request_retry_payout_for_actor(uuid, uuid, uuid)'),
         ('public.set_social_interaction(text, text, text, boolean)'),
+        ('public.set_social_interaction_for_user(uuid, text, text, text, boolean)'),
         ('public.create_party_with_tags(jsonb, uuid[])'),
         ('public.update_party_tags(uuid, uuid[])'),
         ('public.upsert_user_interest_tags(uuid[])')

--- a/supabase/tests/database/109_security_definer_execute_posture_test.sql
+++ b/supabase/tests/database/109_security_definer_execute_posture_test.sql
@@ -16,11 +16,6 @@ SELECT is_empty(
       ('public.get_event_checkin_stats(uuid)'::regprocedure),
       ('public.get_event_checkin_stats_by_group(uuid)'::regprocedure),
       ('public.get_event_participants_for_checkin(uuid)'::regprocedure),
-      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
-      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
-      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
-      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
-      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure),
       ('public.get_ticket_public_key()'::regprocedure)
   )
   SELECT function_oid::regprocedure::text
@@ -45,11 +40,6 @@ SELECT is_empty(
       ('public.get_event_checkin_stats(uuid)'::regprocedure),
       ('public.get_event_checkin_stats_by_group(uuid)'::regprocedure),
       ('public.get_event_participants_for_checkin(uuid)'::regprocedure),
-      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
-      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
-      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
-      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
-      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure),
       ('public.get_ticket_public_key()'::regprocedure)
   )
   SELECT function_oid::regprocedure::text
@@ -58,7 +48,7 @@ SELECT is_empty(
      OR NOT has_function_privilege('service_role', function_oid, 'EXECUTE')
   ORDER BY 1
   $$,
-  'authenticated-client SECURITY DEFINER RPCs remain callable by authenticated and service_role'
+  'read-only authenticated-client SECURITY DEFINER RPCs remain callable by authenticated and service_role'
 );
 
 SELECT is_empty(
@@ -86,13 +76,23 @@ SELECT is_empty(
       ('public.handle_storage_object_created()'::regprocedure),
       ('public.handle_verification_approval()'::regprocedure),
       ('public.issue_ticket_on_approval()'::regprocedure),
+      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
+      ('public.process_manual_checkin_for_actor(uuid, uuid, uuid)'::regprocedure),
+      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
+      ('public.process_qr_checkin_for_actor(uuid, uuid, uuid, uuid)'::regprocedure),
       ('public.process_reconciliation_kill_switch(uuid)'::regprocedure),
       ('public.produce_event()'::regprocedure),
       ('public.produce_event(public.event_type_name, text, uuid, jsonb)'::regprocedure),
       ('public.protect_user_profile_fields()'::regprocedure),
       ('public.remove_participant_on_cancel()'::regprocedure),
+      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
+      ('public.request_retry_payout_for_actor(uuid, uuid, uuid)'::regprocedure),
       ('public.replace_match_rules(uuid, jsonb)'::regprocedure),
+      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
+      ('public.save_user_consents_for_user(uuid, jsonb)'::regprocedure),
       ('public.send_event_reminders()'::regprocedure),
+      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure),
+      ('public.set_social_interaction_for_user(uuid, text, text, text, boolean)'::regprocedure),
       ('public.sync_max_participants()'::regprocedure),
       ('public.trigger_produce_event_application()'::regprocedure),
       ('public.trigger_produce_event_events()'::regprocedure),
@@ -136,13 +136,23 @@ SELECT is_empty(
       ('public.handle_storage_object_created()'::regprocedure),
       ('public.handle_verification_approval()'::regprocedure),
       ('public.issue_ticket_on_approval()'::regprocedure),
+      ('public.process_manual_checkin(uuid, uuid)'::regprocedure),
+      ('public.process_manual_checkin_for_actor(uuid, uuid, uuid)'::regprocedure),
+      ('public.process_qr_checkin(uuid, uuid, uuid)'::regprocedure),
+      ('public.process_qr_checkin_for_actor(uuid, uuid, uuid, uuid)'::regprocedure),
       ('public.process_reconciliation_kill_switch(uuid)'::regprocedure),
       ('public.produce_event()'::regprocedure),
       ('public.produce_event(public.event_type_name, text, uuid, jsonb)'::regprocedure),
       ('public.protect_user_profile_fields()'::regprocedure),
       ('public.remove_participant_on_cancel()'::regprocedure),
+      ('public.request_retry_payout(uuid, uuid)'::regprocedure),
+      ('public.request_retry_payout_for_actor(uuid, uuid, uuid)'::regprocedure),
       ('public.replace_match_rules(uuid, jsonb)'::regprocedure),
+      ('public.save_user_consents(uuid, jsonb)'::regprocedure),
+      ('public.save_user_consents_for_user(uuid, jsonb)'::regprocedure),
       ('public.send_event_reminders()'::regprocedure),
+      ('public.set_social_interaction(text, text, text, boolean)'::regprocedure),
+      ('public.set_social_interaction_for_user(uuid, text, text, text, boolean)'::regprocedure),
       ('public.sync_max_participants()'::regprocedure),
       ('public.trigger_produce_event_application()'::regprocedure),
       ('public.trigger_produce_event_events()'::regprocedure),

--- a/supabase/tests/database/56_user_consents_test.sql
+++ b/supabase/tests/database/56_user_consents_test.sql
@@ -63,15 +63,15 @@ SELECT is_empty(
 );
 
 -- ============================================================
--- 5. RPC — authenticated user can save own consents
+-- 5. RPC — EF service role user context can save own consents
 -- ============================================================
 SELECT tests.create_supabase_user('consent_user_a', 'consent_a@test.com');
 SELECT tests.create_supabase_user('consent_user_b', 'consent_b@test.com');
 
 SELECT results_eq(
   $$SELECT has_function_privilege('authenticated', 'public.save_user_consents(uuid, jsonb)', 'EXECUTE')::text$$,
-  $$VALUES ('true')$$,
-  'authenticated can execute save_user_consents until EF wrapper migration'
+  $$VALUES ('false')$$,
+  'authenticated cannot execute save_user_consents directly after EF wrapper migration'
 );
 
 SELECT results_eq(
@@ -80,22 +80,17 @@ SELECT results_eq(
   'service_role can execute save_user_consents for Edge Function writes'
 );
 
-SELECT tests.authenticate_as('consent_user_a');
+SELECT tests.authenticate_as_service_role_user('consent_user_a');
 
-SELECT lives_ok(
-  format(
-    $$SELECT public.save_user_consents(
-      '%s',
-      '[
-        {"consent_key":"terms_of_service","consented":true,"policy_version":1},
-        {"consent_key":"privacy_collection","consented":true,"policy_version":1},
-        {"consent_key":"age_confirmation","consented":true}
-      ]'::jsonb
-    )$$,
-    tests.get_supabase_uid('consent_user_a')
-  ),
-  'authenticated user context can save own consents via RPC'
+SELECT public.save_user_consents(
+  tests.get_supabase_uid('consent_user_a'),
+  '[
+    {"consent_key":"terms_of_service","consented":true,"policy_version":1},
+    {"consent_key":"privacy_collection","consented":true,"policy_version":1},
+    {"consent_key":"age_confirmation","consented":true}
+  ]'::jsonb
 );
+SELECT pass('service_role user context can save own consents via RPC compatibility wrapper');
 
 -- ============================================================
 -- 6. RLS — user can SELECT only own consents
@@ -127,7 +122,7 @@ ROLLBACK TO SAVEPOINT before_direct_insert;
 -- ============================================================
 -- 8. RPC — user cannot save consents for another user
 -- ============================================================
-SELECT tests.authenticate_as('consent_user_a');
+SELECT tests.authenticate_as_service_role_user('consent_user_a');
 
 SAVEPOINT before_cross_save;
 SELECT throws_ok(
@@ -184,18 +179,13 @@ ROLLBACK TO SAVEPOINT before_direct_delete;
 -- ============================================================
 -- 11. RPC — user can update own consent state
 -- ============================================================
-SELECT tests.authenticate_as('consent_user_a');
+SELECT tests.authenticate_as_service_role_user('consent_user_a');
 
-SELECT lives_ok(
-  format(
-    $$SELECT public.save_user_consents(
-      '%s',
-      '[{"consent_key":"terms_of_service","consented":false}]'::jsonb
-    )$$,
-    tests.get_supabase_uid('consent_user_a')
-  ),
-  'user A can update own consent via RPC'
+SELECT public.save_user_consents(
+  tests.get_supabase_uid('consent_user_a'),
+  '[{"consent_key":"terms_of_service","consented":false}]'::jsonb
 );
+SELECT pass('service_role user context can update own consent via RPC compatibility wrapper');
 
 -- ============================================================
 -- 12. UNIQUE constraint — duplicate (user_id, consent_key) fails
@@ -213,7 +203,7 @@ SELECT throws_ok(
   'duplicate (user_id, consent_key) violates unique constraint'
 );
 ROLLBACK TO SAVEPOINT before_dup;
-SELECT tests.authenticate_as('consent_user_a');
+SELECT tests.authenticate_as_service_role_user('consent_user_a');
 
 -- ============================================================
 -- 13. has_required_consents() — returns false when incomplete
@@ -225,7 +215,7 @@ SELECT results_eq(
 );
 
 -- Restore terms_of_service
-SELECT tests.authenticate_as('consent_user_a');
+SELECT tests.authenticate_as_service_role_user('consent_user_a');
 
 SELECT lives_ok(
   format(
@@ -238,7 +228,7 @@ SELECT lives_ok(
   'restore terms_of_service consent'
 );
 
-SELECT tests.authenticate_as('consent_user_a');
+SELECT tests.authenticate_as_service_role_user('consent_user_a');
 
 -- ============================================================
 -- 14. has_required_consents() — returns true when all 3 required
@@ -300,7 +290,7 @@ SELECT lives_ok(
 -- ============================================================
 -- 18. Fix #2054: server timestamp 강제 — client-supplied consented_at 무시
 -- ============================================================
-SELECT tests.authenticate_as('consent_user_a');
+SELECT tests.authenticate_as_service_role_user('consent_user_a');
 
 SELECT lives_ok(
   format(

--- a/supabase/tests/database/99_checkin_rpcs_test.sql
+++ b/supabase/tests/database/99_checkin_rpcs_test.sql
@@ -1,5 +1,5 @@
 BEGIN;
-SELECT plan(9);
+SELECT plan(10);
 
 -- ============================================================
 -- Setup: service role로 파트너/이벤트/참가자 데이터 구성
@@ -9,6 +9,7 @@ SELECT tests.authenticate_as_service_role();
 
 SELECT tests.create_supabase_user('checkin_staff');
 SELECT tests.create_supabase_user('checkin_no_perm');
+SELECT tests.create_supabase_user('checkin_admin');
 
 DO $$
 DECLARE
@@ -30,6 +31,9 @@ BEGIN
     ARRAY['PARTY_MANAGE']::text[]
   );
 
+  INSERT INTO public.app_roles (user_id, role)
+  VALUES (tests.get_supabase_uid('checkin_admin'), 'super_admin');
+
   INSERT INTO public.parties (partner_id, title, min_confirmed_count, max_participants)
   VALUES (v_partner_id, 'Checkin Test Party', 0, 10)
   RETURNING id INTO v_party_id;
@@ -46,7 +50,8 @@ BEGIN
   INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name)
   VALUES
     (v_event_id, v_ticket_id, tests.get_supabase_uid('checkin_staff'),   'ticket_issued', 'CODE0001', 'Staff User'),
-    (v_event_id, v_ticket_id, tests.get_supabase_uid('checkin_no_perm'), 'checked_in',    'CODE0002', 'No Perm User');
+    (v_event_id, v_ticket_id, tests.get_supabase_uid('checkin_no_perm'), 'checked_in',    'CODE0002', 'No Perm User'),
+    (v_event_id, v_ticket_id, tests.get_supabase_uid('checkin_admin'),   'ticket_issued', 'CODE0003', 'Admin User');
 
   PERFORM set_config('tests.checkin_event_id',  v_event_id::text,  true);
   PERFORM set_config('tests.checkin_ticket_id', v_ticket_id::text, true);
@@ -132,6 +137,17 @@ SELECT isnt(
   'process_qr_checkin: success 후 checked_in_at 설정됨'
 );
 
+SELECT is(
+  public.process_qr_checkin_for_actor(
+    tests.get_supabase_uid('checkin_admin'),
+    current_setting('tests.checkin_ticket_id')::uuid,
+    current_setting('tests.checkin_event_id')::uuid,
+    tests.get_supabase_uid('checkin_admin')
+  ),
+  'success',
+  'process_qr_checkin_for_actor: super_admin actor can check in without partner membership'
+);
+
 -- ============================================================
 -- Test 7: get_event_checkin_stats — PARTY_MANAGE 없는 유저 → permission denied
 -- ============================================================
@@ -161,15 +177,15 @@ SELECT throws_like(
 
 -- ============================================================
 -- Test 9: get_event_checkin_stats — 정상 케이스 → total/checked_in 집계
--- (Test 4 이후: checkin_staff=checked_in, checkin_no_perm=checked_in → total=2, checked_in=2)
+-- (Test 4 이후: checkin_staff/checkin_no_perm/checkin_admin 모두 checked_in)
 -- ============================================================
 
 SELECT is(
   public.get_event_checkin_stats(
     current_setting('tests.checkin_event_id')::uuid
   ),
-  jsonb_build_object('total', 2, 'checked_in', 2),
-  'get_event_checkin_stats: total=2, checked_in=2 집계 정확'
+  jsonb_build_object('total', 3, 'checked_in', 3),
+  'get_event_checkin_stats: total=3, checked_in=3 집계 정확'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/database/99_manual_checkin_rpcs_test.sql
+++ b/supabase/tests/database/99_manual_checkin_rpcs_test.sql
@@ -1,5 +1,5 @@
 BEGIN;
-SELECT plan(11);
+SELECT plan(12);
 
 -- ============================================================
 -- Setup: service role로 파트너/이벤트/티켓/참가자 데이터 구성
@@ -12,6 +12,7 @@ SELECT tests.create_supabase_user('mc_no_perm');
 SELECT tests.create_supabase_user('mc_user_a');
 SELECT tests.create_supabase_user('mc_user_b');
 SELECT tests.create_supabase_user('mc_user_c');
+SELECT tests.create_supabase_user('mc_admin');
 
 DO $$
 DECLARE
@@ -21,6 +22,7 @@ DECLARE
   v_ticket_id        uuid;
   v_ticket_b_id      uuid;
   v_ticket_c_id      uuid;
+  v_ticket_admin_id  uuid;
   v_cancelled_evt_id uuid;
   v_ticket_d_id      uuid;
 BEGIN
@@ -29,6 +31,9 @@ BEGIN
 
   INSERT INTO public.partner_member_permissions (partner_id, user_id, role, permissions)
   VALUES (v_partner_id, tests.get_supabase_uid('mc_staff'), 'staff', ARRAY['PARTY_MANAGE']::text[]);
+
+  INSERT INTO public.app_roles (user_id, role)
+  VALUES (tests.get_supabase_uid('mc_admin'), 'super_admin');
 
   INSERT INTO public.parties (partner_id, title, min_confirmed_count, max_participants)
   VALUES (v_partner_id, 'Manual Checkin Party', 0, 20)
@@ -51,6 +56,9 @@ BEGIN
   INSERT INTO public.tickets (event_id, name, quantity, price)
   VALUES (v_event_id, 'Ticket C', 10, 0) RETURNING id INTO v_ticket_c_id;
 
+  INSERT INTO public.tickets (event_id, name, quantity, price)
+  VALUES (v_event_id, 'Ticket Admin', 10, 0) RETURNING id INTO v_ticket_admin_id;
+
   -- mc_user_b: already checked_in
   INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name, checked_in_at)
   VALUES (v_event_id, v_ticket_b_id, tests.get_supabase_uid('mc_user_b'), 'checked_in', 'MC0002', 'User B', now());
@@ -58,6 +66,9 @@ BEGIN
   -- mc_user_c: no_show (체크인 불가 상태)
   INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name)
   VALUES (v_event_id, v_ticket_c_id, tests.get_supabase_uid('mc_user_c'), 'no_show', 'MC0003', 'User C');
+
+  INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name)
+  VALUES (v_event_id, v_ticket_admin_id, tests.get_supabase_uid('mc_admin'), 'ticket_issued', 'MC0005', 'Admin User');
 
   -- cancelled 이벤트 (이벤트 상태 게이트 테스트용)
   INSERT INTO public.events (party_id, start_time, end_time, min_confirmed_count, max_participants, status)
@@ -74,6 +85,7 @@ BEGIN
   PERFORM set_config('tests.mc_ticket_id',         v_ticket_id::text,        true);
   PERFORM set_config('tests.mc_ticket_b_id',       v_ticket_b_id::text,      true);
   PERFORM set_config('tests.mc_ticket_c_id',       v_ticket_c_id::text,      true);
+  PERFORM set_config('tests.mc_ticket_admin_id',   v_ticket_admin_id::text,  true);
   PERFORM set_config('tests.mc_cancelled_evt_id',  v_cancelled_evt_id::text, true);
   PERFORM set_config('tests.mc_ticket_d_id',       v_ticket_d_id::text,      true);
 END $$;
@@ -115,8 +127,8 @@ SELECT is(
       current_setting('tests.mc_event_id')::uuid
     )
   )),
-  2,
-  'get_event_participants_for_checkin: 참가자 2명 반환 (no_show 제외)'
+  3,
+  'get_event_participants_for_checkin: 참가자 3명 반환 (no_show 제외)'
 );
 
 -- ============================================================
@@ -201,6 +213,16 @@ SELECT is(
      AND event_id  = current_setting('tests.mc_event_id')::uuid),
   'checked_in',
   'process_manual_checkin: 체크인 후 status = checked_in'
+);
+
+SELECT is(
+  public.process_manual_checkin_for_actor(
+    tests.get_supabase_uid('mc_admin'),
+    current_setting('tests.mc_ticket_admin_id')::uuid,
+    current_setting('tests.mc_event_id')::uuid
+  ),
+  'success',
+  'process_manual_checkin_for_actor: super_admin actor can check in without partner membership'
 );
 
 -- ============================================================


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

Closes #3445

## Goal
Move the remaining authenticated direct write-capable SECURITY DEFINER RPC entrypoints behind authenticated Edge Functions, while keeping database-side atomic operations service-role-only.

## Changes
- Added actor-aware service-role-only internal RPCs for check-in, consent writes, social interaction writes, and payout retry.
- Revoked `anon`/`authenticated` EXECUTE from the five direct write RPCs and granted only `service_role` for EF compatibility/internal use.
- Routed client/package write calls through existing Edge Functions:
  - `event-checkin`: `manual_checkin`, `qr_checkin`
  - `user-manage-settings`: `save_consents`
  - `user-manage-social`: `set_interaction`
  - `partner-manage-settlement`: `retry_payout`
- Updated pgTAP, Deno EF tests, and Dart repository/controller tests for the new posture.
- Expanded EF gateway regression tests for validation/RPC error branches so the Deno diff coverage gate covers the new changed lines.

## Verification
- `supabase db reset`
- `supabase test db` — 128 files / 2320 tests passed
- `~/.deno/bin/deno test --allow-all --config supabase/deno.json supabase/functions/event-checkin/event_checkin_test.ts supabase/functions/user-manage-settings/user_manage_settings_test.ts supabase/functions/user-manage-social/user_manage_social_test.ts supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts` — 81 passed
- `cd supabase && ~/.deno/bin/deno test --allow-all --coverage=cov_profile functions/ && ~/.deno/bin/deno coverage --lcov cov_profile > coverage.lcov` — full EF coverage run completed
- `diff-cover supabase/coverage.lcov --compare-branch=origin/dev-staging --fail-under=90 --include 'supabase/functions/**/*.ts' --exclude 'supabase/functions/**/*_test.ts'` — 98% diff coverage
- `TMPDIR=/home/minhyeok/tmp/codex-flutter flutter test test/src/data/repositories/checkin_repository_test.dart test/src/data/repositories/consent_repository_test.dart test/src/data/repositories/social_repository_test.dart test/src/data/repositories/settlement_repository_test.dart` from `shared/packages/minglit_kit` — 59 passed
- `TMPDIR=/home/minhyeok/tmp/codex-flutter flutter test test/src/features/checkin/manual/manual_checkin_controller_test.dart` from `apps/app_partner` — 5 passed
- `~/.deno/bin/deno fmt --check supabase/functions/event-checkin/event_checkin_test.ts supabase/functions/user-manage-settings/user_manage_settings_test.ts supabase/functions/user-manage-social/user_manage_social_test.ts supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts`
- `dart format --set-exit-if-changed ...`
- `git diff --check`
- `rg` check for remaining client direct write RPC calls — no matches

## Residual Risk
- Edge Function routing changes preserve the existing DB transaction boundaries, but deploy order matters: migration and EF/client changes should ship together so clients no longer depend on direct authenticated RPC EXECUTE.