### PR TITLE
fix(test): avoid profile grant dependency in CUJ setup

### DIFF
--- a/supabase/functions/_integration_tests/_framework/actor.ts
+++ b/supabase/functions/_integration_tests/_framework/actor.ts
@@ -85,12 +85,17 @@ async function resolveEmail(
       .select("id")
       .eq("username", identifier)
       .maybeSingle();
-    if (error || !profile) {
+    if (!error && profile) {
+      const { data: auth } = await db.auth.admin.getUserById(profile.id as string);
+      if (!auth?.user?.email) throw new Error(`resolveEmail user: auth.users missing for ${identifier}`);
+      return auth.user.email;
+    }
+
+    const authUser = await resolveAuthUserByUsername(identifier, db);
+    if (!authUser?.email) {
       throw new Error(`resolveEmail user: profile not found for username=${identifier}`);
     }
-    const { data: auth } = await db.auth.admin.getUserById(profile.id as string);
-    if (!auth?.user?.email) throw new Error(`resolveEmail user: auth.users missing for ${identifier}`);
-    return auth.user.email;
+    return authUser.email;
   }
 
   // partner: identifier = partner_id, 첫 멤버 email 사용
@@ -116,10 +121,29 @@ async function resolveId(
     return identifier;
   }
   if (role === "user") {
-    const { data } = await db.from("user_profiles").select("id").eq("username", identifier).single();
-    return (data as { id: string }).id;
+    const { data, error } = await db.from("user_profiles").select("id").eq("username", identifier).maybeSingle();
+    if (!error && data) {
+      return (data as { id: string }).id;
+    }
+
+    const authUser = await resolveAuthUserByUsername(identifier, db);
+    if (!authUser?.id) {
+      throw new Error(`resolveId user: auth.users missing for username=${identifier}`);
+    }
+    return authUser.id;
   }
   return identifier; // partner — identifier 가 partner_id
+}
+
+async function resolveAuthUserByUsername(
+  username: string,
+  db: SupabaseClient,
+): Promise<{ id: string; email?: string } | null> {
+  const { data, error } = await db.auth.admin.listUsers();
+  if (error) {
+    throw new Error(`resolveAuthUserByUsername: ${error.message}`);
+  }
+  return data.users.find((user) => user.user_metadata?.username === username) ?? null;
 }
 
 /** 테스트 간 token 캐시 정리 (필요 시) */

--- a/supabase/functions/_integration_tests/_framework/scenario.ts
+++ b/supabase/functions/_integration_tests/_framework/scenario.ts
@@ -35,12 +35,9 @@ export const scenarios: Record<string, ScenarioFn> = {
       userId = data.user!.id;
     }
 
-    // user_profiles upsert (trigger 가 만들 수도 있지만 안전하게 upsert)
-    const { error: profileErr } = await db.from("user_profiles").upsert(
-      { id: userId, username: "user_test1" },
-      { onConflict: "id" },
-    );
-    if (profileErr) throw new Error(`scenario single-user profile: ${profileErr.message}`);
+    if (!userId) {
+      throw new Error("scenario single-user createUser: missing user id");
+    }
   },
 };
 


### PR DESCRIPTION
Scheduler: swe-codex-gpt55-medium-1

## Summary
- Stop the `single-user` CUJ scenario from upserting `user_profiles` through the service-role PostgREST client.
- Add auth metadata fallback in integration actor resolution, so username-based user actors can resolve from `auth.admin.listUsers()` when direct `user_profiles` reads are blocked by table grants.

## Why
Refs #3508. Promotion PR #3507 failed `pr-gate-core / test-ef-integration` because `supabase db reset --no-seed` skips `seed.sql`; the CUJ setup then tried to upsert `user_profiles` and hit `permission denied for table user_profiles` before the event feed assertions ran.

This PR does not close #3508 because the cut-gate goal is complete only after the latest `dev-staging` snapshot is promoted to `dev`. After this fix merges, the promotion should be retried from `dev-staging`.

## Verification
- `git diff --check origin/dev-staging...HEAD`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- Earlier local DB validation showed `supabase db reset --no-seed` applied cleanly, but this worktree image does not have Deno installed, so the full `deno test --allow-all supabase/functions/_integration_tests/cuj/discovery/event_feed_test.ts` verification is left to CI.

## Residual Risk
- `auth.admin.listUsers()` fallback is intended for the small local CUJ fixture user set. If integration fixtures grow substantially, this may need pagination.
