### PR TITLE
fix(ci): run Vercel app deploys from repo root

### DIFF
--- a/.github/actions/deploy-nextjs-app/action.yml
+++ b/.github/actions/deploy-nextjs-app/action.yml
@@ -50,8 +50,8 @@ runs:
     - name: Deploy to Vercel
       id: deploy
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       env:
+        APP_DIR: ${{ inputs.working-directory }}
         VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
         VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
         VERCEL_TOKEN: ${{ inputs.vercel-token }}
@@ -61,6 +61,18 @@ runs:
         REQUIRE_SUPABASE_ENV: ${{ inputs.require-supabase-env }}
       run: |
         set -euo pipefail
+
+        APP_DIR="${APP_DIR#./}"
+        if [[ ! -f "$APP_DIR/package.json" ]]; then
+          echo "::error::Next.js app package.json not found: $APP_DIR/package.json"
+          exit 1
+        fi
+
+        WORKSPACE_NAME="$(node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); if (!pkg.name) process.exit(1); process.stdout.write(pkg.name);" "$APP_DIR/package.json")"
+        if [[ -z "$WORKSPACE_NAME" ]]; then
+          echo "::error::Next.js app package name is required: $APP_DIR/package.json"
+          exit 1
+        fi
 
         if [[ "$REQUIRE_SUPABASE_ENV" == "true" ]]; then
           : "${NEXT_PUBLIC_SUPABASE_URL:?NEXT_PUBLIC_SUPABASE_URL is required}"
@@ -73,9 +85,9 @@ runs:
         JSON
 
         if [ -f package-lock.json ]; then
-          npm ci
+          npm ci --workspace "$WORKSPACE_NAME" --include-workspace-root
         else
-          npm install
+          npm install --workspace "$WORKSPACE_NAME" --include-workspace-root
         fi
 
         if [[ "${{ inputs.deploy-branch }}" == "main" ]]; then

--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -18,6 +18,7 @@
 | [`check-android-deploy-workflow-contract.py`](./check-android-deploy-workflow-contract.py) | Android deploy release archive token 계약 + merge promotion 뒤 snapshot metadata 탐색 회귀 검증 | `pr-gate.static-checks` |
 | [`check-dev-soak-workflow-contract.py`](./check-dev-soak-workflow-contract.py) | dev event-flow cron install + `monitor-dev-cuj` + `dev-rc-cut-gate` + `shared-soak-gate` 판정 계약 검증 | `pr-gate.static-checks` |
 | [`check-dev-cut-workflow-contract.py`](./check-dev-cut-workflow-contract.py) | promotion cut workflow 의 full-history checkout, merge auto-merge mode, `shared-notify` repo 컨텍스트 계약 검증 | `pr-gate.static-checks` |
+| [`check-vercel-apps-deploy-contract.py`](./check-vercel-apps-deploy-contract.py) | Next.js Vercel app deploy action 이 monorepo root 에서 build/deploy 되는 계약 검증 | `pr-gate.static-checks` |
 | [`check-residual-db-hardening-guards.py`](./check-residual-db-hardening-guards.py) | dev drift 가 가능한 residual DB hardening migration 의 조건부 권한 보정 가드 검증 | `pr-gate.static-checks` |
 | [`check-ios-connectivity-plus-cap.sh`](./check-ios-connectivity-plus-cap.sh) | iOS deploy runner 가 지원할 때까지 `connectivity_plus <7.1.0` resolution 강제 | `pr-gate.guard-ios-connectivity-plus-cap` |
 | [`scan-build-artifact-secrets.py`](./scan-build-artifact-secrets.py) | APK/AAB/`.next` 등 빌드 산출물에서 Supabase service-role secret 패턴을 redacted summary 로 검사 | `pr-gate.scan-build-artifact-secrets` |
@@ -40,4 +41,4 @@
 - [.github/BLUEDOC.md](../BLUEDOC.md) — 상위 진입점
 
 ---
-_Reviewed: 2026-06-05 14:09_
+_Reviewed: 2026-06-11 07:32_

