### PR TITLE
fix(simulator): ignore already-applied apply conflicts

### DIFF
--- a/supabase/functions/event-flow-simulator/core/cascade.ts
+++ b/supabase/functions/event-flow-simulator/core/cascade.ts
@@ -164,6 +164,7 @@ function shouldReserveApplyTicketCapacity(
   const responseType = applyResponseType(responseData);
   if (responseType === "free") return true;
   if (responseType === "paid") return false;
+  if (responseType === "already_applied") return false;
   return ticketPrice === 0;
 }
 

--- a/supabase/functions/event-flow-simulator/core/cascade_test.ts
+++ b/supabase/functions/event-flow-simulator/core/cascade_test.ts
@@ -244,6 +244,42 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "runCascade - already_applied apply result records local application without consuming capacity",
+  fn: async () => {
+    clearRegistry();
+    registerAction(applyAction);
+    const snap = snapshotWithOneEvent();
+    snap.events[0].current_participants = 0;
+    snap.events[0].tickets![0].price = 0;
+    snap.events[0].tickets![0].sold_count = 0;
+    const { transport } = recordingTransport({ type: "already_applied" });
+
+    const { finalSnapshot, trace } = await runCascade({
+      actors: [{ id: "user-1", role: "user" }],
+      initialSnapshot: snap,
+      rates: defaultRates,
+      transport,
+      rng: createPRNG(1),
+      ticks: 1,
+    });
+
+    assertEquals(trace.length, 1);
+    assertEquals(trace[0].ok, true);
+    assertEquals(finalSnapshot.events[0].current_participants, 0);
+    assertEquals(finalSnapshot.events[0].tickets![0].sold_count, 0);
+    assertEquals(finalSnapshot.applications, [
+      {
+        id: "local:user-1:e1",
+        user_id: "user-1",
+        event_id: "e1",
+        status: "local_applied",
+      },
+    ]);
+  },
+});
+
+Deno.test({
   name: "runCascade - records error in trace when transport fails",
   fn: async () => {
     clearRegistry();

--- a/supabase/functions/event-flow-simulator/core/transport.ts
+++ b/supabase/functions/event-flow-simulator/core/transport.ts
@@ -15,6 +15,7 @@ export interface EFTransportConfig {
 }
 
 const IDEMPOTENCY_REQUIRED_FUNCTIONS = new Set(["apply-event"]);
+const ALREADY_APPLIED_ERROR = "Already applied to this event";
 
 /**
  * 실 EF 호출 transport. action.ef 가 정의돼 있으면 callEdgeFunction 으로 POST.
@@ -73,12 +74,21 @@ export class EFTransport implements Transport {
       token,
       extraHeaders,
     );
+    const rawError = extractResponseError(res.data);
+    if (isAlreadyAppliedConflict(action, res.status, rawError)) {
+      return {
+        ok: true,
+        status: res.status,
+        data: { type: "already_applied" },
+      };
+    }
+
     const ok = res.status >= 200 && res.status < 300;
     return {
       ok,
       status: res.status,
       data: res.data,
-      error: ok ? undefined : extractResponseError(res.data),
+      error: ok ? undefined : rawError,
     };
   }
 
@@ -93,6 +103,17 @@ export class EFTransport implements Transport {
         `event-flow-simulator:${runId}:${sequence}:${action.type}`,
     };
   }
+}
+
+function isAlreadyAppliedConflict(
+  action: Action,
+  status: number,
+  error: string | undefined,
+): boolean {
+  return action.type === "user_apply" &&
+    action.ef === "apply-event" &&
+    status === 409 &&
+    error === ALREADY_APPLIED_ERROR;
 }
 
 function extractResponseError(data: unknown): string | undefined {

--- a/supabase/functions/event-flow-simulator/core/transport_test.ts
+++ b/supabase/functions/event-flow-simulator/core/transport_test.ts
@@ -130,6 +130,41 @@ Deno.test("EFTransport includes error body for failed Edge Function calls", asyn
   });
 });
 
+Deno.test("EFTransport treats already-applied apply conflicts as benign", async () => {
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req) => req.url.endsWith("/functions/v1/apply-event"),
+      handler: () =>
+        Response.json(
+          { error: "Already applied to this event" },
+          { status: 409 },
+        ),
+    },
+  ]);
+
+  await withMockedFetch(fetchMock, async () => {
+    const transport = new EFTransport({
+      supabase: {} as SupabaseClient,
+      supabaseUrl: "https://example.supabase.co",
+      tokenByActor: new Map([["user-1", "test-token"]]),
+      runId: "run-1",
+    });
+
+    const result = await transport.execute({
+      type: "user_apply",
+      actorId: "user-1",
+      ef: "apply-event",
+      payload: { event_id: "event-1", ticket_id: "ticket-1" },
+    });
+
+    assertEquals(result, {
+      ok: true,
+      status: 409,
+      data: { type: "already_applied" },
+    });
+  });
+});
+
 Deno.test("EFTransport preserves string error bodies for failed Edge Function calls", async () => {
   const { fetchMock } = createFetchMock([
     {


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## Summary
- Normalize only `user_apply` / `apply-event` 409 `Already applied to this event` responses as benign simulator no-ops.
- Feed an `already_applied` response type into the cascade snapshot so the actor/event pair is recorded locally without consuming free-event capacity.
- Add transport and cascade regression coverage for this exact conflict path.

## Why
Fixes #3466. The representative dev cascade issue and follow-up automated issues (#3469, #3470, #3471) have zero invariant violations and fail only because `apply-event` correctly rejects a duplicate application. In long-lived dev simulator state, stale/missed snapshot data can make this guard fire even though the backend is behaving correctly. Other 409s and all unexpected failures still remain action failures.

Note: PR #3433 is present on `dev-staging` but has not yet been promoted to current `dev` (`8b3d867...`), so the existing dev cron is still running old simulator supply code. This PR separately stops the duplicate-application guard from producing cascade failure issues once deployed.

## Verification
- `git diff --check`
- `npx -y deno fmt --check supabase/functions/event-flow-simulator/core/transport.ts supabase/functions/event-flow-simulator/core/cascade.ts supabase/functions/event-flow-simulator/core/transport_test.ts supabase/functions/event-flow-simulator/core/cascade_test.ts`
- `cd supabase && npx -y deno test functions/event-flow-simulator/ --allow-all` (73 passed)
- `BASE_REF=mark/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`

## Residual Risk
- This intentionally hides only the exact duplicate-application guard from simulator issue reporting. If future evidence shows this was masking a real feed/snapshot regression, the next fix should move user action selection closer to `user-event-feed` rather than broadening this exception.
