### PR TITLE
fix(simulator): retry edge function load transients

### DIFF
--- a/supabase/functions/event-flow-simulator/core/transport.ts
+++ b/supabase/functions/event-flow-simulator/core/transport.ts
@@ -12,10 +12,14 @@ export interface EFTransportConfig {
   tokenByActor: Map<ActorId, string>;
   /** Current simulator run id, used to avoid idempotency-key reuse across runs. */
   runId?: string;
+  /** Backoff delays for Supabase Edge Runtime load transients. */
+  edgeLoadRetryDelaysMs?: number[];
 }
 
 const IDEMPOTENCY_REQUIRED_FUNCTIONS = new Set(["apply-event"]);
 const ALREADY_APPLIED_ERROR = "Already applied to this event";
+const EDGE_LOAD_FAILURE_ERROR = "Failed to load edge function";
+const DEFAULT_EDGE_LOAD_RETRY_DELAYS_MS = [500, 1_500, 3_000];
 
 /**
  * 실 EF 호출 transport. action.ef 가 정의돼 있으면 callEdgeFunction 으로 POST.
@@ -66,10 +70,10 @@ export class EFTransport implements Transport {
     if (!action.ef) {
       return { ok: false, status: 0, error: `action ${action.type} has no ef` };
     }
+    const functionName = action.ef;
     const extraHeaders = this.headersForAction(action);
-    const res = await callEdgeFunction(
-      this.cfg.supabaseUrl,
-      action.ef,
+    const res = await this.callEdgeFunctionWithLoadRetry(
+      functionName,
       action.payload,
       token,
       extraHeaders,
@@ -103,6 +107,38 @@ export class EFTransport implements Transport {
         `event-flow-simulator:${runId}:${sequence}:${action.type}`,
     };
   }
+
+  private async callEdgeFunctionWithLoadRetry(
+    functionName: string,
+    payload: Record<string, unknown>,
+    token: string,
+    extraHeaders: Record<string, string>,
+  ): Promise<{ status: number; data: unknown }> {
+    const retryDelays = this.cfg.edgeLoadRetryDelaysMs ??
+      DEFAULT_EDGE_LOAD_RETRY_DELAYS_MS;
+
+    for (let attempt = 0;; attempt++) {
+      const res = await callEdgeFunction(
+        this.cfg.supabaseUrl,
+        functionName,
+        payload,
+        token,
+        extraHeaders,
+      );
+      const rawError = extractResponseError(res.data);
+      if (
+        !isEdgeLoadFailure(res.status, rawError) ||
+        attempt >= retryDelays.length
+      ) {
+        return res;
+      }
+
+      const delayMs = retryDelays[attempt] ?? 0;
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+  }
 }
 
 function isAlreadyAppliedConflict(
@@ -126,4 +162,8 @@ function extractResponseError(data: unknown): string | undefined {
   return typeof message === "string" && message.length > 0
     ? message
     : undefined;
+}
+
+function isEdgeLoadFailure(status: number, error: string | undefined): boolean {
+  return status === 503 && error === EDGE_LOAD_FAILURE_ERROR;
 }

--- a/supabase/functions/event-flow-simulator/core/transport_test.ts
+++ b/supabase/functions/event-flow-simulator/core/transport_test.ts
@@ -130,6 +130,129 @@ Deno.test("EFTransport includes error body for failed Edge Function calls", asyn
   });
 });
 
+Deno.test("EFTransport retries transient Edge Function load failures", async () => {
+  let calls = 0;
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req) => req.url.endsWith("/functions/v1/apply-event"),
+      handler: () => {
+        calls++;
+        if (calls === 1) {
+          return Response.json(
+            { message: "Failed to load edge function" },
+            { status: 503 },
+          );
+        }
+        return Response.json({ type: "free", application_id: "app-1" });
+      },
+    },
+  ]);
+
+  await withMockedFetch(fetchMock, async () => {
+    const transport = new EFTransport({
+      supabase: {} as SupabaseClient,
+      supabaseUrl: "https://example.supabase.co",
+      tokenByActor: new Map([["user-1", "test-token"]]),
+      runId: "run-1",
+      edgeLoadRetryDelaysMs: [0],
+    });
+
+    const result = await transport.execute({
+      type: "user_apply",
+      actorId: "user-1",
+      ef: "apply-event",
+      payload: { event_id: "event-1", ticket_id: "ticket-1" },
+    });
+
+    assertEquals(result, {
+      ok: true,
+      status: 200,
+      data: { type: "free", application_id: "app-1" },
+      error: undefined,
+    });
+  });
+
+  assertEquals(calls, 2);
+});
+
+Deno.test("EFTransport does not retry non-load 503 failures", async () => {
+  let calls = 0;
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req) => req.url.endsWith("/functions/v1/apply-event"),
+      handler: () => {
+        calls++;
+        return Response.json(
+          { error: "Service unavailable" },
+          { status: 503 },
+        );
+      },
+    },
+  ]);
+
+  await withMockedFetch(fetchMock, async () => {
+    const transport = new EFTransport({
+      supabase: {} as SupabaseClient,
+      supabaseUrl: "https://example.supabase.co",
+      tokenByActor: new Map([["user-1", "test-token"]]),
+      runId: "run-1",
+      edgeLoadRetryDelaysMs: [0, 0],
+    });
+
+    const result = await transport.execute({
+      type: "user_apply",
+      actorId: "user-1",
+      ef: "apply-event",
+      payload: { event_id: "event-1", ticket_id: "ticket-1" },
+    });
+
+    assertEquals(result.ok, false);
+    assertEquals(result.status, 503);
+    assertEquals(result.error, "Service unavailable");
+  });
+
+  assertEquals(calls, 1);
+});
+
+Deno.test("EFTransport preserves final Edge Function load failure after retries", async () => {
+  let calls = 0;
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req) => req.url.endsWith("/functions/v1/apply-event"),
+      handler: () => {
+        calls++;
+        return Response.json(
+          { error: "Failed to load edge function" },
+          { status: 503 },
+        );
+      },
+    },
+  ]);
+
+  await withMockedFetch(fetchMock, async () => {
+    const transport = new EFTransport({
+      supabase: {} as SupabaseClient,
+      supabaseUrl: "https://example.supabase.co",
+      tokenByActor: new Map([["user-1", "test-token"]]),
+      runId: "run-1",
+      edgeLoadRetryDelaysMs: [0, 0],
+    });
+
+    const result = await transport.execute({
+      type: "user_apply",
+      actorId: "user-1",
+      ef: "apply-event",
+      payload: { event_id: "event-1", ticket_id: "ticket-1" },
+    });
+
+    assertEquals(result.ok, false);
+    assertEquals(result.status, 503);
+    assertEquals(result.error, "Failed to load edge function");
+  });
+
+  assertEquals(calls, 3);
+});
+
 Deno.test("EFTransport treats already-applied apply conflicts as benign", async () => {
   const { fetchMock } = createFetchMock([
     {


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-xhigh-1

## What changed
- Added a narrow retry path in `event-flow-simulator` `EFTransport` for Supabase Edge Runtime `503 Failed to load edge function` responses.
- Kept ordinary 503 responses and business failures non-retryable.
- Added regression tests for retry success, non-load 503 pass-through, and final load failure preservation.

## Why
Closes #3499.

The cascade issue was created at 2026-06-10T19:55:24Z while the same dev SHA's `deploy-supabase` run was still in progress (19:54:52Z to 19:58:26Z). The post-deploy simulator verify tick succeeded at 20:00:00Z with 5/5 actions OK. The reported body `Failed to load edge function` is a Supabase Edge Runtime load failure before the `apply-event` handler/wrapper path, not a domain error response from `apply-event`.

## Verification
- `npx --yes deno@2 fmt supabase/functions/event-flow-simulator/core/transport.ts supabase/functions/event-flow-simulator/core/transport_test.ts`
- `cd supabase/functions && npx --yes deno@2 test event-flow-simulator/core/transport_test.ts`
- `cd supabase/functions && npx --yes deno@2 test --allow-env --allow-net --allow-read event-flow-simulator/`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- `git diff --check`

## Residual risk
- Axiom CLI is not installed in this worker environment, so the diagnosis is based on GitHub issue/run timing and code-path behavior rather than direct Axiom log retrieval.
- Persistent Edge Runtime load failures still surface after retries; this only absorbs short load transients.