--- a/.github/scripts/check-vercel-apps-deploy-contract.py
+++ b/.github/scripts/check-vercel-apps-deploy-contract.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Validate Vercel web app deploy workflow contracts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_NEXTJS_ACTION = ROOT / ".github/actions/deploy-nextjs-app/action.yml"
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_action(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as file:
+        data = yaml.safe_load(file)
+    if not isinstance(data, dict):
+        fail(f"{path} did not parse as a mapping")
+    return data
+
+
+def named_step(action: dict[str, Any], step_name: str) -> dict[str, Any]:
+    runs = action.get("runs", {})
+    if not isinstance(runs, dict):
+        fail("deploy-nextjs action runs block did not parse as a mapping")
+    steps = runs.get("steps", [])
+    if not isinstance(steps, list):
+        fail("deploy-nextjs action steps did not parse as a list")
+    for step in steps:
+        if isinstance(step, dict) and step.get("name") == step_name:
+            return step
+    fail(f"deploy-nextjs action missing step: {step_name}")
+
+
+def assert_nextjs_deploy_runs_from_repo_root() -> None:
+    action = load_action(DEPLOY_NEXTJS_ACTION)
+    deploy = named_step(action, "Deploy to Vercel")
+
+    if "working-directory" in deploy:
+        fail("Deploy to Vercel must run from the repository root, not the app subdirectory")
+
+    env = deploy.get("env", {})
+    if not isinstance(env, dict) or env.get("APP_DIR") != "${{ inputs.working-directory }}":
+        fail("Deploy to Vercel must pass inputs.working-directory through APP_DIR")
+
+    run = deploy.get("run", "")
+    if not isinstance(run, str):
+        fail("Deploy to Vercel run block did not parse as text")
+
+    required_fragments = [
+        'APP_DIR="${APP_DIR#./}"',
+        '[[ ! -f "$APP_DIR/package.json" ]]',
+        'WORKSPACE_NAME="$(node -e',
+        'npm ci --workspace "$WORKSPACE_NAME" --include-workspace-root',
+        'npm install --workspace "$WORKSPACE_NAME" --include-workspace-root',
+        'npx --yes vercel@latest build --token=$VERCEL_TOKEN --yes',
+        'npx --yes vercel@latest deploy --prebuilt --archive=tgz --token=$VERCEL_TOKEN --yes',
+    ]
+    for fragment in required_fragments:
+        if fragment not in run:
+            fail(f"deploy-nextjs action run block missing fragment: {fragment}")
+
+    forbidden_fragments = [
+        "cd $APP_DIR",
+        "cd \"$APP_DIR\"",
+        "--cwd",
+    ]
+    for fragment in forbidden_fragments:
+        if fragment in run:
+            fail(f"deploy-nextjs action must not invoke Vercel from the app subdirectory: {fragment}")
+
+
+def main() -> None:
+    assert_nextjs_deploy_runs_from_repo_root()
+    print("Vercel apps deploy contract OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -123,6 +123,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: python3 .github/scripts/check-dev-cut-workflow-contract.py
 
+      - name: Check Vercel apps deploy contract
+        if: ${{ !cancelled() }}
+        run: python3 .github/scripts/check-vercel-apps-deploy-contract.py
+
       - name: Check residual DB hardening guards
         if: ${{ !cancelled() }}
         run: python3 .github/scripts/check-residual-db-hardening-guards.py


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## What Changed
- Run `.github/actions/deploy-nextjs-app` from the monorepo root instead of each app subdirectory.
- Resolve the app npm workspace from `inputs.working-directory` and install with `npm ci --workspace <name> --include-workspace-root`.
- Add `check-vercel-apps-deploy-contract.py` and wire it into `pr-gate.static-checks` so the action cannot regress to invoking Vercel from an app subdirectory.

## Why
Closes #3500.

The failed dev run `27302291556` showed:
- `mds-docs`: Vercel deploy looked for `apps/mds/docs/apps/mds/docs`, meaning the Vercel project Root Directory was effectively applied on top of an app-local cwd.
- `landing-user` / `landing-partner`: Vercel build ran from app-local context and failed resolving Next/Turbopack dependencies.

Vercel's monorepo guidance says the CLI should be invoked from the monorepo root, not from a subdirectory: https://vercel.com/docs/monorepos

## Verification
- `python3 .github/scripts/check-vercel-apps-deploy-contract.py`
- `python3 .github/scripts/check-dev-cut-workflow-contract.py`
- `python3 .github/scripts/check-dev-soak-workflow-contract.py`
- `python3 .github/scripts/check-residual-db-hardening-guards.py`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- full `.github/workflows/*.yml` YAML parse loop
- Node 20/npm 10 app builds:
  - `apps/landing_user`: `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=dummy npm run build`
  - `apps/landing_partner`: `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=dummy npm run build`
  - `apps/mds/docs`: `npm run build`

## Residual Risk
The exact Vercel prebuilt deploy path still depends on the Vercel project Root Directory settings stored in Vercel. This PR matches Vercel's monorepo CLI contract and adds a repo-side guard, but the final proof is the next `deploy-vercel-apps` run after merge/promotion.